### PR TITLE
Apache license header to source files

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,3 @@
 max_width = 78
+# Enable when available: https://github.com/rust-lang/rustfmt/issues/3352
+#license_template_path = "license-header.tpl"

--- a/docker/fedora/wait.sh
+++ b/docker/fedora/wait.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2021 Keylime Authors
+#
 # wait.sh
 
 set -e

--- a/license-header.tpl
+++ b/license-header.tpl
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright {\d+} Keylime Authors

--- a/src/cmd_exec.rs
+++ b/src/cmd_exec.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
 use super::*;
 use crate::error::{Error, Result};
 use std::collections::HashMap;

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
 use crate::error::{Error, Result};
 use ini::Ini;
 use log::*;

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
 // use super::*;
 use openssl::hash::MessageDigest;
 use openssl::pkcs5;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
 /// Code ported from Hash_Algorithms at https://github.com/keylime/keylime/blob/master/keylime/tpm/tpm_abstract.py
 
 #[derive(Debug)]

--- a/src/keys_handler.rs
+++ b/src/keys_handler.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
 use actix_web::{web, HttpResponse, Responder};
 use serde::Deserialize;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
 #![deny(
     nonstandard_style,
     const_err,

--- a/src/quotes_handler.rs
+++ b/src/quotes_handler.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
 use actix_web::{web, HttpResponse, Responder};
 use serde::Deserialize;
 

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
 #[macro_use]
 use log::*;
 

--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
 use super::*;
 
 use crate::cmd_exec;

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
 use std::str::FromStr;
 
 use crate::{common::config_get, Error as KeylimeError, Result};

--- a/tests/nopanic.ci
+++ b/tests/nopanic.ci
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
-
 '''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2021 Keylime Authors
+
 To prevent CI failing for approved instance of banned words, add a comment: //#[allow_ci]
 '''
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2021 Keylime Authors
 
 set -euf -o pipefail
 

--- a/tests/unzipped/rev_script1.py
+++ b/tests/unzipped/rev_script1.py
@@ -1,4 +1,8 @@
 #!/usr/bin/python3
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2021 Keylime Authors
+'''
 
 import sys
 import json

--- a/tests/unzipped/rev_script2.py
+++ b/tests/unzipped/rev_script2.py
@@ -1,4 +1,8 @@
 #!/usr/bin/python3
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2021 Keylime Authors
+'''
 
 import sys
 import json


### PR DESCRIPTION
- Add ASLv2 SPDX header to source files
- Add `license-header.tpl`
- Add commented out config for `rustfmt` to check for license headers in the future

Resolves #111 