### PR TITLE
Basic quote handlers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,10 @@ async fn main() -> Result<()> {
                 web::resource("/quotes/identity")
                     .route(web::get().to(quotes_handler::identity)),
             )
+            .service(
+                web::resource("/quotes/integrity")
+                    .route(web::get().to(quotes_handler::integrity)),
+            )
     })
     .bind(format!("{}:{}", cloudagent_ip, cloudagent_port))?
     .run()

--- a/src/quotes_handler.rs
+++ b/src/quotes_handler.rs
@@ -6,6 +6,64 @@ pub struct Ident {
     nonce: String,
 }
 
+#[derive(Deserialize)]
+pub struct Integ {
+    nonce: String,
+    mask: String,
+    vmask: String,
+    partial: String,
+}
+
 pub async fn identity(param: web::Query<Ident>) -> impl Responder {
-    HttpResponse::Ok().body(format!("Nonce: {}", param.nonce))
+    // nonce can only be in alphanumerical format
+    if !param.nonce.chars().all(char::is_alphanumeric) {
+        HttpResponse::BadRequest()
+            .body(format!(
+                "Parameters should be strictly alphanumeric: {}",
+                param.nonce
+            ))
+            .await
+    } else {
+        // place holder for identity quote code
+        HttpResponse::Ok()
+            .body(format!(
+                "Calling Identity Quote with nonce: {}",
+                param.nonce
+            ))
+            .await
+    }
+}
+
+pub async fn integrity(param: web::Query<Integ>) -> impl Responder {
+    // nonce, mask, vmask can only be in alphanumerical format
+    if !param.nonce.chars().all(char::is_alphanumeric) {
+        HttpResponse::BadRequest()
+            .body(format!(
+                "nonce should be strictly alphanumeric: {}",
+                param.nonce
+            ))
+            .await
+    } else if !param.mask.chars().all(char::is_alphanumeric) {
+        HttpResponse::BadRequest()
+            .body(format!(
+                "mask should be strictly alphanumeric: {}",
+                param.mask
+            ))
+            .await
+    } else if !param.vmask.chars().all(char::is_alphanumeric) {
+        HttpResponse::BadRequest()
+            .body(format!(
+                "vmask should be strictly alphanumeric: {}",
+                param.vmask
+            ))
+            .await
+    } else {
+        // place holder for integrity quote code
+        HttpResponse::Ok()
+            .body(format!(
+                "Calling Integrity Quote with nonce: {}",
+                param.nonce
+            ))
+            .await
+    }
 }


### PR DESCRIPTION
The following code replicates python agent code:

https://github.com/keylime/keylime/blob/d987c71dd878492ac2b59eca781009fe270d219a/keylime/keylime_agent.py#L95-L114

This is more or a less at the point that we can call the tpm for quote.

Signed-off-by: Luke Hinds <lhinds@redhat.com>