### PR TITLE
Small fixes relating to Keylime components working together

### DIFF
--- a/docker/fedora/keylime_rust.Dockerfile
+++ b/docker/fedora/keylime_rust.Dockerfile
@@ -10,6 +10,7 @@ LABEL version="2.0.1" description="Keylime - Bootstrapping and Maintaining Trust
 
 # environment variables
 ARG BRANCH=master
+ENV KEYLIME_HOME ${HOME}/keylime
 ENV container docker
 COPY dbus-policy.conf /etc/dbus-1/system.d/
 
@@ -26,6 +27,7 @@ dbus \
 dbus-daemon \
 dbus-devel \
 dnf-plugins-core \
+efivar-devel \
 gcc \
 git \
 glib2-devel \
@@ -47,10 +49,16 @@ tpm2-abrmd \
 tpm2-tools \
 tpm2-tss \
 tpm2-tss-devel \
-uthash-devel"
+uthash-devel \
+czmq-devel"
 
 RUN dnf makecache && \
   dnf -y install $PKGS_DEPS && \
   dnf clean all && \
   rm -rf /var/cache/dnf/*
 
+# Move keylime.conf to expected location in /etc/
+WORKDIR ${KEYLIME_HOME}
+RUN git clone https://github.com/keylime/keylime.git && \
+cd keylime && \
+cp keylime.conf /etc/keylime.conf

--- a/src/cmd_exec.rs
+++ b/src/cmd_exec.rs
@@ -77,7 +77,7 @@ pub(crate) fn run(
         info!("Time cost: {}", t_diff.as_secs());
 
         // assume the system is linux
-        println!("number tries: {:?}", number_tries);
+        info!("Number tries: {:?}", number_tries);
 
         match output.status.code() {
             Some(TPM_IO_ERROR) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,9 +28,9 @@ pub(crate) enum Error {
     IO(std::io::Error),
     #[error("Text decoding error: {0}")]
     Utf8(std::string::FromUtf8Error),
-    #[error("Secure Mount error")]
+    #[error("Secure Mount error: {0})")]
     #[allow(unused)]
-    SecureMount,
+    SecureMount(String),
     #[error("TPM in use")]
     TPMInUse,
     #[error("UUID error")]

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -132,7 +132,9 @@ pub(crate) async fn run_revocation_service() -> Result<()> {
 
     let revocation_ip = config_get("general", "receive_revocation_ip")?;
     let revocation_port = config_get("general", "receive_revocation_port")?;
-    let endpoint = format!("{}:{}", revocation_ip, revocation_port);
+    let endpoint = format!("tcp://{}:{}", revocation_ip, revocation_port);
+
+    info!("Connecting to revocation endpoint at {}...", endpoint);
 
     mysock.connect(endpoint.as_str())?;
 


### PR DESCRIPTION
These all relate to running the `keylime_agent`, `keylime-verifier`, and `keylime-registrar` with `docker-compose`, but some of the fixes are also generally applicable. Backstory: I am trying to make sure the components can work together before writing the 3-party key protocol. These are changes I made while fixing some bugs or trying to understand them.

~~I am still debugging some errors, so there are probably a few more commits to be added. EDIT: But these could go in an immediate future PR as well.~~

~~Currently:
`ERROR keylime_agent::revocation   > Path for the 0mq socket: /tmp/secure/unzipped/RevocationNotifier-cert.crt doesn't exist`~~