### PR TITLE
Use git tss-esapi and add tpm vendor check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,8 +2103,7 @@ dependencies = [
 [[package]]
 name = "tss-esapi"
 version = "4.0.9-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a09d4314f5c2e87e86838a56363c35a941004a64a89af135ab9e2d0b6bddc5f4"
+source = "git+https://github.com/parallaxsecond/rust-tss-esapi?rev=743b3a63385dd9960013e26f6a35d34d64b16498#743b3a63385dd9960013e26f6a35d34d64b16498"
 dependencies = [
  "bindgen",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,6 @@ serde_json = "1.0"
 tempfile = "3.0.4"
 tokio = {version = "0.2", features = ["full"]}
 tokio-io = "0.1"
-tss-esapi = "4.0.9-alpha.1"
+# While functions are being added, we use the git repo version for now
+# tss-esapi = "4.0.9-alpha.1"
+tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi", rev = "743b3a63385dd9960013e26f6a35d34d64b16498" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,13 @@ static NOTFOUND: &[u8] = b"Not Found";
 async fn main() -> Result<()> {
     pretty_env_logger::init();
     let mut ctx = tpm::get_tpm2_ctx()?;
+    //  Retreive the TPM Vendor, this allows us to warn if someone is using a
+    // Software TPM ("SW")
+    if tss_esapi::utils::get_tpm_vendor(&mut ctx)?.contains("SW") {
+        warn!("INSECURE: Keylime is using a software TPM emulator rather than a real hardware TPM.");
+        warn!("INSECURE: The security of Keylime is NOT linked to a hardware root of trust.");
+        warn!("INSECURE: Only use Keylime in this mode for testing or debugging purposes.");
+    }
     let cloudagent_ip =
         config_get("/etc/keylime.conf", "cloud_agent", "cloudagent_ip")?;
     let cloudagent_port =

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -1,10 +1,11 @@
 use std::str::FromStr;
 
-use tss_esapi::constants::algorithm::HashingAlgorithm;
-use tss_esapi::constants::tss as tss_constants;
-use tss_esapi::tss2_esys::{ESYS_TR, ESYS_TR_NONE, ESYS_TR_RH_OWNER};
-use tss_esapi::Context;
-use tss_esapi::Tcti;
+use crate::Result;
+
+use tss_esapi::{
+    constants::{algorithm::HashingAlgorithm, tss::*},
+    Context, Tcti,
+};
 
 /*
  * Input: None
@@ -13,7 +14,7 @@ use tss_esapi::Tcti;
  * Example call:
  * let mut ctx = tpm::get_tpm2_ctx();
  */
-pub(crate) fn get_tpm2_ctx() -> Result<tss_esapi::Context, tss_esapi::Error> {
+pub(crate) fn get_tpm2_ctx() -> Result<tss_esapi::Context> {
     let tcti_path = if std::path::Path::new("/dev/tpmrm0").exists() {
         "device:/dev/tpmrm0"
     } else {
@@ -21,5 +22,5 @@ pub(crate) fn get_tpm2_ctx() -> Result<tss_esapi::Context, tss_esapi::Error> {
     };
 
     let tcti = Tcti::from_str(tcti_path)?;
-    unsafe { Context::new(tcti) }
+    unsafe { Context::new(tcti) }.map_err(|e| e.into())
 }


### PR DESCRIPTION
This PR makes us use the Git copy of tss-esapi for now, while we are still actively adding features there.
It also adds the TPM vendor check from #113.