### PR TITLE
keys_handler: verify HMAC in constant-time

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,8 @@ pub(crate) enum Error {
     Base64(#[from] base64::DecodeError),
     #[error("parse bool error: {0}")]
     ParseBool(#[from] std::str::ParseBoolError),
+    #[error("from hex error: {0}")]
+    FromHex(#[from] hex::FromHexError),
     #[error("{0}")]
     Other(String),
 }


### PR DESCRIPTION
It is generally recommended that HMAC verification should be done
using a constant-time primitive so it does not involve timing side
channel.  This uses openssl::memcmp as suggested in the crate
documentation:
https://docs.rs/openssl/0.10.36/openssl/sign/index.html#examples

Signed-off-by: Daiki Ueno <dueno@redhat.com>