### PR TITLE
quotes_handler: send the TPM2 UEFI eventlog if PCR0 is in mask

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -10,7 +10,7 @@ use std::convert::TryFrom;
 use std::env;
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use tss_esapi::utils::TpmsContext;
+use tss_esapi::{structures::PcrSlot, utils::TpmsContext};
 
 /*
  * Constants and static variables
@@ -25,6 +25,8 @@ pub static RSA_PUBLICKEY_EXPORTABLE: &str = "rsa placeholder";
 pub static TPM_TOOLS_PATH: &str = "/usr/local/bin/";
 pub static IMA_ML: &str =
     "/sys/kernel/security/ima/ascii_runtime_measurements";
+pub static MEASUREDBOOT_ML: &str =
+    "/sys/kernel/security/tpm0/binary_bios_measurements";
 pub static KEY: &str = "secret";
 pub static WORK_DIR: &str = "/var/lib/keylime";
 pub static TPM_DATA: &str = "tpmdata.json";
@@ -315,6 +317,10 @@ cfg_if::cfg_if! {
 
 pub(crate) fn tpm_data_path_get() -> PathBuf {
     Path::new(WORK_DIR).join(TPM_DATA)
+}
+
+pub(crate) fn measuredboot_ml_path_get() -> PathBuf {
+    Path::new(MEASUREDBOOT_ML).to_path_buf()
 }
 
 // Unit Testing

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ mod quotes_handler;
 mod registrar_agent;
 mod revocation;
 mod secure_mount;
+mod serialization;
 mod tpm;
 
 use actix_web::{web, App, HttpServer};

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
+use serde::{Deserialize, Serialize};
+use serde_json::Number;
+
+#[derive(Debug, Deserialize)]
+struct WrappedBase64Encoded(
+    #[serde(deserialize_with = "deserialize_as_base64")] Vec<u8>,
+);
+
+pub(crate) fn serialize_as_base64<S>(
+    bytes: &[u8],
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&base64::encode(bytes))
+}
+
+pub(crate) fn deserialize_as_base64<'de, D>(
+    deserializer: D,
+) -> Result<Vec<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    String::deserialize(deserializer).and_then(|string| {
+        base64::decode(&string).map_err(serde::de::Error::custom)
+    })
+}
+
+pub(crate) fn serialize_maybe_base64<S>(
+    value: &Option<Vec<u8>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match *value {
+        Some(ref value) => serializer.serialize_str(&base64::encode(value)),
+        None => serializer.serialize_none(),
+    }
+}
+
+pub(crate) fn deserialize_maybe_base64<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<u8>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<WrappedBase64Encoded>::deserialize(deserializer)
+        .map(|wrapped| wrapped.map(|wrapped| wrapped.0))
+}

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -423,6 +423,12 @@ pub(crate) fn read_mask(mask: &str) -> Result<Vec<PcrSlot>> {
     Ok(pcrs)
 }
 
+//This checks if a PCR is contained in a mask
+pub(crate) fn check_mask(mask: &str, pcr: &PcrSlot) -> Result<bool> {
+    let selected_pcrs = read_mask(mask)?;
+    Ok(selected_pcrs.contains(pcr))
+}
+
 // This encodes a quote string as input to Python Keylime's quote checking functionality.
 // The quote, signature, and pcr blob are concatenated with ':' separators. To match the
 // expected format, the quote, signature, and pcr blob must be individually compressed


### PR DESCRIPTION
The agent now also sends the UEFI eventlog for measured boot attestation.

I've also moved our serialization functions to a new module because it can be shared between quotes handler and the registration process.