### PR TITLE
Implements Config Parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Pei Jia <leojia@bu.edu>"]
 [dependencies]
 futures = "0.1.24"
 hyper = "0.12"
+rust-ini = "0.12.1"
 tokio-io = "0.1"
 serde_json = "1.0"
 pretty_env_logger = "0.2.0"

--- a/keylime.conf
+++ b/keylime.conf
@@ -1,0 +1,117 @@
+[general]
+#=============================================================================
+# these options are self explanatory ip/port combinations to find the various
+# keylime services on the network.  some services use these, some do not.
+# But they are used frequently enough that they end up here
+cloudverifier_port = 8881
+registrar_port = 8890
+registrar_tls_port = 8891
+registrar_ip = 127.0.0.1
+cloudagent_port = 9002
+provider_registrar_port = 8990
+provider_registrar_tls_port = 8991
+provider_registrar_ip = 127.0.0.1
+webapp_port = 443
+webapp_ip = 127.0.0.1
+
+# This is the port combination of the notification server.  The cloud verifier
+# will start a notification server automatically if the revocation_notifier
+# option is set to true
+revocation_notifier_ip = 127.0.0.1
+revocation_notifier_port = 8992
+
+# turn on or off TLS keylime wide
+enable_tls = True
+
+# turn on or off DNS hostname checking for TLS certificates.
+tls_check_hostnames = False
+
+# set which provider you want for the generation of certificates
+# valid options are 'cfssl' or 'openssl'  For cfssl to work, you must have the
+# go binary installed in your path or in /usr/local/
+# revocation list generation is only supported by cfssl
+ca_implementation = cfssl
+
+#=============================================================================
+[cloud_agent]
+#=============================================================================
+# What is the name of the rsa key that keylime should use for protecting
+# shares of U/V
+rsa_keyname = tci_rsa_key
+
+# what filename in /var/lib/keylime/secure should the encryption key be placed
+enc_keyname = derived_tci_key
+
+# what filename in /var/lib/keylime/secure should the optional decrypted
+# payload be placed
+dec_payload_file = decrypted_payload
+
+# size of the memory backed tmpfs partition where keylime stores crypto keys
+# use syntax that mount would accept as a size parameter for tmpfs
+# the default below sets it to 1 megabyte
+secure_size = 1m
+
+# use this option to set the TPM ownerpassword to something you want to use.
+# Set it to "generate" if you want keylime to choose a random owner password
+# for you
+tpm_ownerpassword = keylime
+
+# set to true to allow the cloud_agent to automatically extract a zip file in
+# the delivered payload after it has been decrypted.  It will be decrypted to
+# a folder unzipped in /var/lib/keylime/secure.  Note the limits on the size
+# of the tmpfs partition above with secure_size option
+extract_payload_zip = True
+
+# set the agent's uuid to the given value.
+# set to 'openstack', it will try to get the uuid from the metadata service
+# if you set this to 'generate', keylime will create a random uuid
+# if you set this to 'hash_ek', keylime will set the UUID to the result
+# of SHA256(public EK in PEM format)
+agent_uuid = D432FBB3-D2F1-4A97-9EF7-75BD81C00000
+
+# whether to listen for revocation notifications from the verifier
+listen_notfications = True
+
+# path to the certificate to verify revocation messages received from the
+# verifier.  path is relative to /var/lib/keylime
+# if set to "default", keylime will use the file RevocationNotifier-cert.crt
+# from the unzipped contents provided by the tenant
+revocation_cert = default
+
+# Comma separated list of python scripts to run upon receiving a revocation
+# message. Keylime will verify the signature first, then call these python
+# scripts with the json revocation message.  The scripts must be located in
+# revocation_actions directory
+#
+# keylime will also get the list of revocation actions from the file
+# action_list in the unzipped contents provided by the verifier
+# all actions must be named local_action_[some name]
+revocation_actions=
+
+# A script to execute after unzipping the tenant payload.  This is like
+# cloud-init lite =)  Keylime will run it with a /bin/sh environment with
+# a working directory of /var/lib/keylime/secure/unzipped
+payload_script=autorun.sh
+
+# Jason @henn made be do it! he wanted a way for keylime to measure the
+# delivered payload into a pcr of choice.  specify a PCR number to turn it on
+# set to -1 or any negative or out of range PCR value to turn off
+measure_payload_pcr=-1
+
+# how long to wait between failed attempts to communicate with the tpm in
+# seconds.  floating point values accepted here
+retry_interval = 1
+
+# integer number of retries to communicate with the tpm before giving up
+max_retries = 10
+
+# TPM2-specific options, allow customizing default algorithms to use.
+# specify the default crypto algorithms to use with a TPM2 for this agent
+#
+# currently accepted values include:
+# hashing: sha512, sha384, sha256 or sha1
+# encryption: ecc or rsa
+# signing: rsassa, rsapss, ecdsa, ecdaa or ecschnorr
+tpm_hash_alg = sha256
+tpm_encryption_alg = rsa
+tpm_signing_alg = rsassa

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ extern crate flate2;
 extern crate futures;
 extern crate hex;
 extern crate hyper;
+extern crate ini;
 extern crate libc;
 extern crate openssl;
 extern crate pretty_env_logger;
@@ -24,6 +25,7 @@ mod crypto;
 mod secure_mount;
 mod tpm;
 
+use common::config_get;
 use common::emsg;
 use common::set_response_content;
 use futures::future;
@@ -44,10 +46,16 @@ static NOTFOUND: &[u8] = b"Not Found";
 
 fn main() {
     pretty_env_logger::init();
+
+    let cloudagent_ip =
+        config_get("/etc/keylime.conf", "general", "cloudagent_ip");
+    let cloudagent_port =
+        config_get("/etc/keylime.conf", "general", "cloudagent_port");
+    let endpoint = format!("{}:{}", cloudagent_ip, cloudagent_port);
+
     info!("Starting server...");
 
-    /* Should be port 3000 eventually */
-    let addr = ([127, 0, 0, 1], 1337).into();
+    let addr = (endpoint).parse().expect("Cannot parse IP & Port");
 
     let server = Server::bind(&addr)
         .serve(|| service_fn(response_function))

--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use common::config_get;
 use common::emsg;
 use std::error::Error;
 use std::fs;
@@ -78,8 +79,10 @@ fn mount() -> Result<String, Box<String>> {
         return emsg("Failed to get the path string.", None::<String>);
     }
 
-    // Monut the directory to file system
+    // Mount the directory to file system
     let secure_dir = format!("{}/secure", common::WORK_DIR);
+    let secure_size =
+        config_get("/etc/keylime.conf", "cloud_agent", "secure_size");
     match check_mount(&secure_dir) {
         Ok(false) => {
             // If the directory is not mount to file system, mount the directory to
@@ -125,8 +128,7 @@ fn mount() -> Result<String, Box<String>> {
                     tpm::run(
                         format!(
                             "mount -t tmpfs -o size={},mode=0700 tmpfs {}",
-                            common::SECURE_SIZE,
-                            s,
+                            secure_size, s,
                         ),
                         None,
                     )


### PR DESCRIPTION
This pull request allows the agent to make use of the existing
INI config format used in the python variation of keylime.conf

It also allows declaration of an individual config file for each
function call. This will allow future use of more config files
(should we care to have them) such as `database.ini` or
`myplugin.ini`

I selected `rust-ini` crate as it is an active and maintainted
project generally considered stable

Resolves: #27