### PR TITLE
Add Dockerfile to create Fedora dev environment

### DIFF
--- a/docker/fedora/fedora.Dockerfile
+++ b/docker/fedora/fedora.Dockerfile
@@ -1,0 +1,19 @@
+FROM fedora:32
+
+# Install dev tools and libraries (includes openssl-devel)
+RUN dnf groupinstall -y \
+    "Development Tools" \
+    "Development Libraries"
+
+# Install additional packages
+RUN dnf install -y \
+    clang-devel \
+    kmod \
+    libtpms \
+    swtpm \
+    swtpm-tools \
+    tpm2-tss-devel
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc


### PR DESCRIPTION
Running a container from this image with a bind mount to the host copy of the rust-keylime repo creates a dev environment that will work properly (no missing libraries, env vars, etc.).

Signed-off-by: Lily Sturmann <lsturman@redhat.com>