### PR TITLE
Call revocation actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
  "actix-service",
  "actix-threadpool",
  "actix-utils",
- "base64",
+ "base64 0.13.0",
  "bitflags",
  "brotli2",
  "bytes 0.5.6",
@@ -332,7 +332,7 @@ dependencies = [
  "actix-http",
  "actix-rt",
  "actix-service",
- "base64",
+ "base64 0.13.0",
  "bytes 0.5.6",
  "cfg-if 1.0.0",
  "derive_more",
@@ -371,6 +371,12 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bindgen"
@@ -1070,7 +1076,7 @@ name = "keylime_agent"
 version = "0.1.0"
 dependencies = [
  "actix-web",
- "base64",
+ "base64 0.12.3",
  "flate2",
  "futures 0.3.8",
  "hex",
@@ -1700,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rust-ini = "0.12.1"
 rustc-serialize = "0.3.24"
 serde = "1.0.80"
 serde_derive = "1.0.80"
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["raw_value"] }
 tempfile = "3.0.4"
 tokio = {version = "0.2", features = ["full"]}
 tokio-io = "0.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,8 @@ pub(crate) enum Error {
     OpenSSL(openssl::error::ErrorStack),
     #[error("ZMQ error: {0}")]
     ZMQ(zmq::Error),
+    #[error("{0}")]
+    Other(String),
 }
 
 impl From<tss_esapi::Error> for Error {

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -7,9 +7,150 @@ use crate::error;
 use crate::error::{Error, Result};
 use crate::secure_mount;
 
+use std::io::Write;
 use std::path::Path;
+use std::process::{Child, Command, Output, Stdio};
 
 use serde_json::Value;
+
+/// Runs a script with a json value as argument (used for revocation actions)
+pub(crate) fn run_action(
+    dir: &Path,
+    script: &str,
+    json: Value,
+) -> Result<Output> {
+    let raw_json = serde_json::value::to_raw_value(&json)?;
+
+    let mut child = match Command::new(format!("{}{}", "./", script))
+        .current_dir(dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(e) => {
+            let msg = format!(
+                "ERROR: failed to run revocation action: {}, received: {}",
+                script, e
+            );
+            error!("{}", msg);
+            return Err(Error::Other(msg));
+        }
+    };
+
+    let msg = format!(
+        "ERROR: failed writing to stdin on revocation action: {:?}",
+        script
+    );
+    if let Err(e) = child
+        .stdin
+        .as_mut()
+        .expect(&msg)
+        .write_all(raw_json.get().as_bytes())
+    {
+        error!("{}", msg);
+        return Err(Error::Other(msg));
+    }
+
+    let output = match child.wait_with_output() {
+        Ok(output) => output,
+        Err(e) => {
+            let msg = format!("ERROR: failed to wait on child process while running revocation action: {:?}", script);
+            error!("{}", msg);
+            return Err(Error::Other(msg));
+        }
+    };
+
+    if !output.status.success() {
+        let code = match output.status.code() {
+            Some(code) => code.to_string(),
+            None => {
+                "no code; process likely terminated by signal".to_string()
+            }
+        };
+        let stdout = String::from_utf8(output.stdout)?;
+        let stderr = String::from_utf8(output.stderr)?;
+
+        let mut msg = format!(
+            "ERROR: revocation action {} returned with {}\n",
+            script, code
+        );
+
+        if !stdout.is_empty() {
+            msg = format!(
+                "{}{}",
+                msg,
+                format!(
+                    "ERROR: revocation action {} stdout: {:?}",
+                    script, stdout
+                )
+            );
+        }
+
+        if !stderr.is_empty() {
+            msg = format!(
+                "{}{}",
+                msg,
+                format!(
+                    "ERROR: revocation action {} stderr: {:?}",
+                    script, stderr
+                )
+            );
+        }
+
+        error!("{}", msg);
+        return Err(Error::Other(msg));
+    }
+
+    info!(
+        "{}",
+        format!("INFO: revocation action {:?} successful", script)
+    );
+    Ok(output)
+}
+
+/// Runs revocation actions received from tenant post-attestation
+pub(crate) fn run_revocation_actions(
+    json: Value,
+) -> Result<Vec<Result<Output>>> {
+    #[cfg(not(test))]
+    pretty_env_logger::init();
+
+    #[cfg(test)]
+    let mount = concat!(env!("CARGO_MANIFEST_DIR"), "/tests");
+
+    #[cfg(not(test))]
+    let mount = secure_mount::mount()?;
+    let unzipped = format!("{}/unzipped", mount);
+    let action_file = format!("{}/unzipped/action_list", mount);
+
+    let mut outputs = Vec::new();
+
+    if Path::new(&action_file).exists() {
+        let action_data = std::fs::read_to_string(action_file)
+            .expect("unable to read action_list");
+
+        let action_list = action_data
+            .split('\n')
+            .filter(|&script| !script.is_empty())
+            .map(|script| script.trim())
+            .collect::<Vec<&str>>();
+
+        if !action_list.is_empty() {
+            for action in action_list {
+                let output =
+                    run_action(&Path::new(&unzipped), action, json.clone());
+                outputs.push(output);
+            }
+        } else {
+            warn!("WARNING: no actions found in revocation action list");
+        }
+    } else {
+        warn!("WARNING: no action_list found in secure directory");
+    }
+    Ok(outputs)
+}
 
 /// Handles revocation messages via 0mq
 /// See:
@@ -118,8 +259,7 @@ pub(crate) async fn run_revocation_service() -> Result<()> {
                     "Revocation signature validated for revocation: {}",
                     msg_payload
                 );
-                // TODO: Implement callback
-                //callback(msg_payload)
+                let _ = run_revocation_actions(msg_payload)?;
             }
             _ => {
                 error!("Invalid revocation message siganture {}", body);
@@ -127,4 +267,31 @@ pub(crate) async fn run_revocation_service() -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn revocation_scripts() {
+        let json_file =
+            concat!(env!("CARGO_MANIFEST_DIR"), "/tests/unzipped/test.json");
+        let json_str = std::fs::read_to_string(json_file).unwrap(); //#[allow_ci]
+        let json = serde_json::from_str(&json_str).unwrap(); //#[allow_ci]
+
+        let outputs = run_revocation_actions(json);
+        assert!(outputs.is_ok());
+        let outputs = outputs.unwrap(); //#[allow_ci]
+        assert!(outputs.len() == 2);
+
+        for output in outputs {
+            assert!(output.is_ok());
+            let output = output.unwrap(); //#[allow_ci]
+            assert_eq!(
+                String::from_utf8(output.stdout).unwrap(), //#[allow_ci]
+                "there\n"
+            );
+        }
+    }
 }

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,4 +5,5 @@ RUN dnf install -y \
 	swtpm swtpm-tools \
 	rust clippy cargo \
 	llvm llvm-devel clang pkg-config \
-	dbus-daemon czmq-devel
+	dbus-daemon czmq-devel \
+	python3

--- a/tests/unzipped/action_list
+++ b/tests/unzipped/action_list
@@ -1,0 +1,2 @@
+rev_script1.py
+rev_script2.py

--- a/tests/unzipped/rev_script1.py
+++ b/tests/unzipped/rev_script1.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python3
+
+import sys
+import json
+
+input_data = sys.stdin.read()
+input_json = json.loads(input_data)
+
+value = input_json.get('hello')
+
+print(value)

--- a/tests/unzipped/rev_script2.py
+++ b/tests/unzipped/rev_script2.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python3
+
+import sys
+import json
+
+input_data = sys.stdin.read()
+input_json = json.loads(input_data)
+
+value = input_json.get('hello')
+
+print(value)

--- a/tests/unzipped/test.json
+++ b/tests/unzipped/test.json
@@ -1,0 +1,3 @@
+{
+    "hello": "there"
+}


### PR DESCRIPTION
This code runs those revocation scripts which were sent by the tenant and can be accessed from the secure mount point post-attestation.

I've decided not to check whether the revocation scripts begin with `local_action`, since they are all listed in `action_list` anyhow. But if someone has a reason that they should be marked that way, I can add this check back again.

I had a few other thoughts and questions inline marked with `TODO` and would love some suggestions on those points. The most important being: If these scripts don't run for whatever reason (ex. the Python version was too old), is that detected in some other part of the code? It seems like we would want a guarantee that a node can't continue to be in the cluster if it doesn't run the scripts, since it could still be in communication with the compromised node, for example.