### PR TITLE
Add handling for Identity and Integrity quotes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,8 @@ pub(crate) enum Error {
     Other(String),
 }
 
+impl actix_web::ResponseError for Error {}
+
 impl Error {
     pub(crate) fn http_code(&self) -> Result<u16> {
         match self {

--- a/src/quotes_handler.rs
+++ b/src/quotes_handler.rs
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2021 Keylime Authors
 
+use crate::{tpm, Error as KeylimeError, QuoteData};
+
 use actix_web::{web, HttpResponse, Responder};
+use log::*;
 use serde::{Deserialize, Serialize};
+use std::fs::read_to_string;
+
+const IMA_PATH: &str = "/sys/kernel/security/ima/ascii_runtime_measurements";
 
 #[derive(Deserialize)]
 pub struct Ident {
@@ -40,7 +46,74 @@ impl Default for KeylimeIdQuote {
     }
 }
 
-pub async fn identity(param: web::Query<Ident>) -> impl Responder {
+// The fields of this struct and their default values must
+// match what is expected by Python Keylime.
+#[derive(Serialize, Debug)]
+pub(crate) struct KeylimeIntegrityQuote {
+    pub quote: String, // 'r' + quote + sig + pcrblob
+    pub hash_alg: String,
+    pub enc_alg: String,
+    pub sign_alg: String,
+    pub pubkey: String,
+    pub ima_measurement_list: String,
+}
+
+impl KeylimeIntegrityQuote {
+    fn from_id_quote(idquote: KeylimeIdQuote, ima: String) -> Self {
+        KeylimeIntegrityQuote {
+            quote: idquote.quote,
+            hash_alg: idquote.hash_alg,
+            enc_alg: idquote.enc_alg,
+            sign_alg: idquote.sign_alg,
+            pubkey: idquote.pubkey,
+            ima_measurement_list: ima,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct JsonIdWrapper {
+    code: u32,
+    status: String,
+    results: KeylimeIdQuote,
+}
+
+// The fields of this struct and their default values must
+// match what is expected by Python Keylime.
+#[derive(Serialize)]
+struct JsonIntegWrapper {
+    code: u32,
+    status: String,
+    results: KeylimeIntegrityQuote,
+}
+
+impl JsonIdWrapper {
+    fn new(results: KeylimeIdQuote) -> Self {
+        JsonIdWrapper {
+            code: 200,
+            status: String::from("Success"),
+            results,
+        }
+    }
+}
+
+impl JsonIntegWrapper {
+    fn new(results: KeylimeIntegrityQuote) -> Self {
+        JsonIntegWrapper {
+            code: 200,
+            status: String::from("Success"),
+            results,
+        }
+    }
+}
+
+// This is a Quote request from the tenant, which does not check
+// integrity measurement. It should return this data:
+// { QuoteAIK(nonce, 16:H(NK_pub)), NK_pub }
+pub async fn identity(
+    param: web::Query<Ident>,
+    data: web::Data<QuoteData>,
+) -> impl Responder {
     // nonce can only be in alphanumerical format
     if !param.nonce.chars().all(char::is_alphanumeric) {
         HttpResponse::BadRequest()
@@ -50,17 +123,31 @@ pub async fn identity(param: web::Query<Ident>) -> impl Responder {
             ))
             .await
     } else {
-        // place holder for identity quote code
-        HttpResponse::Ok()
-            .body(format!(
-                "Calling Identity Quote with nonce: {}",
-                param.nonce
-            ))
-            .await
+        info!("Calling Identity Quote with nonce: {}", param.nonce);
+
+        let mut quote =
+            tpm::quote(param.nonce.as_bytes(), None, data.clone())?;
+        quote.pubkey = String::from_utf8(
+            data.pub_key
+                .public_key_to_pem()
+                .map_err(KeylimeError::from)?,
+        )
+        .map_err(KeylimeError::from)?;
+
+        let response = JsonIdWrapper::new(quote);
+        HttpResponse::Ok().json(response).await
     }
 }
 
-pub async fn integrity(param: web::Query<Integ>) -> impl Responder {
+// This is a Quote request from the cloud verifier, which will check
+// integrity measurement. The PCRs inclued in the Quote will be specified
+// by the mask, vmask. It should return this data:
+// { QuoteAIK(nonce, 16:H(NK_pub), xi:yi), NK_pub}
+// where xi:yi are additional PCRs to be included in the quote.
+pub async fn integrity(
+    param: web::Query<Integ>,
+    data: web::Data<QuoteData>,
+) -> impl Responder {
     // nonce, mask, vmask can only be in alphanumerical format
     if !param.nonce.chars().all(char::is_alphanumeric) {
         HttpResponse::BadRequest()
@@ -76,6 +163,7 @@ pub async fn integrity(param: web::Query<Integ>) -> impl Responder {
                 param.mask
             ))
             .await
+    // TODO: Will we ever need to use the vmask?
     } else if !param.vmask.chars().all(char::is_alphanumeric) {
         HttpResponse::BadRequest()
             .body(format!(
@@ -84,12 +172,27 @@ pub async fn integrity(param: web::Query<Integ>) -> impl Responder {
             ))
             .await
     } else {
-        // place holder for integrity quote code
-        HttpResponse::Ok()
-            .body(format!(
-                "Calling Integrity Quote with nonce: {}",
-                param.nonce
-            ))
-            .await
+        info!("Calling Integrity Quote with nonce: {}", param.nonce);
+
+        let mut quote = tpm::quote(
+            param.nonce.as_bytes(),
+            Some(&param.mask),
+            data.clone(),
+        )?;
+
+        let mut quote = KeylimeIntegrityQuote::from_id_quote(
+            quote,
+            read_to_string(IMA_PATH)?,
+        );
+
+        quote.pubkey = String::from_utf8(
+            data.pub_key
+                .public_key_to_pem()
+                .map_err(KeylimeError::from)?,
+        )
+        .map_err(KeylimeError::from)?;
+
+        let response = JsonIntegWrapper::new(quote);
+        HttpResponse::Ok().json(response).await
     }
 }


### PR DESCRIPTION
This should pass CI when rebased on #195 

Thoughts: the JsonWrapper and KeylimeQuote variations are completely based on the Python interface, so they could possibly go in their own interface module. On the other hand, there isn't much code here so it may not be necessary to separate it that way. Opinions welcome.

Also: will we ever need to use the vmask? From what I understand, it is only necessary when tying a vtpm value to a hardware tpm value, which isn't used anymore in the Python codebase? But I could be wrong here.