### PR TITLE
Add crypto binding for OpenSSL RSA decryption

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -483,13 +483,19 @@ fn get_request_handler(
         if let Err(e) =
             set_response_content(200, "Success", response_map, my_response)
         {
-            return emsg("Failed to edit the response content body.", Some(e));
+            return emsg(
+                "Failed to edit the response content body.",
+                Some(e),
+            );
         }
     } else {
         if let Err(e) =
             set_response_content(400, "Bad Request.", Map::new(), my_response)
         {
-            return emsg("Failed to edit the response content body.", Some(e));
+            return emsg(
+                "Failed to edit the response content body.",
+                Some(e),
+            );
         }
         return emsg("Bad Request. Invalid request content.", None::<String>);
     }


### PR DESCRIPTION
This PR implements a binding in `crypto.rs` for RSA decryption, necessary for work on the Rust client's POST handling logic. This addition also constitutes part of the crypto interface as specified in #20.

Tagging @frozencemetery @leonjia0112 for review.