### PR TITLE
Override config location with environment variable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,10 +71,8 @@ async fn main() -> Result<()> {
         warn!("INSECURE: The security of Keylime is NOT linked to a hardware root of trust.");
         warn!("INSECURE: Only use Keylime in this mode for testing or debugging purposes.");
     }
-    let cloudagent_ip =
-        config_get("/etc/keylime.conf", "cloud_agent", "cloudagent_ip")?;
-    let cloudagent_port =
-        config_get("/etc/keylime.conf", "cloud_agent", "cloudagent_port")?;
+    let cloudagent_ip = config_get("cloud_agent", "cloudagent_ip")?;
+    let cloudagent_port = config_get("cloud_agent", "cloudagent_port")?;
     info!("Starting server...");
     let actix_server = HttpServer::new(move || {
         App::new()

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -130,13 +130,8 @@ pub(crate) async fn run_revocation_service() -> Result<()> {
 
     mysock.set_subscribe(b"")?;
 
-    let revocation_ip =
-        config_get("/etc/keylime.conf", "general", "receive_revocation_ip")?;
-    let revocation_port = config_get(
-        "/etc/keylime.conf",
-        "general",
-        "receive_revocation_port",
-    )?;
+    let revocation_ip = config_get("general", "receive_revocation_ip")?;
+    let revocation_port = config_get("general", "receive_revocation_port")?;
     let endpoint = format!("{}:{}", revocation_ip, revocation_port);
 
     mysock.connect(endpoint.as_str())?;

--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -80,8 +80,7 @@ pub(crate) fn mount() -> Result<String> {
 
     // Mount the directory to file system
     let secure_dir = format!("{}/secure", common::WORK_DIR);
-    let secure_size =
-        config_get("/etc/keylime.conf", "cloud_agent", "secure_size")?;
+    let secure_size = config_get("cloud_agent", "secure_size")?;
 
     match check_mount(&secure_dir)? {
         false => {

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -48,7 +48,6 @@ pub(crate) fn create_ek(
         Some(a) => a,
         None => {
             match config_get(
-                "/etc/keylime.conf",
                 "cloud_agent",
                 "tpm_encryption_alg",
             )?


### PR DESCRIPTION
`KEYLIME_CONFIG` can be set to override the default config file location.

*Note*:
I think we should eventually rework the configuration system so that we load the configuration once and then reload when we receive the proper signal. My reasoning is that the current set up means that if the file changes while the agent is running then the result could be old and new variables in use based on when they have been read. I've started to make structs for the keylime config. If folks agree I'll slowly but surely chip away at that no matter if this merges or not :smile: 