### PR TITLE
Add KeylimeTpmError support and change return type in tpm.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ use hyper::service::service_fn;
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use serde_json::Map;
 use std::collections::HashMap;
+use std::error::Error;
 use std::fs::File;
 use std::io::BufReader;
 use std::io::Read;
@@ -368,8 +369,8 @@ fn get_request_handler(
                 common::RSA_PUBLICKEY_EXPORTABLE.to_string(),
                 p.to_string(),
             ) {
-                Some(q) => q,
-                None => {
+                Ok(q) => q,
+                Err(err) => {
                     if let Err(e) = set_response_content(
                         400,
                         "Failed to crate quote from TPM.",
@@ -383,7 +384,7 @@ fn get_request_handler(
                     }
                     return emsg(
                         "TPM error. Failed to create quote from TPM.",
-                        None::<String>,
+                        Some(err.description().to_string()),
                     );
                 }
             };
@@ -396,8 +397,8 @@ fn get_request_handler(
                 v.to_string(),
                 p.to_string(),
             ) {
-                Some(q) => q,
-                None => {
+                Ok(q) => q,
+                Err(err) => {
                     if let Err(e) = set_response_content(
                         400,
                         "Failed to create deep quote from TPM.",
@@ -411,7 +412,7 @@ fn get_request_handler(
                     }
                     return emsg(
                         "TPM error. Failed to create deep quote from TPM.",
-                        None::<String>,
+                        Some(err.description().to_string()),
                     );
                 }
             };

--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -122,17 +122,24 @@ fn mount() -> Result<String, Box<String>> {
                         })?;
 
                     // mount tmpfs with secure directory
-                    tpm::run(
+                    if let Err(e) = tpm::run(
                         format!(
                             "mount -t tmpfs -o size={},mode=0700 tmpfs {}",
                             common::SECURE_SIZE,
                             s,
                         ),
                         tpm::EXIT_SUCCESS,
-                        true,
-                        false,
-                        String::new(),
-                    );
+                        None,
+                    ) {
+                        error!(
+                            "Failed to execute mount command with error {}.",
+                            e
+                        );
+                        return emsg(
+                            "Failed to mount secure directory tmpfs.",
+                            None::<String>,
+                        );
+                    }
 
                     Ok(s.to_string())
                 }

--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -1,10 +1,10 @@
 use super::*;
 
 use common::emsg;
+use std::error::Error;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
-
 /*
  * Input: secure mount directory
  * Return: Result wrap boolean with error message
@@ -122,24 +122,15 @@ fn mount() -> Result<String, Box<String>> {
                         })?;
 
                     // mount tmpfs with secure directory
-                    if let Err(e) = tpm::run(
+                    tpm::run(
                         format!(
                             "mount -t tmpfs -o size={},mode=0700 tmpfs {}",
                             common::SECURE_SIZE,
                             s,
                         ),
-                        tpm::EXIT_SUCCESS,
                         None,
-                    ) {
-                        error!(
-                            "Failed to execute mount command with error {}.",
-                            e
-                        );
-                        return emsg(
-                            "Failed to mount secure directory tmpfs.",
-                            None::<String>,
-                        );
-                    }
+                    )
+                    .map_err(|e| e.description().to_string())?;
 
                     Ok(s.to_string())
                 }

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -62,8 +62,8 @@ fn get_tpm_metadata_content(key: &str) -> Result<String, Box<String>> {
  * Return: Result wrap success or error code -1
  *
  * Set the corresponding tpm data key with new value and save the new content
- * to tpmdata.json. This version remove global tpmdata variable. Read the file
- * before write the content to the file.
+ * to tpmdata.json. This version remove global tpmdata variable. Read the
+ * file before write the content to the file.
  */
 fn set_tpm_metadata_content(
     key: &str,
@@ -167,19 +167,10 @@ pub fn is_vtpm() -> bool {
  * is_vtpm helper method
  */
 fn get_tpm_manufacturer() -> Result<String, Box<String>> {
-    let (return_output, _return_code, _file_output) = run(
-        "getcapability -cap 1a".to_string(),
-        EXIT_SUCCESS,
-        true,
-        false,
-        String::new(),
-    );
-    let content = match String::from_utf8(return_output) {
-        Ok(c) => c,
-        Err(e) => return emsg("Failed to convert output to string.", Some(e)),
-    };
+    let (return_output, _, _) =
+        run("getcapability -cap 1a".to_string(), EXIT_SUCCESS, None)?;
 
-    let lines: Vec<&str> = content.split("\n").collect();
+    let lines: Vec<&str> = return_output.split("\n").collect();
     let mut manufacturer = String::new();
     for line in lines {
         let line_tmp = String::from(line);
@@ -259,7 +250,10 @@ pub fn create_quote(
         let mut command = format!("pcrreset -ix {}", common::TPM_DATA_PCR);
 
         // RUN
-        run(command, EXIT_SUCCESS, true, false, String::new());
+        if let Err(e) = run(command, EXIT_SUCCESS, None) {
+            error!("Failed to execute TPM command with error {}.", e);
+            return None;
+        }
 
         // Use SHA1 to hash the data
         let mut hasher = sha::Sha1::new();
@@ -272,7 +266,11 @@ pub fn create_quote(
             hex::encode(data_sha1_hash),
         );
 
-        run(command, EXIT_SUCCESS, true, false, String::new());
+        // RUN
+        if let Err(e) = run(command, EXIT_SUCCESS, None) {
+            error!("Failed to execute TPM command with error {}.", e);
+            return None;
+        }
     }
 
     // store quote into the temp file that will be extracted later
@@ -281,17 +279,18 @@ pub fn create_quote(
         key_handle, aik_password, pcrmask, nonce, quote_path,
     );
 
-    let (_return_output, _exit_code, quote_raw) =
-        run(command, EXIT_SUCCESS, true, false, quote_path.to_string());
+    let (_, _, quote_raw) = match run(command, EXIT_SUCCESS, Some(quote_path))
+    {
+        Ok((o, c, q)) => ((o, c, q)),
+        Err(e) => {
+            error!("Failed to execute TPM command with error {}.", e);
+            return None;
+        }
+    };
 
     let mut quote_return = String::from("r");
-
-    if let Some(s) = quote_raw {
-        quote_return.push_str(&base64_zlib_encode(s));
-        Some(quote_return)
-    } else {
-        None
-    }
+    quote_return.push_str(&base64_zlib_encode(quote_raw));
+    Some(quote_return)
 }
 
 /*
@@ -367,8 +366,11 @@ pub fn create_deep_quote(
             format!("0x{}", (vpcrmask_int + (1 << common::TPM_DATA_PCR)));
         let mut command = format!("pcrreset -ix {}", common::TPM_DATA_PCR);
 
-        // RUN
-        run(command, EXIT_SUCCESS, true, false, String::new());
+        //RUN
+        if let Err(e) = run(command, EXIT_SUCCESS, None) {
+            error!("Failed to execute TPM command with error {}.", e);
+            return None;
+        }
 
         let mut hasher = sha::Sha1::new();
         hasher.update(data.as_bytes());
@@ -380,8 +382,11 @@ pub fn create_deep_quote(
             hex::encode(data_sha1_hash),
         );
 
-        // RUN
-        run(command, EXIT_SUCCESS, true, false, String::new());
+        //RUN
+        if let Err(e) = run(command, EXIT_SUCCESS, None) {
+            error!("Failed to execute TPM command with error {}.", e);
+            return None;
+        }
     }
 
     // store quote into the temp file that will be extracted later
@@ -397,16 +402,18 @@ pub fn create_deep_quote(
     );
 
     // RUN
-    let (_, _, quote_raw) =
-        run(command, EXIT_SUCCESS, true, false, quote_path.to_string());
+    let (_, _, quote_raw) = match run(command, EXIT_SUCCESS, Some(quote_path))
+    {
+        Ok((o, c, q)) => ((o, c, q)),
+        Err(e) => {
+            error!("Failed to execute TPM command with error {}.", e);
+            return None;
+        }
+    };
 
     let mut quote_return = String::from("d");
-    if let Some(q) = quote_raw {
-        quote_return.push_str(&base64_zlib_encode(q));
-        Some(quote_return)
-    } else {
-        None
-    }
+    quote_return.push_str(&quote_raw);
+    Some(quote_return)
 }
 
 /*
@@ -491,26 +498,30 @@ Following are function from tpm_exec.py program
 
 /*
  * Input:
- *     cmd: command to be executed
- *     except_code: return code that needs extra handling
- *     raise_on_error: raise exception/panic while encounter error option
- *     lock: lock engage option
+ *     command: command to be executed
+ *     expect_code: code expect to have from execution result
  *     output_path: file output location
  * return:
- *     tuple contains (standard output, return code, and file output)
+ *     tuple contains:
+ *         return output: execution standard output
+ *         return code: execution result code
+ *         file output: output file content if avaiable
  *
- * Execute tpm command through shell commands and return the execution
- * result in a tuple. Implement as original python version. Haven't
- * implemented tpm stubbing and metric.
+ * Set up execution envrionment to execute tpm command through shell commands
+ * and return the execution result in a tuple. Based on the latest update of
+ * python keylime this function implement the functionality of cmd_exec
+ * script in the python keylime repo. RaiseOnError and lock are dropped due
+ * to different error handling in Rust. Output are preprocessed to before
+ * returning for code efficient.
  */
 pub fn run<'a>(
     command: String,
-    except_code: i32,
-    raise_on_error: bool,
-    _lock: bool,
-    output_path: String,
-) -> (Vec<u8>, Option<i32>, Option<String>) {
-    /* stubbing  placeholder */
+    expect_code: i32,
+    output_path: Option<&str>,
+) -> Result<(String, i32, String), Box<String>> {
+    let mut t_diff: u64 = 0;
+    let mut file_output = String::new();
+    let mut output: Output;
 
     // tokenize input command
     let words: Vec<&str> = command.split(" ").collect();
@@ -521,35 +532,31 @@ pub fn run<'a>(
     // setup environment variable
     let mut env_vars: HashMap<String, String> = HashMap::new();
     for (key, value) in env::vars() {
-        // println!("{}: {}", key, value);
         env_vars.insert(key.to_string(), value.to_string());
     }
-
     env_vars.insert("TPM_SERVER_PORT".to_string(), "9998".to_string());
     env_vars.insert("TPM_SERVER_NAME".to_string(), "localhost".to_string());
     match env_vars.get_mut("PATH") {
         Some(v) => v.push_str(common::TPM_TOOLS_PATH),
-        None => error!("PATH doesn't exist."),
+        None => return emsg("PATH doesn't exist.", None::<String>),
     }
 
-    let mut t_diff: u64 = 0;
-    let mut output: Output;
-
-    loop {
+    // main loop
+    'exec: loop {
+        // Start time stamp
         let t0 = SystemTime::now();
 
-        // command execution
-        output = Command::new(&cmd)
-            .args(args)
-            .envs(&env_vars)
-            .output()
-            .expect("failed to execute process");
+        output = match Command::new(&cmd).args(args).envs(&env_vars).output()
+        {
+            Ok(o) => o,
+            Err(e) => return emsg("Failed to execute command", Some(e)),
+        };
 
         // measure execution time
-        match t0.duration_since(t0) {
-            Ok(t_delta) => t_diff = t_delta.as_secs(),
-            Err(_) => {}
-        }
+        t_diff = match t0.duration_since(t0) {
+            Ok(t_delta) => t_delta.as_secs(),
+            Err(e) => return emsg("Can't get time duration", Some(e)),
+        };
         info!("Time cost: {}", t_diff);
 
         // assume the system is linux
@@ -559,8 +566,13 @@ pub fn run<'a>(
             Some(TPM_IO_ERROR) => {
                 number_tries += 1;
                 if number_tries >= MAX_TRY {
-                    error!("TPM appears to be in use by another application.  Keylime is incompatible with other TPM TSS applications like trousers/tpm-tools. Please uninstall or disable.");
-                    break;
+                    return emsg(
+                        "TPM appears to be in use by another application. 
+                                Keylime is incompatible with other TPM TSS 
+                                applications like trousers/tpm-tools. Please 
+                                uninstall or disable.",
+                        None::<String>,
+                    );
                 }
 
                 info!(
@@ -572,40 +584,56 @@ pub fn run<'a>(
 
                 thread::sleep(RETRY_SLEEP);
             }
-            _ => break,
+
+            _ => break 'exec,
         }
     }
 
-    let return_output = output.stdout;
-    let return_code = output.status.code();
+    // preprocess execution result
+    let return_output = String::from_utf8(output.stdout).map_err(|e| {
+        Box::new(format!(
+            "Can't convert output to utf8 encoded String. Error {}.",
+            e,
+        ))
+    })?;
 
-    if let (Some(c), true) = (return_code, raise_on_error) {
-        if c != except_code {
-            error!(
+    // preprocess execution status code
+    let return_code = match output.status.code() {
+        Some(c) => c,
+        None => {
+            return emsg("Execution status code is None.", None::<String>);
+        }
+    };
+
+    // Execution return code checking
+    if return_code != expect_code {
+        return emsg(
+            format!(
                 "Command: {} returned {}, expected {}, output {}",
                 command,
-                c,
-                except_code.to_string(),
-                String::from_utf8_lossy(&return_output),
-            );
-        }
+                return_code,
+                expect_code.to_string(),
+                return_output,
+            )
+            .as_str(),
+            None::<String>,
+        );
     }
 
-    let mut file_output: String = String::new();
-
-    match read_file_output_path(output_path) {
-        Ok(content) => file_output = content,
-        Err(_) => {}
+    // Retrive data from output path file
+    if let Some(p) = output_path {
+        file_output = match read_file_output_path(p.to_string()) {
+            Ok(content) => content,
+            Err(e) => return emsg("Failed to read output path", Some(e)),
+        };
     }
 
-    /* metric output placeholder */
-
-    (return_output, return_code, Some(file_output))
+    Ok((return_output, return_code, file_output))
 }
 
 /*
- * input: file name
- * return: the content of the file int Result<>
+ * Input: file name
+ * Return: the content of the file int Result<>
  *
  * run method helper method
  * read in the file and  return the content of the file into a Result enum
@@ -663,14 +691,10 @@ mod tests {
         match command_exist("getrandom") {
             true => {
                 let command = "getrandom -size 8 -out foo.out".to_string();
-                run(command, EXIT_SUCCESS, true, false, String::new());
-
+                run(command, EXIT_SUCCESS, None);
                 let p = Path::new("foo.out");
                 assert_eq!(p.exists(), true);
-                match fs::remove_file("foo.out") {
-                    Ok(_) => {}
-                    Err(_) => {}
-                }
+                fs::remove_file("foo.out").unwrap();
             }
             false => assert!(true),
         }


### PR DESCRIPTION
Add support for tpm custom error type. This is aim on solving #40 for changing return type.
Implementation details:
1. Implement KeylimeTpmError enum has two contribution
    - error generate from TPM command execution
    - error generate from rust part of TPM interface
2. Implement From trait for Error:
    - `serde_json::error::Error`
    - `std::num::ParseIntError`    
    - `std::string::FromUtf8Error`
    - `std::io::Error`
    - `std::time::SystemTimeError`    
3. Upate return type of `run()` function in a tuple and a custom error
    `Result<(String, String), TpmExecError>`    
4. Support return type of other function in tpm.rs with `KeylimeTpmError`, which has benefit in code efficient and early return efficient
