### PR TITLE
Fix communication errors between agent and registrar

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - secure-volume:/var/lib/keylime
     ports:
-        - "8881:8881"
+        - "8892:8892"
     command: [
       "/usr/local/bin/keylime_verifier"
     ]
@@ -25,6 +25,7 @@ services:
       - secure-volume:/var/lib/keylime
     ports:
         - "8891:8891"
+        - "8890:8890"
     command: ["/root/wait.sh", "/var/lib/keylime/cv_ca/client-cert.crt", "keylime_registrar"]
   keylime_agent:
     build:
@@ -35,6 +36,7 @@ services:
     user: root
     volumes:
       - ./target/debug/:/rust-keylime
+    network_mode: host
     ports:
         - "9002:9002"
     environment:

--- a/docker/fedora/keylime_py.Dockerfile
+++ b/docker/fedora/keylime_py.Dockerfile
@@ -73,11 +73,14 @@ RUN dnf install -y \
     wget \
     which
 
-WORKDIR ${KEYLIME_HOME}
-RUN git clone https://github.com/keylime/keylime.git $KEYLIME_HOME
-RUN python3 $KEYLIME_HOME/setup.py install
-RUN pip3 install -r $KEYLIME_HOME/requirements.txt
-RUN ${KEYLIME_HOME}/services/installer.sh
+WORKDIR ${HOME}
+RUN git clone https://github.com/keylime/keylime.git && \
+cd keylime && \
+sed -e 's/127.0.0.1/0.0.0.0/g' keylime.conf > tmp_keylime.conf && \
+mv tmp_keylime.conf keylime.conf && \
+python3 ${KEYLIME_HOME}/setup.py install && \
+pip3 install -r $KEYLIME_HOME/requirements.txt && \
+${KEYLIME_HOME}/services/installer.sh
 
 RUN dnf makecache && \
   dnf clean all && \

--- a/docker/fedora/keylime_py.Dockerfile
+++ b/docker/fedora/keylime_py.Dockerfile
@@ -37,6 +37,7 @@ RUN dnf install -y \
     dbus-daemon \
     dbus-devel \
     dnf-plugins-core \
+    efivar-devel \
     gcc \
     git \
     glib2-devel \

--- a/src/cmd_exec.rs
+++ b/src/cmd_exec.rs
@@ -55,7 +55,7 @@ pub(crate) fn run(
     let _ = env_vars
         .insert("TPM_SERVER_NAME".to_string(), "localhost".to_string());
     match env_vars.get_mut("PATH") {
-        Some(v) => v.push_str(common::TPM_TOOLS_PATH),
+        Some(v) => v.push_str(TPM_TOOLS_PATH),
         None => {
             return Err(Error::Configuration(
                 "PATH environment variable doesn't exist".to_string(),

--- a/src/common.rs
+++ b/src/common.rs
@@ -46,6 +46,96 @@ pub(crate) fn config_file_get() -> String {
     }
 }
 
+/// Returns revocation ip from keylime.conf if env var not present
+pub(crate) fn revocation_ip_get() -> Result<String> {
+    match env::var("REVOCATION_IP") {
+        Ok(ip) => {
+            // The variable length must be larger than 0 to accept
+            if !ip.is_empty() {
+                Ok(ip)
+            } else {
+                config_get("general", "receive_revocation_ip")
+            }
+        }
+        _ => config_get("general", "receive_revocation_ip"),
+    }
+}
+
+/// Returns revocation port from keylime.conf if env var not present
+pub(crate) fn revocation_port_get() -> Result<String> {
+    match env::var("REVOCATION_PORT") {
+        Ok(ip) => {
+            // The variable length must be larger than 0 to accept
+            if !ip.is_empty() {
+                Ok(ip)
+            } else {
+                config_get("general", "receive_revocation_port")
+            }
+        }
+        _ => config_get("general", "receive_revocation_port"),
+    }
+}
+
+/// Returns cloud agent IP from keylime.conf if env var not present
+pub(crate) fn cloudagent_ip_get() -> Result<String> {
+    match env::var("CLOUDAGENT_IP") {
+        Ok(ip) => {
+            // The variable length must be larger than 0 to accept
+            if !ip.is_empty() {
+                Ok(ip)
+            } else {
+                config_get("cloud_agent", "cloudagent_ip")
+            }
+        }
+        _ => config_get("cloud_agent", "cloudagent_ip"),
+    }
+}
+
+/// Returns cloud agent port from keylime.conf if env var not present
+pub(crate) fn cloudagent_port_get() -> Result<String> {
+    match env::var("CLOUDAGENT_PORT") {
+        Ok(ip) => {
+            // The variable length must be larger than 0 to accept
+            if !ip.is_empty() {
+                Ok(ip)
+            } else {
+                config_get("cloud_agent", "cloudagent_port")
+            }
+        }
+        _ => config_get("cloud_agent", "cloudagent_port"),
+    }
+}
+
+/// Returns registrar IP from keylime.conf if env var not present
+pub(crate) fn registrar_ip_get() -> Result<String> {
+    match env::var("REGISTRAR_IP") {
+        Ok(ip) => {
+            // The variable length must be larger than 0 to accept
+            if !ip.is_empty() {
+                Ok(ip)
+            } else {
+                config_get("registrar", "registrar_ip")
+            }
+        }
+        _ => config_get("registrar", "registrar_ip"),
+    }
+}
+
+/// Returns registrar port from keylime.conf if env var not present
+pub(crate) fn registrar_port_get() -> Result<String> {
+    match env::var("REGISTRAR_PORT") {
+        Ok(ip) => {
+            // The variable length must be larger than 0 to accept
+            if !ip.is_empty() {
+                Ok(ip)
+            } else {
+                config_get("registrar", "registrar_port")
+            }
+        }
+        _ => config_get("registrar", "registrar_port"),
+    }
+}
+
 /*
  * Input: [section] and key
  * Return: Returns the matched key

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,17 +46,17 @@ mod secure_mount;
 mod tpm;
 
 use actix_web::{web, App, HttpServer};
-use common::config_get;
+use common::*;
 use error::{Error, Result};
-use futures::future::TryFutureExt;
-use futures::try_join;
+use futures::{future::TryFutureExt, try_join};
 use log::*;
 use openssl::{hash::MessageDigest, pkey::PKey, sign::Signer};
-use std::convert::TryFrom;
-use std::fs::File;
-use std::io::BufReader;
-use std::io::Read;
-use std::path::Path;
+use std::{
+    convert::TryFrom,
+    fs::File,
+    io::{BufReader, Read},
+    path::Path,
+};
 use tss_esapi::{
     constants::algorithm::AsymmetricAlgorithm,
     interface_types::resource_handles::Hierarchy,
@@ -117,10 +117,10 @@ async fn main() -> Result<()> {
         tpm::create_ak(&mut ctx, ek_handle)?;
 
     // Gather configs
-    let cloudagent_ip = config_get("cloud_agent", "cloudagent_ip")?;
-    let cloudagent_port = config_get("cloud_agent", "cloudagent_port")?;
-    let registrar_ip = config_get("registrar", "registrar_ip")?;
-    let registrar_port = config_get("registrar", "registrar_port")?;
+    let cloudagent_ip = cloudagent_ip_get()?;
+    let cloudagent_port = cloudagent_port_get()?;
+    let registrar_ip = registrar_ip_get()?;
+    let registrar_port = registrar_port_get()?;
     let agent_uuid_config = config_get("cloud_agent", "agent_uuid")?;
     let agent_uuid = get_uuid(&agent_uuid_config);
 

--- a/src/registrar_agent.rs
+++ b/src/registrar_agent.rs
@@ -134,6 +134,9 @@ pub(crate) async fn do_register_agent(
         "http://{}:{}/agents/{}",
         registrar_ip, registrar_port, agent_uuid
     );
+
+    info!("Sending data to {}", addr);
+
     let resp = reqwest::Client::new()
         .post(&addr)
         .json(&data)

--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -62,9 +62,9 @@ fn check_mount(secure_dir: &str) -> Result<bool> {
 pub(crate) fn mount() -> Result<String> {
     // Use /tmpfs-dev directory if MOUNT_SECURE flag is not set. This
     // is for development environment and does not mount to the system.
-    if !common::MOUNT_SECURE {
+    if !MOUNT_SECURE {
         info!("Using /tmpfs-dev (dev environment)");
-        let secure_dir = format!("{}{}", common::WORK_DIR, "/tmpfs-dev");
+        let secure_dir = format!("{}{}", WORK_DIR, "/tmpfs-dev");
         let secure_dir_path = Path::new(secure_dir.as_str());
         if !secure_dir_path.exists() {
             fs::create_dir(secure_dir_path).map_err(|e| {
@@ -80,7 +80,7 @@ pub(crate) fn mount() -> Result<String> {
     }
 
     // Mount the directory to file system
-    let secure_dir = format!("{}/secure", common::WORK_DIR);
+    let secure_dir = format!("{}/secure", WORK_DIR);
     let secure_size = config_get("cloud_agent", "secure_size")?;
 
     match check_mount(&secure_dir)? {
@@ -114,11 +114,9 @@ pub(crate) fn mount() -> Result<String> {
                     info!("Mounting secure storage location {} on tmpfs.", s);
 
                     // change the secure path directory owner to root
-                    if let Err(e) =
-                        common::chownroot(s.to_string()).map(|path| {
-                            info!("Changed path {} owner to root.", path);
-                        })
-                    {
+                    if let Err(e) = chownroot(s.to_string()).map(|path| {
+                        info!("Changed path {} owner to root.", path);
+                    }) {
                         return Err(Error::SecureMount(
                                 format!(
                                     "unable to change secure path dir owner to root: received exit code {}",


### PR DESCRIPTION
In this PR:
- Update to send IPs and ports and env vars (resort to keylime.conf if vars are not present)
- Add `efivar-devel` to `keylime_py` dockerfile
- Add `network_mode: host` to `keylime_agent` in docker-compose file, update port bindings, use IP `0.0.0.0`

Fixes #167 