### PR TITLE
Registrar call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "async-trait"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,19 +379,25 @@ checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
 
 [[package]]
 name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
-
-[[package]]
-name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bincode"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+dependencies = [
+ "byteorder",
+ "serde",
+]
 
 [[package]]
 name = "bindgen"
@@ -587,6 +599,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
 
 [[package]]
+name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+
+[[package]]
+name = "cow-utils"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79bb3adfaf5f75d24b01aee375f7555907840fa2800e5ec8fa3b9e2031830173"
+
+[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +634,12 @@ checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
  "cfg-if 0.1.10",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
 
 [[package]]
 name = "derive_more"
@@ -634,6 +674,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
+name = "educe"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7260c7e6e656fc7702a1aa8d5b498a1a69aa84ac4ffcd5501b7d26939f368a93"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +707,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
 dependencies = [
  "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "3.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1676e1daadfd216bda88d3a6fedd1bf53b829a085f5cc4d81c6f3054f50ef983"
+dependencies = [
+ "num-bigint",
+ "num-traits",
  "proc-macro2",
  "quote",
  "syn",
@@ -704,6 +769,28 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -976,10 +1063,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes 0.5.6",
+ "http",
+]
+
+[[package]]
 name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
@@ -995,6 +1098,43 @@ name = "humantime"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+
+[[package]]
+name = "hyper"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+dependencies = [
+ "bytes 0.5.6",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-tls",
+]
 
 [[package]]
 name = "idna"
@@ -1044,7 +1184,22 @@ dependencies = [
  "socket2",
  "widestring",
  "winapi 0.3.9",
- "winreg",
+ "winreg 0.6.2",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1052,6 +1207,15 @@ name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+
+[[package]]
+name = "js-sys"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -1068,7 +1232,7 @@ name = "keylime_agent"
 version = "0.1.0"
 dependencies = [
  "actix-web",
- "base64 0.9.3",
+ "base64 0.13.0",
  "flate2",
  "futures 0.3.6",
  "hex",
@@ -1076,15 +1240,20 @@ dependencies = [
  "log",
  "openssl",
  "pretty_env_logger",
+ "reqwest",
  "rust-ini",
  "rustc-serialize",
  "serde",
+ "serde_bytes",
  "serde_derive",
  "serde_json",
  "tempfile",
  "tokio",
  "tokio-io",
  "tss-esapi",
+ "uuid",
+ "validators 0.22.2",
+ "validators-derive",
 ]
 
 [[package]]
@@ -1104,6 +1273,19 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 0.1.10",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -1190,6 +1372,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1456,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,8 +1490,20 @@ version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
+ "lexical-core",
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1337,6 +1559,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
+name = "oncemutex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d11de466f4a3006fe8a5e7ec84e93b79c70cb992ae0aa0eb631ad2df8abfe2"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,6 +1583,12 @@ dependencies = [
  "libc",
  "openssl-sys",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
@@ -1406,6 +1640,26 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "phonenumber"
+version = "0.2.4+8.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207b3a8b4b30da166f6d8175ad39b86aa84d190965be4533af3d5541754de358"
+dependencies = [
+ "bincode",
+ "either",
+ "failure",
+ "fnv",
+ "itertools",
+ "lazy_static",
+ "nom",
+ "quick-xml",
+ "regex",
+ "regex-cache",
+ "serde",
+ "serde_derive",
+]
 
 [[package]]
 name = "pin-project"
@@ -1491,6 +1745,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-xml"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe1e430bdcf30c9fdc25053b9c459bb1a4672af4617b6c783d7d91dc17c6bbb0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1822,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-cache"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c86351f6af6bbf23b4c5f73ee4fdfe92d298fdf28572ea4f69494cabe38699"
+dependencies = [
+ "lru-cache",
+ "oncemutex",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1846,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
+dependencies = [
+ "base64 0.12.3",
+ "bytes 0.5.6",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.7.0",
 ]
 
 [[package]]
@@ -1613,7 +1924,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -1623,10 +1934,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
-name = "safemem"
-version = "0.3.3"
+name = "schannel"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1635,10 +1950,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "security-framework"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
 dependencies = [
  "semver-parser",
 ]
@@ -1656,6 +2003,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1767,6 +2123,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stdweb"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +2176,16 @@ name = "stdweb-internal-runtime"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
+
+[[package]]
+name = "str-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29ac83e616d9ed4e3c05d0e8ddd8ebcaf4911fd9c8184f30e9b720a9a87f463"
+dependencies = [
+ "cow-utils",
+ "unicase",
+]
 
 [[package]]
 name = "strsim"
@@ -2031,6 +2403,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,6 +2425,12 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
@@ -2106,6 +2494,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
 name = "tss-esapi"
 version = "4.0.10-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,6 +2524,15 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -2179,6 +2582,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "validators"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f22ef6e4b72e85d3dc433dde771a4c150cd109da39227f38abcaf4f4294d4b6e"
+dependencies = [
+ "data-encoding",
+ "failure",
+ "idna",
+ "phonenumber",
+ "regex",
+ "semver 0.10.0",
+ "serde_json",
+ "str-utils",
+ "url",
+ "validators-options 0.21.1",
+]
+
+[[package]]
+name = "validators"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1e12610b2fca355aedadffd1d7da21bdce48b6feeb9096a724a21c7686ebe4"
+dependencies = [
+ "validators-options 0.22.0",
+]
+
+[[package]]
+name = "validators-derive"
+version = "0.21.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07ee868e672cc6dc6f8a16255233e7d4ec8e44cf4c021b194b3a4156fd43ec4"
+dependencies = [
+ "educe",
+ "enum-ordinalize",
+ "phonenumber",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+ "validators 0.21.4",
+ "validators-options 0.21.1",
+]
+
+[[package]]
+name = "validators-options"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef76bca3bdc3c08b403c80cc4e7cbf322437876f67962f5c560c84d5962e5f0"
+dependencies = [
+ "educe",
+ "enum-ordinalize",
+]
+
+[[package]]
+name = "validators-options"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075051f42fdc55a6757a99646dc07d9d0865ccec510474877ace7622971bd9e3"
+dependencies = [
+ "educe",
+ "enum-ordinalize",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,6 +2671,16 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -2215,6 +2701,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
  "cfg-if 0.1.10",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -2231,6 +2719,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+dependencies = [
+ "cfg-if 0.1.10",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2261,6 +2761,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+
+[[package]]
+name = "web-sys"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "which"
@@ -2325,6 +2835,15 @@ name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 actix-web = "3"
-base64 = "0.9.3"
+base64 = "0.13.0"
 flate2 = "1.0.4"
 futures = "0.3.6"
 hex = "0.3.2"
@@ -14,12 +14,17 @@ libc = "0.2.43"
 log = "0.4"
 openssl = "0.10.15"
 pretty_env_logger = "0.2.0"
+reqwest = {version = "0.10.8", features = ["json"]}
 rust-ini = "0.12.1"
 rustc-serialize = "0.3.24"
 serde = "1.0.80"
 serde_derive = "1.0.80"
 serde_json = "1.0"
+serde_bytes = "0.11"
 tempfile = "3.0.4"
 tokio = {version = "0.2", features = ["full"]}
 tokio-io = "0.1"
+uuid = {version = "0.8", features = ["v4"]}
+validators = "0.22.2"
+validators-derive = "0.21.6"
 tss-esapi = "4.0.10-alpha.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,12 +7,14 @@ pub(crate) enum Error {
     InvalidRequest,
     Ini(ini::ini::Error),
     Configuration(String),
+    Reqwest(reqwest::Error),
     Serde(serde_json::Error),
     Permission,
     IO(std::io::Error),
     Utf8(std::string::FromUtf8Error),
     SecureMount,
     TPMInUse,
+    UUIDError(uuid::Error),
     Execution(Option<i32>, String),
     NumParse(std::num::ParseIntError),
 }
@@ -25,6 +27,9 @@ impl fmt::Display for Error {
             }
             Error::TPM(err) => write!(f, "TPM Error encountered: {}", err),
             Error::ActixWeb(err) => write!(f, "HttpServer({})", err),
+            Error::UUIDError(err) => {
+                write!(f, "TPM Error encountered: {}", err)
+            }
             anything => write!(f, "Another error: {:?}", anything),
         }
     }
@@ -63,6 +68,18 @@ impl From<serde_json::Error> for Error {
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Self {
         Error::IO(err)
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        Error::Reqwest(err)
+    }
+}
+
+impl From<uuid::Error> for Error {
+    fn from(err: uuid::Error) -> Self {
+        Error::UUIDError(err)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,17 @@
-#[macro_use]
-use log::*;
-
-#[macro_use]
-use futures::try_join;
+use actix_web::{web, App, HttpServer};
+use common::config_get;
+use error::{Error, Result};
 use futures::future::TryFutureExt;
+use futures::try_join;
 use ini;
+use log::*;
 use pretty_env_logger;
+use std::fs::File;
+use std::io::BufReader;
+use std::io::Read;
+use std::path::Path;
+use tss_esapi::constants::algorithm::AsymmetricAlgorithm;
+use uuid::Uuid;
 
 mod cmd_exec;
 mod common;
@@ -14,24 +20,63 @@ mod error;
 mod hash;
 mod keys_handler;
 mod quotes_handler;
+mod registrar_agent;
 mod secure_mount;
 mod tpm;
 
-use actix_web::{web, App, HttpServer};
-use common::config_get;
-use std::fs::File;
-use std::io::BufReader;
-use std::io::Read;
-use std::path::Path;
-
-use error::{Error, Result};
-
 static NOTFOUND: &[u8] = b"Not Found";
+
+fn get_uuid(agent_uuid_config: &str) -> String {
+    match agent_uuid_config {
+        "openstack" => {
+            info!("Openstack placeholder...");
+            "openstack".into()
+        }
+        "hash_ek" => {
+            info!("hash_ek placeholder...");
+            "hash_ek".into()
+        }
+        "generate" => {
+            let agent_uuid = Uuid::new_v4();
+            info!("Generated a new UUID: {}", &agent_uuid);
+            agent_uuid.to_string()
+        }
+        uuid_config => match Uuid::parse_str(uuid_config) {
+            Ok(uuid_config) => uuid_config.to_string(),
+            Err(_) => {
+                info!("Misformatted UUID: {}", &uuid_config);
+                let agent_uuid = Uuid::new_v4();
+                agent_uuid.to_string()
+            }
+        },
+    }
+}
+
+#[test]
+fn test_get_uuid() {
+    assert_eq!(get_uuid("openstack"), "openstack");
+    assert_eq!(get_uuid("hash_ek"), "hash_ek");
+    Uuid::parse_str(&get_uuid("generate")).unwrap(); //#[allow_ci]
+    assert_eq!(
+        get_uuid("D432FBB3-D2F1-4A97-9EF7-75BD81C00000"),
+        "d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
+    );
+    assert_ne!(
+        get_uuid("D432FBB3-D2F1-4A97-9EF7-75BD81C0000X"),
+        "d432fbb3-d2f1-4a97-9ef7-75bd81c0000X"
+    );
+    Uuid::parse_str(&get_uuid("D432FBB3-D2F1-4A97-9EF7-75BD81C0000X"))
+        .unwrap(); //#[allow_ci]
+}
 
 #[actix_web::main]
 async fn main() -> Result<()> {
+    // Initialise Logger
     pretty_env_logger::init();
+
+    // Initialise TPM connection
     let mut ctx = tpm::get_tpm2_ctx()?;
+
     //  Retreive the TPM Vendor, this allows us to warn if someone is using a
     // Software TPM ("SW")
     if tss_esapi::utils::get_tpm_vendor(&mut ctx)?.contains("SW") {
@@ -39,11 +84,49 @@ async fn main() -> Result<()> {
         warn!("INSECURE: The security of Keylime is NOT linked to a hardware root of trust.");
         warn!("INSECURE: Only use Keylime in this mode for testing or debugging purposes.");
     }
+
+    // Request keyblob material
+    let (key, cert, tpm_pub) =
+        tpm::create_ek(&mut ctx, Some(AsymmetricAlgorithm::Rsa))?;
+
+    // Set up config params required
     let cloudagent_ip =
         config_get("/etc/keylime.conf", "cloud_agent", "cloudagent_ip")?;
     let cloudagent_port =
         config_get("/etc/keylime.conf", "cloud_agent", "cloudagent_port")?;
-    info!("Starting server...");
+    let registrar_ip =
+        config_get("/etc/keylime.conf", "registrar", "registrar_ip")?;
+    let registrar_port =
+        config_get("/etc/keylime.conf", "registrar", "registrar_port")?;
+    let agent_uuid_config =
+        config_get("/etc/keylime.conf", "cloud_agent", "agent_uuid")?;
+
+    let agent_uuid = get_uuid(&agent_uuid_config);
+    println!("{}", agent_uuid);
+    // Placeholder BEGIN
+    // The following will be removed on the final commit, these are just placeholders for now
+    let ek = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmYicaAAArcin6fRZmzkc\nssyW5VFDWuB+FXF1HdEmJR4jEMdhlp8H9uAMwExY/+6aujElLJgBSKYPPeC7d/nI\nUIYc71oBxQEn6l3DTJO+1Nl1Wq6xYvlGrJMcuAFlznJCo0IF3MVLd45zEgdDmG5T\ntQ+EMAl64eC+aIG9Zp6InLbuZd3oisjE16TiK4Rg5dHAnfU6YSo9CIVSGw6PuCqX\n3aEyeikKNLGwX7ENp+fIVxj9Y00I5JoxDgD9ufLF7V55JVXKdZ0F51NghMyJRSt+\nkyEiqHPRRVTHw+248uziY4ioaDb3EBNKjnC/xcAdUoNxE4I1W8IW8UF/4td/AU11\nfwIDAQAB\n-----END PUBLIC KEY-----\n";
+    let aik = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvRI0YcjxLLHFzBmVxO6I\nwuGri5ejIBaCb/XqirXgryXQYATmStk4WgdaDbZtW8JuLdYiTQftCFSP9iIo5jGA\nU443s/zXlWv15raraOsRlSdtSXAKv4dUFOc18GvyiL4ubrkHF5MnbdDlNoG5gZNS\nBV5/MIka5h4p7fpji93neoHNjbm/L3rSPknJnX4TVdxeOOV5izbkfD2TYD+rZ2nx\nzxqox/++dtl4yZ8jLEQnGAyFPMhMLHg8uZKNki2+DPM1oB7hKCHcG3QspVi4mOCc\nvDBt5+2VHakDi8dfFeTncHAQFqAWAHQfvYTo+EUPZpP3+49zBll/DnGt2He/GEvT\nFwIDAQAB\n-----END PUBLIC KEY-----\n";
+    let ekcert = "MIID8zCCAlugAwIBAgIBIDANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1zd3RwbS1sb2NhbGNhMB4XDTIwMTIwMTExMzgwMVoXDTMwMTEyOTExMzgwMVowEjEQMA4GA1UEAxMHdW5rbm93bjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLEHnYAAWJY7AQ3pf5Iq08PNYtZfBVU2cVqrgR18oc5tjFxORObM6haNTfMQLge9wqbpB/jdMzTipIUh6GwIqDuioLKbe1Ag7yJHYmBZuFq5j/EY4IGH9+Zy2mvTVDIkx1zV0zDCopliZC6pmFJtVA6oRQD1drIlMFAb7oX5SilqQE+++PWR9BCEmFxpRla32F/ejcFIbP1+DhtwSPXbXGcw885FjCjOlPhXTeDdXXkipf9KtKHblfFsx1DD4hEviiYqt1XwPtgOZlabIsHV+KLHRzLGvjUtVmOP4QKY00LfhFH9b0+8vCIRBlhdISMXWDiv8QIxm2iq/jSGPdPJo8CAwEAAaOBzTCByjAQBgNVHSUECTAHBgVngQUIATBSBgNVHREBAf8ESDBGpEQwQjEWMBQGBWeBBQIBDAtpZDowMDAwMTAxNDEQMA4GBWeBBQICDAVzd3RwbTEWMBQGBWeBBQIDDAtpZDoyMDE3MDYxOTAMBgNVHRMBAf8EAjAAMCIGA1UdCQQbMBkwFwYFZ4EFAhAxDjAMDAMyLjACAQACAgCWMB8GA1UdIwQYMBaAFNZCf4X9wlnqDfz4wdpgGhA40JZIMA8GA1UdDwEB/wQFAwMHIAAwDQYJKoZIhvcNAQELBQADggGBAKqAAL6rA9JotB5jVr4JiCT3tuKKMHx0dIn2ioYPd7LWahWKcgCgSWqrRziDOVgoTGcWp+Jc2exQ0Rsle3SrdY+Vp4EODsIN3TRkJ0HtzP6NoacEJheKkAdcMhfJfDCam25Wdv1unIDbbwkjSqYR4qfiPOKTFIH4+Dl+uypuvECw5OAyMG64EDTV5aWKtNYkYf7h60Yo77gYNmAP6XJhk2QrMKhWH4RsJvibcXp5CC7dhJEvnCUAnRE85zS3eoppaxssfd+4EIcCqQRCY7a9kIAKBGtemIFgkOwrynxhSBjpMSfcU99tsuNnMnSOhqJRLoJ3wKncTaBiJbzJDwuzPAOYNoBTOiBWLQNThv0Ky4KyuLFkxWM9Q3zcecpxR2PL0hVskB7c0H5+urwDid6SZ7VZ7nWY0z3WexqUY6xRp1C6BtBGVeh6w3Vlu60c31k89mR6eC6K1j/iNHXBdvgGPqH23wPhOr5MeB+g+UOOSaR+EYkr7NF+ekUvItXtB/tY7Q==";
+    let ekcert = base64::decode(ekcert).unwrap(); //#[allow_ci]
+    let ek_tpm = "AToAAQALAAMAsgAgg3GXZ0SEs/gakMyNRqXXJP1S124GUgtk8qHaGzMUaaoABgCAAEMAEAgAAAAAAAEAmYicaAAArcin6fRZmzkcssyW5VFDWuB+FXF1HdEmJR4jEMdhlp8H9uAMwExY/+6aujElLJgBSKYPPeC7d/nIUIYc71oBxQEn6l3DTJO+1Nl1Wq6xYvlGrJMcuAFlznJCo0IF3MVLd45zEgdDmG5TtQ+EMAl64eC+aIG9Zp6InLbuZd3oisjE16TiK4Rg5dHAnfU6YSo9CIVSGw6PuCqX3aEyeikKNLGwX7ENp+fIVxj9Y00I5JoxDgD9ufLF7V55JVXKdZ0F51NghMyJRSt+kyEiqHPRRVTHw+248uziY4ioaDb3EBNKjnC/xcAdUoNxE4I1W8IW8UF/4td/AU11fw==";
+    let ek_tpm = base64::decode(ek_tpm).unwrap(); //#[allow_ci]
+    let aik_name = "000bb35615c533f39df1f1a30d35a42c2f9dc5b8a6a3c5332ec59e702d8e04a288fa";
+    // placeholder END
+    let mut keyblob = registrar_agent::do_register_agent(
+        &registrar_ip,
+        &registrar_port,
+        &agent_uuid,
+        &ek,
+        &ekcert,
+        &aik,
+        &ek_tpm,
+        &aik_name,
+    )
+    .await;
+    // TODO: After keyblob is returned we need to activate indentity
+    // key = tpm.activate_identity(keyblob)
+
     let actix_server = HttpServer::new(move || {
         App::new()
             .service(

--- a/src/registrar_agent.rs
+++ b/src/registrar_agent.rs
@@ -1,0 +1,94 @@
+use crate::error::Error;
+use reqwest::header::*;
+use serde::{Deserialize, Serialize};
+use serde_json::Number;
+
+fn serialize_as_base64<S>(
+    bytes: &[u8],
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&base64::encode(bytes))
+}
+
+fn deserialize_as_base64<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    String::deserialize(deserializer).and_then(|string| {
+        base64::decode(&string).map_err(serde::de::Error::custom)
+    })
+}
+
+pub fn deserialize_maybe_base64<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<u8>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<WrappedBase64Encoded>::deserialize(deserializer)
+        .map(|wrapped| wrapped.map(|wrapped| wrapped.0))
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Register<'a> {
+    ek: &'a str,
+    #[serde(serialize_with = "serialize_as_base64")]
+    ekcert: &'a [u8],
+    #[serde(serialize_with = "serialize_as_base64")]
+    ek_tpm: &'a [u8],
+    aik: &'a str,
+    aik_name: &'a str,
+    tpm_version: u8,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RegisterResponseResults {
+    #[serde(deserialize_with = "deserialize_maybe_base64")]
+    blob: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RegisterResponse {
+    code: Number,
+    status: String,
+    results: RegisterResponseResults,
+}
+
+#[derive(Debug, Deserialize)]
+struct WrappedBase64Encoded(
+    #[serde(deserialize_with = "deserialize_as_base64")] Vec<u8>,
+);
+
+pub(crate) async fn do_register_agent(
+    registrar_ip: &str,
+    registrar_port: &str,
+    agent_uuid: &str,
+    ek: &str,
+    ekcert: &[u8],
+    aik: &str,
+    ek_tpm: &[u8],
+    aik_name: &str,
+) -> Result<RegisterResponse, Error> {
+    let data = Register {
+        ek: ek,
+        ekcert: ekcert,
+        ek_tpm: ek_tpm,
+        aik: aik,
+        aik_name: aik_name,
+        tpm_version: 2,
+    };
+    reqwest::Client::new()
+        .post(&format!(
+            "http://{}:{}/agents/{}",
+            registrar_ip, registrar_port, agent_uuid
+        ))
+        .json(&data)
+        .send()
+        .await?
+        .json()
+        .await
+        .map_err(|e| e.into())
+}

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -61,7 +61,7 @@ pub(crate) fn create_ek(
     // Retrieve EK handle, EK pub cert, and TPM pub object
     let handle = ek::create_ek_object(context, alg)?;
     let cert = ek::retrieve_ek_pubcert(context, alg)?;
-    let (tpm_pub, _, _) = context.read_public(handle)?;
+    let (tpm_pub) = context.read_public(handle)?;
 
     // Convert TPM pub object to Vec<u8>
     // See: https://github.com/fedora-iot/clevis-pin-tpm2/blob/master/src/tpm_objects.rs#L64


### PR DESCRIPTION
This call takes tpm artifacts (ek, ekcert, ek_tpm, aik etc) and sends the to the registrar using a http client (reqwest).

The registrar then returns a keyblob in the response, which will then be passed to tpm activation. 

Note crypto strings are temporary and will be removed by final commit (once the AIK code is in). 