### PR TITLE
Fix for race condition bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 tempfile = "3.0.4"
 tokio = {version = "0.2", features = ["full"]}
 tokio-io = "0.1"
-tss-esapi = "5.0"
+#tss-esapi = "5.0"
+tss-esapi = { git = "https://github.com/puiterwijk/rust-tss-esapi.git", branch = "keylime" }
 thiserror = "1.0"
 zmq = "0.9.2"
 uuid = {version = "0.8", features = ["v4"]}

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub(crate) enum Error {
     InvalidRequest,
     #[error("Configuration loading error: {0}")]
     Ini(#[from] ini::ini::Error),
+    #[error("Infallible: {0}")]
+    Infallible(#[from] std::convert::Infallible),
     #[error("Compress tools error: {0}")]
     CompressTools(#[from] compress_tools::Error),
     #[error("Configuration error: {0}")]


### PR DESCRIPTION
This change adds a check to make sure digests returned in the Quote match the PCR values retrieved from `pcr_read`. There can be a mismatch here due to a race condition inherent to TPM2.0. See section `17.6.2` in TCG's [TPM spec](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part1_Architecture_pub.pdf) for more on this race condition.

There were also some ESAPI bugs related to the ordering of data in `PcrSelectionList` and `PcrData`, affecting our results. Therefore the code is temporarily pinned to a branch of the ESAPI until @puiterwijk 's ESAPI [bug fixes](https://github.com/parallaxsecond/rust-tss-esapi/pull/236) are merged.

Fixes #210 