### PR TITLE
Accept sets of U and V keys; use new Key types

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -38,6 +38,54 @@ pub const AUTH_TAG_LEN: usize = 96;
 pub const KEY_LEN: usize = 32;
 pub const AES_BLOCK_SIZE: usize = 16;
 
+// symmetric keys as bytes
+pub type KeyBytes = [u8; KEY_LEN];
+
+// a vector holding keys
+#[derive(Debug, Clone)]
+pub struct KeySet {
+    pub set: Vec<SymmKey>,
+}
+
+impl Default for KeySet {
+    fn default() -> Self {
+        let set = Vec::new();
+        KeySet { set }
+    }
+}
+
+impl KeySet {
+    pub fn all_empty(&self) -> bool {
+        self.set.iter().all(|&key| key.is_empty())
+    }
+}
+
+// a key of len KEY_LEN
+#[derive(Debug, Clone, Copy)]
+pub struct SymmKey {
+    pub bytes: KeyBytes,
+}
+
+impl Default for SymmKey {
+    fn default() -> Self {
+        SymmKey {
+            bytes: [0u8; KEY_LEN],
+        }
+    }
+}
+
+impl SymmKey {
+    pub fn is_empty(&self) -> bool {
+        self.bytes == [0u8; KEY_LEN]
+    }
+
+    pub fn from_vec(v: Vec<u8>) -> Self {
+        let mut b = [0u8; KEY_LEN];
+        b.copy_from_slice(&v[..]);
+        SymmKey { bytes: b }
+    }
+}
+
 /*
  * Return: Returns the configuration file provided in the environment variable
  * KEYLIME_CONFIG or defaults to /etc/keylime.conf

--- a/src/quotes_handler.rs
+++ b/src/quotes_handler.rs
@@ -236,7 +236,7 @@ pub async fn integrity(
         // it's the first quote request by seeing if the symmetric key has been
         // derived (which happens after both u and v key are received once).
         let symm_key = data.payload_symm_key.lock().unwrap(); //#[allow_ci]
-        if *symm_key == [0u8; KEY_LEN] {
+        if symm_key.is_empty() {
             let quote = KeylimeIntegrityQuotePreAttestation::from_id_quote(
                 quote,
                 read_to_string(IMA_ML)?,


### PR DESCRIPTION
The key types seem like a good idea, especially if we start using vectors of U and V keys, which become cumbersome to read everywhere. I'm not completely convinced about making the U and V keys into sets as it adds a bit of complexity and seems like not the best way to mitigate attacks, but this would at least get the Rust agent to do what the Python agent is doing. Fixes #209 fixes #237 