### PR TITLE
Add "v1.0" prefix to agent APIs

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -9,6 +9,7 @@ use std::env;
 /*
  * Constants and static variables
  */
+pub const API_VERSION: &str = "v1.0";
 pub const STUB_VTPM: bool = false;
 pub const STUB_IMA: bool = true;
 pub const TPM_DATA_PCR: usize = 16;

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,7 +273,7 @@ async fn main() -> Result<()> {
         warn!("INSECURE: Only use Keylime in this mode for testing or debugging purposes.");
     }
 
-    info!("Starting server...");
+    info!("Starting server with API version {}...", API_VERSION);
 
     // Gather EK and AK key values and certs
     let (ek_handle, ek_cert, ek_tpm2b_pub) =
@@ -359,20 +359,20 @@ async fn main() -> Result<()> {
         App::new()
             .app_data(quotedata.clone())
             .service(
-                web::resource("/keys/ukey")
+                web::resource(format!("/{}/keys/ukey", API_VERSION))
                     .route(web::post().to(keys_handler::u_or_v_key)),
             )
             .service(
                 // the double slash may be a typo on the python side
-                web::resource("//keys/vkey")
+                web::resource(format!("/{}/keys/vkey", API_VERSION))
                     .route(web::post().to(keys_handler::u_or_v_key)),
             )
             .service(
-                web::resource("/quotes/identity")
+                web::resource(format!("/{}/quotes/identity", API_VERSION))
                     .route(web::get().to(quotes_handler::identity)),
             )
             .service(
-                web::resource("/quotes/integrity")
+                web::resource(format!("/{}/quotes/integrity", API_VERSION))
                     .route(web::get().to(quotes_handler::integrity)),
             )
     })

--- a/src/registrar_agent.rs
+++ b/src/registrar_agent.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 
+use crate::common::API_VERSION;
 use log::*;
 use reqwest::header::*;
 use serde::{Deserialize, Serialize};
@@ -103,8 +104,8 @@ pub(crate) async fn do_activate_agent(
 
     #[cfg(not(test))]
     let addr = format!(
-        "http://{}:{}/agents/{}",
-        registrar_ip, registrar_port, agent_uuid
+        "http://{}:{}/{}/agents/{}",
+        registrar_ip, registrar_port, API_VERSION, agent_uuid
     );
 
     info!(
@@ -146,8 +147,8 @@ pub(crate) async fn do_register_agent(
 
     #[cfg(not(test))]
     let addr = format!(
-        "http://{}:{}/agents/{}",
-        registrar_ip, registrar_port, agent_uuid
+        "http://{}:{}/{}/agents/{}",
+        registrar_ip, registrar_port, API_VERSION, agent_uuid
     );
 
     info!(


### PR DESCRIPTION
This is in preparation for the versioned-apis feature to land in keylime main.