### PR TITLE
Add Identity and Integrity Quote functionality

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -111,4 +111,6 @@ impl From<tss_esapi::Error> for Error {
     }
 }
 
+impl actix_web::ResponseError for Error {}
+
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/src/keys_handler.rs
+++ b/src/keys_handler.rs
@@ -4,6 +4,8 @@
 use actix_web::{web, HttpResponse, Responder};
 use serde::Deserialize;
 
+use crate::QuoteData;
+
 #[derive(Deserialize)]
 pub struct Verify {
     challenge: String,
@@ -15,11 +17,17 @@ pub struct UkeyJson {
     auth_tag: String,
 }
 
-pub async fn verify(param: web::Query<Verify>) -> impl Responder {
+pub async fn verify(
+    param: web::Query<Verify>,
+    data: web::Data<QuoteData>,
+) -> impl Responder {
     HttpResponse::Ok().body(format!("Challenge: {}", param.challenge))
 }
 
-pub async fn ukey(param: web::Json<UkeyJson>) -> impl Responder {
+pub async fn ukey(
+    param: web::Json<UkeyJson>,
+    data: web::Data<QuoteData>,
+) -> impl Responder {
     HttpResponse::Ok().body(format!(
         "b64_encrypted_key: {} auth_tag: {}",
         param.b64_encrypted_key, param.auth_tag

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,22 +50,35 @@ use common::*;
 use error::{Error, Result};
 use futures::{future::TryFutureExt, try_join};
 use log::*;
-use openssl::{hash::MessageDigest, pkey::PKey, sign::Signer};
+use openssl::{
+    hash::MessageDigest,
+    pkey::{PKey, Private, Public},
+    sign::Signer,
+};
 use std::{
     convert::TryFrom,
     fs::File,
     io::{BufReader, Read},
     path::Path,
+    sync::Mutex,
 };
 use tss_esapi::{
     interface_types::{
         algorithm::AsymmetricAlgorithm, resource_handles::Hierarchy,
     },
-    utils,
+    utils, Context,
 };
 use uuid::Uuid;
 
 static NOTFOUND: &[u8] = b"Not Found";
+
+// data that is passed in to the actix httpserver threads that
+// handle quotes
+#[derive(Debug)]
+pub struct QuoteData {
+    tpmcontext: Mutex<Context>,
+    keypair: (PKey<Public>, PKey<Private>),
+}
 
 fn get_uuid(agent_uuid_config: &str) -> String {
     match agent_uuid_config {
@@ -155,8 +168,17 @@ async fn main() -> Result<()> {
         info!("SUCCESS: agent activated");
     }
 
+    // generate key pair for secure transmission of u, v keys
+    let keypair = crypto::rsa_generate_pair(2048)?;
+
+    let quotedata = web::Data::new(QuoteData {
+        tpmcontext: Mutex::new(ctx),
+        keypair,
+    });
+
     let actix_server = HttpServer::new(move || {
         App::new()
+            .app_data(quotedata.clone())
             .service(
                 web::resource("/keys/verify")
                     .route(web::get().to(keys_handler::verify)),

--- a/src/registrar_agent.rs
+++ b/src/registrar_agent.rs
@@ -5,7 +5,7 @@ use reqwest::header::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Number;
 
-fn serialize_as_base64<S>(
+pub(crate) fn serialize_as_base64<S>(
     bytes: &[u8],
     serializer: S,
 ) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
This is a draft to return the identity Quote to the tenant. Outstanding todos:
- ~~Is it okay to generate the NK?~~
- ~~Is it okay to regenerate the AIK?~~
- How to get the [`TPM2B_ATTEST`](https://github.com/parallaxsecond/rust-tss-esapi/blob/main/tss-esapi-sys/src/bindings/x86_64-unknown-linux-gnu.rs#L3116) and [`Signature`](https://github.com/parallaxsecond/rust-tss-esapi/blob/main/tss-esapi/src/utils/mod.rs#L722) data types + the `NKpub` (which is an `openssl::rsa::Rsa<Public>`) into a format acceptable to [`actix_web::dev::Body`](https://docs.rs/actix-web/3.3.2/actix_web/dev/enum.Body.html)? This looks like it can be a String or bytes or maybe a `serde_json::Value`. But are these TSS ESAPI types compatible with any of those?