### PR TITLE
Build out infrastructure for POST request handling

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -76,11 +76,11 @@ pub fn rsa_decrypt(
 ) -> Result<String, KeylimeCryptoError> {
     let mut dec_result = vec![0; private_key.size() as usize];
     let dec_len = private_key.private_decrypt(
-        ciphertext.as_bytes(),
+        &ciphertext,
         &mut dec_result,
         Padding::PKCS1,
     )?;
-    Ok(to_hex_string(dec_result[..dec_len].to_vec()))
+    Ok(to_hex_string(&dec_result[..dec_len].to_vec()))
 }
 
 /*


### PR DESCRIPTION
This draft PR contains work done toward handling POST requests for the Rust Keylime agent. It is not ready to be merged into the mainline project as of yet.

The bulk of the work focuses on refactoring the components that handle incoming requests; before, the body of the request was unused, and the request type was used to dictate what happened after. The body was then disposed of and unusable by the handling function. This has been changed, and the POST request's body is now passed onto the POST function to handle it appropriately. That handling logic still needs to be built out, and is a logical next step towards taking this to completion.