### PR TITLE
Make #[allow_ci] a comment

### DIFF
--- a/src/cmd_exec.rs
+++ b/src/cmd_exec.rs
@@ -133,7 +133,7 @@ mod tests {
     fn test_read_file_output_path() {
         assert_eq!(
             read_file_output_path("test-data/test_input.txt".to_string())
-                .unwrap(),
+                .unwrap(), //#[allow_ci]
             "Hello World!\n"
         );
     }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -198,7 +198,7 @@ mod tests {
                 "b8558314f515931c8d9b329805978fe77b9bb020b05406c0e",
                 "f189d89846ff8f5f0ca10e387d2c424358171df7f896f9f"
             ),
-            mac.unwrap()
+            mac.unwrap() //#[allow_ci]
         );
     }
 
@@ -212,30 +212,30 @@ mod tests {
         assert_eq!(
             "8a6de415abb8b27de5c572c8137bd14e5658395f9a2346e0b1ad8b9d8b9028af"
                 .to_string(),
-            key.unwrap()
+            key.unwrap() //#[allow_ci]
         );
     }
 
     #[test]
     fn test_hmac_verification() {
         // Generate a keypair
-        let keypair = Rsa::generate(2048).unwrap();
-        let keypair = PKey::from_rsa(keypair).unwrap();
+        let keypair = Rsa::generate(2048).unwrap(); //#[allow_ci]
+        let keypair = PKey::from_rsa(keypair).unwrap(); //#[allow_ci]
         let data = b"hello, world!";
         let data2 = b"hola, mundo!";
 
         // Sign the data
         let mut signer =
-            Signer::new(MessageDigest::sha256(), &keypair).unwrap();
-        signer.update(data).unwrap();
-        signer.update(data2).unwrap();
-        let signature = signer.sign_to_vec().unwrap();
+            Signer::new(MessageDigest::sha256(), &keypair).unwrap(); //#[allow_ci]
+        signer.update(data).unwrap(); //#[allow_ci]
+        signer.update(data2).unwrap(); //#[allow_ci]
+        let signature = signer.sign_to_vec().unwrap(); //#[allow_ci]
 
         // Verify the data
         let mut verifier =
-            Verifier::new(MessageDigest::sha256(), &keypair).unwrap();
-        verifier.update(data).unwrap();
-        verifier.update(data2).unwrap();
-        assert!(verifier.verify(&signature).unwrap());
+            Verifier::new(MessageDigest::sha256(), &keypair).unwrap(); //#[allow_ci]
+        verifier.update(data).unwrap(); //#[allow_ci]
+        verifier.update(data2).unwrap(); //#[allow_ci]
+        assert!(verifier.verify(&signature).unwrap()); //#[allow_ci]
     }
 }

--- a/tests/nopanic.ci
+++ b/tests/nopanic.ci
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 '''
-To prevent CI failing for approved instance of banned words, add a comment: #[allow_ci]
+To prevent CI failing for approved instance of banned words, add a comment: //#[allow_ci]
 '''
 
 import os
@@ -16,7 +16,7 @@ for f in srcs:
     with open("src/" + f) as src_file:
         for line_no, line in enumerate(src_file):
             for b in banned:
-                if b not in line or "#[allow_ci]" in line:
+                if b not in line or "//#[allow_ci]" in line:
                     continue
                 failed = True
                 print("File %s on line number  %s calls banned function: %s)" % (f, line_no + 1, b))


### PR DESCRIPTION
This allows Rust to ignore it, but our CI tests to detect it.

Signed-off-by: Lily Sturmann <lsturman@redhat.com>

~~Edit: The failures are related to the `unwraps()` that this tests for and which are fixed in #144 .~~