### PR TITLE
Implement get_ek() function

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,7 @@ pub(crate) enum Error {
     SecureMount,
     TPMInUse,
     Execution(Option<i32>, String),
+    NumParse(std::num::ParseIntError),
 }
 
 impl fmt::Display for Error {
@@ -68,6 +69,12 @@ impl From<std::io::Error> for Error {
 impl From<std::string::FromUtf8Error> for Error {
     fn from(err: std::string::FromUtf8Error) -> Self {
         Error::Utf8(err)
+    }
+}
+
+impl From<std::num::ParseIntError> for Error {
+    fn from(err: std::num::ParseIntError) -> Self {
+        Error::NumParse(err)
     }
 }
 

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -83,3 +83,37 @@ pub(crate) fn create_ek(
 
     Ok((handle, cert, tpm_pub_vec))
 }
+
+/* Converts a hex value in the form of a string (ex. from keylime.conf's
+ * ek_handle) to a key handle.
+ *
+ * Input: &str
+ * Return: Key handle
+ *
+ * Example call:
+ * let ek_handle = tpm::ek_from_hex_str("0x81000000");
+ */
+pub(crate) fn ek_from_hex_str(val: &str) -> Result<KeyHandle> {
+    let val = val.trim_start_matches("0x");
+    Ok(KeyHandle::from(u32::from_str_radix(val, 16)?))
+}
+
+#[test]
+fn ek_from_hex() {
+    assert_eq!(
+        ek_from_hex_str("0x81000000").unwrap(), //#[allow_ci]
+        ek_from_hex_str("81000000").unwrap()    //#[allow_ci]
+    );
+    assert_eq!(
+        ek_from_hex_str("0xdeadbeef").unwrap(), //#[allow_ci]
+        ek_from_hex_str("deadbeef").unwrap()    //#[allow_ci]
+    );
+
+    assert!(ek_from_hex_str("a").is_ok());
+    assert!(ek_from_hex_str("18bb9").is_ok());
+
+    assert!(ek_from_hex_str("qqq").is_err());
+    assert!(ek_from_hex_str("0xqqq").is_err());
+    assert!(ek_from_hex_str("0xdeadbeefqwerty").is_err());
+    assert!(ek_from_hex_str("0x0x0x").is_err());
+}


### PR DESCRIPTION
Resolves #115 

I changed the name ~~to `get_ek()` because that seems like what it does (rather than "use" the ek)~~.
Please let me know if I should make changes or if this isn't the right way to generate the key handle.