### PR TITLE
hash: Port HashAlgorithms

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,0 +1,71 @@
+/// Code ported from Hash_Algorithms at https://github.com/keylime/keylime/blob/master/keylime/tpm/tpm_abstract.py
+
+#[derive(Debug)]
+struct HashAlgorithms;
+
+impl HashAlgorithms {
+    const SHA1: &'static str = "sha1";
+    const SHA256: &'static str = "sha256";
+    const SHA384: &'static str = "sha384";
+    const SHA512: &'static str = "sha512";
+
+    fn is_recognized(algorithm: String) -> bool {
+        if [
+            HashAlgorithms::SHA1,
+            HashAlgorithms::SHA256,
+            HashAlgorithms::SHA384,
+            HashAlgorithms::SHA512,
+        ]
+        .contains(&algorithm.as_str())
+        {
+            return true;
+        }
+        false
+    }
+
+    fn get_hash_size(algorithm: String) -> u16 {
+        match algorithm.as_str() {
+            HashAlgorithms::SHA1 => 160,
+            HashAlgorithms::SHA256 => 256,
+            HashAlgorithms::SHA384 => 384,
+            HashAlgorithms::SHA512 => 512,
+            _ => 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn test_is_recognized() {
+        assert!(HashAlgorithms::is_recognized(String::from("sha256")));
+        assert_eq!(
+            HashAlgorithms::is_recognized(String::from("wubalubadubdub")),
+            false
+        );
+    }
+
+    #[test]
+    fn test_get_hash_size() {
+        assert_eq!(
+            HashAlgorithms::get_hash_size(String::from("wubalubadubdub")),
+            0
+        );
+        assert_eq!(HashAlgorithms::get_hash_size(String::from("sha1")), 160);
+        assert_eq!(
+            HashAlgorithms::get_hash_size(String::from("sha256")),
+            256
+        );
+        assert_eq!(
+            HashAlgorithms::get_hash_size(String::from("sha384")),
+            384
+        );
+        assert_eq!(
+            HashAlgorithms::get_hash_size(String::from("sha512")),
+            512
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ extern crate tempfile;
 mod cmd_exec;
 mod common;
 mod crypto;
+mod hash;
 mod keylime_error;
 mod secure_mount;
 mod tpm;


### PR DESCRIPTION
Not sure if this is truly needed or not, but just in case ....

`is_accepted` left out as it's more of a generic function.

May help with #66

See: https://github.com/keylime/keylime/blob/master/keylime/tpm/tpm_abstract.py#L47