### PR TITLE
Do not fail if EK cert is not present in TPM NV

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,7 @@ async fn main() -> Result<()> {
             &registrar_port,
             &agent_uuid,
             &ek_tpm2b_pub,
-            &ek_cert,
+            ek_cert,
             &ak_tpm2b_pub,
         )
         .await?;


### PR DESCRIPTION
According to the spec (4.5.2), it is not mandatory that an EK
certificate is pre-provisioned in NVRAM; actually some TPM chips do
not have it, e.g., AMD fTPM, and the Python registrar tolerates
"ekcert: null".

Signed-off-by: Daiki Ueno <dueno@redhat.com>