### PR TITLE
cmd_exec: Fix PATH envvar construction

### DIFF
--- a/src/cmd_exec.rs
+++ b/src/cmd_exec.rs
@@ -55,7 +55,12 @@ pub(crate) fn run(
     let _ = env_vars
         .insert("TPM_SERVER_NAME".to_string(), "localhost".to_string());
     match env_vars.get_mut("PATH") {
-        Some(v) => v.push_str(TPM_TOOLS_PATH),
+        Some(v) => {
+            if !v.is_empty() {
+                v.push(':');
+            }
+            v.push_str(TPM_TOOLS_PATH);
+        }
         None => {
             return Err(Error::Configuration(
                 "PATH environment variable doesn't exist".to_string(),

--- a/src/common.rs
+++ b/src/common.rs
@@ -27,7 +27,7 @@ pub static WORK_DIR: &str = "/tmp";
 // information, check the README: https://github.com/keylime/keylime/#using-keylime-ca
 pub static REV_CERT: &str = "RevocationNotifier-cert.crt";
 
-// Secure mount of tpmfs (False is generally used for development environments)
+// Secure mount of tmpfs (False is generally used for development environments)
 #[cfg(not(feature = "testing"))]
 pub static MOUNT_SECURE: bool = true;
 

--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -40,7 +40,7 @@ fn check_mount(secure_dir: &str) -> Result<bool> {
                 return Err(Error::SecureMount(msg));
             } else {
                 info!(
-                    "Using existing secure storage tmpsfs mount {}",
+                    "Using existing secure storage tmpfs mount {}",
                     secure_dir
                 );
             }


### PR DESCRIPTION
When PATH is non-empty, TPM_TOOLS_PATH ("/usr/local/bin/") was
appended without a path separator, resulting in a corrupted PATH
value: "$PATH/usr/local/bin/".

Signed-off-by: Daiki Ueno <dueno@redhat.com>