### PR TITLE
Fix secure mount error and add more verbose TPM error output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ thiserror = "1.0"
 zmq = "0.9.2"
 uuid = {version = "0.8", features = ["v4"]}
 wiremock = "0.5"
+
+[features]
+# this should change to dev-dependencies when we have integration testing
+testing = []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,6 @@ services:
     volumes:
       - ./target/debug/:/rust-keylime
     network_mode: host
-    ports:
-        - "9002:9002"
     environment:
     - TCTI=tabrmd:bus_type=system
     command:

--- a/src/common.rs
+++ b/src/common.rs
@@ -23,7 +23,11 @@ pub static KEY: &str = "secret";
 pub static WORK_DIR: &str = "/tmp";
 
 // Secure mount of tpmfs (False is generally used for development environments)
+#[cfg(not(feature = "testing"))]
 pub static MOUNT_SECURE: bool = true;
+
+#[cfg(feature = "testing")]
+pub static MOUNT_SECURE: bool = false;
 
 /*
  * Return: Returns the configuration file provided in the environment variable

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,8 @@ async fn main() -> Result<()> {
             &ak_tpm2b_pub,
         )
         .await?;
+        info!("SUCCESS: agent registered");
+
         let key = tpm::activate_credential(
             &mut ctx, keyblob, ak_handle, ek_handle,
         )?;
@@ -152,6 +154,7 @@ async fn main() -> Result<()> {
             &auth_tag,
         )
         .await?;
+        info!("SUCCESS: agent activated");
     }
 
     let actix_server = HttpServer::new(move || {

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -155,9 +155,13 @@ pub(crate) async fn run_revocation_service() -> Result<()> {
             }
         }
     } else {
-        error!("Path for the 0mq socket socket doesn't exist");
-        return Err(Error::Configuration(String::from(
-            "Path for the 0mq socket socket doesn't exist",
+        error!(
+            "Path {} for the 0mq socket doesn't exist",
+            revocation_cert_path
+        );
+        return Err(Error::Configuration(format!(
+            "Path {} for the 0mq socket socket doesn't exist",
+            revocation_cert_path,
         )));
     };
 

--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -63,7 +63,7 @@ pub(crate) fn mount() -> Result<String> {
     // Use /tmpfs-dev directory if MOUNT_SECURE flag is not set. This
     // is for development environment and does not mount to the system.
     if !MOUNT_SECURE {
-        info!("Using /tmpfs-dev (dev environment)");
+        warn!("Using /tmpfs-dev (dev environment)");
         let secure_dir = format!("{}{}", WORK_DIR, "/tmpfs-dev");
         let secure_dir_path = Path::new(secure_dir.as_str());
         if !secure_dir_path.exists() {


### PR DESCRIPTION
This PR:

- fixes an error in the Keylime agent saying it is unable to mount the tmpfs by adding a "testing" feature
- adds more verbose error output for revocation and TPM-related errors
- adds logging output when agent activation and registration succeed
- removes port bindings for the agent (this was causing another error)