### PR TITLE
Incorrect format from old tool chain

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -13,8 +13,8 @@ use std::collections::HashMap;
 use error::{Error, Result};
 
 pub(crate) async fn response_function(
-    req: Request<Body>),
-    -> Result<Response<Body>> {
+    req: Request<Body>,
+) -> Result<Response<Body>> {
     let mut my_response: Response<Body> =
         Response::new("Nothing here.".into());
 


### PR DESCRIPTION
Apologies folks, my battling with rustfmt led to me breaking the
build. This change now passed cargo fmt and also builds correctly.