### PR TITLE
Bump to tss-esapi-4.0.10-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,16 +389,15 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "bindgen"
-version = "0.54.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
+checksum = "2da379dbebc0b76ef63ca68d8fc6e71c0f13e59432e0987e508c1820e6ab5239"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if 0.1.10",
  "clang-sys",
  "clap",
- "env_logger 0.7.1",
+ "env_logger 0.8.2",
  "lazy_static",
  "lazycell",
  "log",
@@ -531,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "0.29.3"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
+checksum = "0659001ab56b791be01d4b729c44376edc6718cf389a502e579b77b758f3296c"
 dependencies = [
  "glob",
  "libc",
@@ -688,7 +687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
  "log",
  "regex",
  "termcolor",
@@ -696,12 +695,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 2.0.1",
  "log",
  "regex",
  "termcolor",
@@ -992,6 +991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+
+[[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,11 +1113,11 @@ checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+checksum = "e9367bdfa836b7e3cf895867f7a570283444da90562980ec2263d6e1569b16bc"
 dependencies = [
- "cc",
+ "cfg-if 1.0.0",
  "winapi 0.3.9",
 ]
 
@@ -2102,8 +2107,9 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi"
-version = "4.0.9-alpha.1"
-source = "git+https://github.com/parallaxsecond/rust-tss-esapi?rev=743b3a63385dd9960013e26f6a35d34d64b16498#743b3a63385dd9960013e26f6a35d34d64b16498"
+version = "4.0.10-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaaec68e3832d2ab7ad322aa4ec5e8f13aa5004e1d058ede8337575a48d0310"
 dependencies = [
  "bindgen",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,4 @@ serde_json = "1.0"
 tempfile = "3.0.4"
 tokio = {version = "0.2", features = ["full"]}
 tokio-io = "0.1"
-# While functions are being added, we use the git repo version for now
-# tss-esapi = "4.0.9-alpha.1"
-tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi", rev = "743b3a63385dd9960013e26f6a35d34d64b16498" }
+tss-esapi = "4.0.10-alpha.2"

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -61,7 +61,7 @@ pub(crate) fn create_ek(
     // Retrieve EK handle, EK pub cert, and TPM pub object
     let handle = ek::create_ek_object(context, alg)?;
     let cert = ek::retrieve_ek_pubcert(context, alg)?;
-    let tpm_pub = context.read_public(handle)?;
+    let (tpm_pub, _, _) = context.read_public(handle)?;
 
     // Convert TPM pub object to Vec<u8>
     // See: https://github.com/fedora-iot/clevis-pin-tpm2/blob/master/src/tpm_objects.rs#L64


### PR DESCRIPTION
This version of `tss-esapi` includes everything that rust-keylime will need.