### PR TITLE
Use PKeys consistently

### DIFF
--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -165,7 +165,6 @@ pub(crate) async fn run_revocation_service() -> Result<()> {
             revocation_cert_path,
         )));
     };
-    let cert_key = PKey::from_rsa(cert_key)?;
 
     info!("Waiting for revocation messages on 0mq {}", endpoint);
 


### PR DESCRIPTION
Following on #181, use the openssl crate's PKey type instead of the inner
RSA type. Also, add additional key-related helper functions. (These make the future identity quote code less messy.)