### PR TITLE
Rebase on tss-esapi 5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 .auditing-0
 tpmdata.json
+/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 tempfile = "3.0.4"
 tokio = {version = "0.2", features = ["full"]}
 tokio-io = "0.1"
-tss-esapi = "4.0.10-alpha.2"
+tss-esapi = "5.0"
 thiserror = "1.0"
 zmq = "0.9.2"
 uuid = {version = "0.8", features = ["v4"]}

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,12 +58,10 @@ use std::{
     path::Path,
 };
 use tss_esapi::{
-    constants::algorithm::AsymmetricAlgorithm,
-    interface_types::resource_handles::Hierarchy,
-    utils::{
-        self, AsymSchemeUnion, ObjectAttributes, Tpm2BPublicBuilder,
-        TpmsEccParmsBuilder,
+    interface_types::{
+        algorithm::AsymmetricAlgorithm, resource_handles::Hierarchy,
     },
+    utils,
 };
 use uuid::Uuid;
 


### PR DESCRIPTION
Rebase our use of tss-esapi to the 5.0 version, to ensure long time
success.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>