### PR TITLE
Implements TPM vendor check function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,6 @@ type BoxFut = Box<Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
 static NOTFOUND: &[u8] = b"Not Found";
 
-fn print_type_of<T>(_: &T) {
-    println!("{}", std::any::type_name::<T>())
-}
-
 fn main() {
     pretty_env_logger::init();
     //  Retreive the TPM Vendor, this allows us to warn if someone is using a

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,9 +49,10 @@ static NOTFOUND: &[u8] = b"Not Found";
 
 fn main() {
     pretty_env_logger::init();
+    let mut ctx = tpm::get_tpm2_ctx()?;
     //  Retreive the TPM Vendor, this allows us to warn if someone is using a
     // Software TPM ("SW")
-    let tpm_vendor = match tpm::get_tpm_vendor() {
+    let tpm_vendor = match tpm::get_tpm_vendor(&mut ctx) {
         Ok(content) => content,
         Err(e) => panic!("{:?}", e),
     };

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -1,10 +1,29 @@
+use std::collections::HashMap;
 use std::str::FromStr;
-
 use tss_esapi::constants::algorithm::HashingAlgorithm;
-use tss_esapi::constants::tss as tss_constants;
+use tss_esapi::constants::tss::*;
 use tss_esapi::tss2_esys::{ESYS_TR, ESYS_TR_NONE, ESYS_TR_RH_OWNER};
 use tss_esapi::Context;
 use tss_esapi::Tcti;
+
+fn int_to_str(num: u32) -> String {
+    let mut num = num;
+    let mut result = String::new();
+
+    loop {
+        let chr: u8 = (num & 0xFF) as u8;
+        num >>= 8;
+        if chr == 0 {
+            continue;
+        }
+        let chr = char::from(chr);
+        result.insert(0, chr);
+        if num == 0 {
+            break;
+        }
+    }
+    result
+}
 
 /*
  * Input: None
@@ -22,4 +41,54 @@ pub(crate) fn get_tpm2_ctx() -> Result<tss_esapi::Context, tss_esapi::Error> {
 
     let tcti = Tcti::from_str(tcti_path)?;
     unsafe { Context::new(tcti) }
+}
+
+/*
+ * Input: None
+ * Return:
+ *   TPM Vendor Type
+ *   tss_esapi::Error
+ *
+ * get_tpm_vendor will retrieve the type of TPM. This allows us
+ * to perform opertions, such as understand the host is using a
+ * software TPM as opposed to hardware TPM.
+ */
+pub fn get_tpm_vendor() -> Result<String, tss_esapi::Error> {
+    let mut ctx = get_tpm2_ctx()?;
+
+    let mut allprops = HashMap::new();
+    let (capabs, more) = ctx.get_capabilities(
+        TPM2_CAP_TPM_PROPERTIES,
+        TPM2_PT_MANUFACTURER,
+        80,
+    )?;
+
+    if capabs.capability != TPM2_CAP_TPM_PROPERTIES {
+        panic!("Invalid property returned");
+    }
+
+    // SAFETY: This is a C union, and Rust wants us to make sure we're using the correct one.
+    // We checked the returned capability type just above, so this should be fine.
+    unsafe {
+        for i in 0..capabs.data.tpmProperties.count {
+            let capab = capabs.data.tpmProperties.tpmProperty[i as usize];
+            allprops.insert(capab.property, capab.value);
+        }
+    }
+
+    let mut vend_strs: String = [
+        TPM2_PT_VENDOR_STRING_1,
+        TPM2_PT_VENDOR_STRING_2,
+        TPM2_PT_VENDOR_STRING_3,
+        TPM2_PT_VENDOR_STRING_4,
+    ]
+    .iter()
+    .map(|propid| allprops.get(&propid))
+    .filter(|x| x.is_some())
+    .map(|x| x.unwrap())
+    .filter(|x| x != &&0)
+    .map(|x| int_to_str(*x))
+    .collect::<Vec<String>>()
+    .join("");
+    Ok(vend_strs.split_whitespace().collect())
 }


### PR DESCRIPTION
This change implements a means to check the vendor of the TPM.

The main use for this function is to establish if we are using
a software based TPM and in turn warn that no hardware root of
trust is available