### PR TITLE
libarchive-devel is needed to build on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ The rust-keylime agent requires the following packages for both compile and run 
 
 For Fedora, use the following command
 ```
-$ dnf install openssl-devel gcc tpm2-tss-devel zeromq-devel
+$ dnf install openssl-devel gcc tpm2-tss-devel zeromq-devel libarchive-devel
 ```
 
 For Ubuntu OS, use the following command
 ```
-$ apt-get install openssl-dev gcc libtss-dev libzmq3-dev
+$ apt-get install openssl-dev gcc libtss-dev libzmq3-dev libarchive-dev
 ```
 
 ### Rust


### PR DESCRIPTION
Rust complains that it can't find libarchive but what it really needs
are the header files.