### PR TITLE
Rename `node` to `agent`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "keylime_node"
+name = "keylime_agent"
 version = "0.1.0"
 authors = ["Pei Jia <leojia@bu.edu>"]
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ features:
 For more information, see the original [python implementation repo](https://github.com/mit-ll/python-keylime)
 and paper in the References section.
 
-For now, this project is focusing on the keylime node component, which is a
+For now, this project is focusing on the keylime agent component, which is a
 HTTP server running on the server machine that executes keylime operations.
 Most keylime operations rely on TPM co-processor; therefore, the server needs
 a physical TPM chip (or a TPM emulator) to perform keylime operations.  The
@@ -56,7 +56,7 @@ other environments.
 To run with `pretty-env-logger` trace logging active, set cargo run
 within `RUST_LOG`, as follows:
 
-    $ RUST_LOG=keylime_node=trace cargo run
+    $ RUST_LOG=keylime_agent=trace cargo run
 
 ## Testing
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -28,7 +28,7 @@ pub static WORK_DIR: &'static str = "/tmp";
  * Temporaray location for configuration parameters
  */
 
-// cloud node
+// cloud agent
 pub static SECURE_SIZE: &'static str = "1m";
 pub static MOUNT_SECURE: bool = true;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -506,7 +506,7 @@ fn get_request_handler(
  * Input: file path
  * Output: file content
  *
- * Helper function to help the keylime node read file and get the file
+ * Helper function to help the keylime agent read file and get the file
  * content. It is not from the original python version. Because rust needs
  * to handle error in result, it is good to keep this function seperate from
  * the main function.


### PR DESCRIPTION
As per mailing list discussion [0] we decided to rename `node`
to `agent`.

The following pull request is open on python-keylime [1]

[0] https://keylime.groups.io/g/main/topic/node_agent/30833147
[1] keylime/python-keylime#97

resolves: #58