### PR TITLE
Do not resend pubkey to CV after attestation

### DIFF
--- a/src/quotes_handler.rs
+++ b/src/quotes_handler.rs
@@ -3,7 +3,7 @@
 
 use crate::{tpm, Error as KeylimeError, QuoteData};
 
-use crate::common::IMA_ML;
+use crate::common::{IMA_ML, KEY_LEN};
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use log::*;
 use serde::{Deserialize, Serialize};
@@ -45,9 +45,12 @@ impl Default for KeylimeIdQuote {
 }
 
 // The fields of this struct and their default values must
-// match what is expected by Python Keylime.
+// match what is expected by Python Keylime. Because the Python
+// verifier resends the vkey based on whether there is a pubkey
+// field included in the returned data, we must use a struct
+// without this field after attestation is complete.
 #[derive(Serialize, Debug)]
-pub(crate) struct KeylimeIntegrityQuote {
+pub(crate) struct KeylimeIntegrityQuotePreAttestation {
     pub quote: String, // 'r' + quote + sig + pcrblob
     pub hash_alg: String,
     pub enc_alg: String,
@@ -56,14 +59,39 @@ pub(crate) struct KeylimeIntegrityQuote {
     pub ima_measurement_list: String,
 }
 
-impl KeylimeIntegrityQuote {
-    fn from_id_quote(idquote: KeylimeIdQuote, ima: String) -> Self {
-        KeylimeIntegrityQuote {
+impl KeylimeIntegrityQuotePreAttestation {
+    fn from_id_quote(
+        idquote: KeylimeIdQuote,
+        ima: String,
+        pubkey: String,
+    ) -> Self {
+        KeylimeIntegrityQuotePreAttestation {
             quote: idquote.quote,
             hash_alg: idquote.hash_alg,
             enc_alg: idquote.enc_alg,
             sign_alg: idquote.sign_alg,
-            pubkey: idquote.pubkey,
+            pubkey,
+            ima_measurement_list: ima,
+        }
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub(crate) struct KeylimeIntegrityQuotePostAttestation {
+    pub quote: String, // 'r' + quote + sig + pcrblob
+    pub hash_alg: String,
+    pub enc_alg: String,
+    pub sign_alg: String,
+    pub ima_measurement_list: String,
+}
+
+impl KeylimeIntegrityQuotePostAttestation {
+    fn from_id_quote(idquote: KeylimeIdQuote, ima: String) -> Self {
+        KeylimeIntegrityQuotePostAttestation {
+            quote: idquote.quote,
+            hash_alg: idquote.hash_alg,
+            enc_alg: idquote.enc_alg,
+            sign_alg: idquote.sign_alg,
             ima_measurement_list: ima,
         }
     }
@@ -79,10 +107,17 @@ struct JsonIdWrapper {
 // The fields of this struct and their default values must
 // match what is expected by Python Keylime.
 #[derive(Serialize)]
-struct JsonIntegWrapper {
+struct JsonIntegWrapperPreAttestation {
     code: u32,
     status: String,
-    results: KeylimeIntegrityQuote,
+    results: KeylimeIntegrityQuotePreAttestation,
+}
+
+#[derive(Serialize)]
+struct JsonIntegWrapperPostAttestation {
+    code: u32,
+    status: String,
+    results: KeylimeIntegrityQuotePostAttestation,
 }
 
 impl JsonIdWrapper {
@@ -95,9 +130,19 @@ impl JsonIdWrapper {
     }
 }
 
-impl JsonIntegWrapper {
-    fn new(results: KeylimeIntegrityQuote) -> Self {
-        JsonIntegWrapper {
+impl JsonIntegWrapperPreAttestation {
+    fn new(results: KeylimeIntegrityQuotePreAttestation) -> Self {
+        JsonIntegWrapperPreAttestation {
+            code: 200,
+            status: String::from("Success"),
+            results,
+        }
+    }
+}
+
+impl JsonIntegWrapperPostAttestation {
+    fn new(results: KeylimeIntegrityQuotePostAttestation) -> Self {
+        JsonIntegWrapperPostAttestation {
             code: 200,
             status: String::from("Success"),
             results,
@@ -183,20 +228,34 @@ pub async fn integrity(
             data.clone(),
         )?;
 
-        let mut quote = KeylimeIntegrityQuote::from_id_quote(
-            quote,
-            read_to_string(IMA_ML)?,
-        );
-
-        quote.pubkey = String::from_utf8(
-            data.pub_key
-                .public_key_to_pem()
+        // pubkey should only be sent for the first quote request; otherwise
+        // the verifier will keep sending a v key every time. we check whether
+        // it's the first quote request by seeing if the symmetric key has been
+        // derived (which happens after both u and v key are received once).
+        let symm_key = data.payload_symm_key.lock().unwrap(); //#[allow_ci]
+        if *symm_key == [0u8; KEY_LEN] {
+            let quote = KeylimeIntegrityQuotePreAttestation::from_id_quote(
+                quote,
+                read_to_string(IMA_ML)?,
+                String::from_utf8(
+                    data.pub_key
+                        .public_key_to_pem()
+                        .map_err(KeylimeError::from)?,
+                )
                 .map_err(KeylimeError::from)?,
-        )
-        .map_err(KeylimeError::from)?;
+            );
+            let response = JsonIntegWrapperPreAttestation::new(quote);
+            info!("GET integrity quote returning 200 response");
+            HttpResponse::Ok().json(response).await
+        } else {
+            let quote = KeylimeIntegrityQuotePostAttestation::from_id_quote(
+                quote,
+                read_to_string(IMA_ML)?,
+            );
 
-        let response = JsonIntegWrapper::new(quote);
-        info!("GET integrity quote returning 200 response");
-        HttpResponse::Ok().json(response).await
+            let response = JsonIntegWrapperPostAttestation::new(quote);
+            info!("GET integrity quote returning 200 response");
+            HttpResponse::Ok().json(response).await
+        }
     }
 }


### PR DESCRIPTION
This keeps the CV from resending the V key each time it polls for
an integrity quote.

Fixes #211 