### PR TITLE
move global configuration into one single struct

### DIFF
--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -4,7 +4,6 @@
 use super::*;
 
 use crate::error::{Error, Result};
-use common::config_get;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
@@ -58,7 +57,7 @@ fn check_mount(secure_dir: &str) -> Result<bool> {
  * implementation as the original python version, but the chown/geteuid
  * functions are unsafe function in Rust to use.
  */
-pub(crate) fn mount() -> Result<String> {
+pub(crate) fn mount(secure_size: &str) -> Result<String> {
     // Use /tmpfs-dev directory if MOUNT_SECURE flag is not set. This
     // is for development environment and does not mount to the system.
     if !MOUNT_SECURE {
@@ -80,7 +79,6 @@ pub(crate) fn mount() -> Result<String> {
 
     // Mount the directory to file system
     let secure_dir = format!("{}/secure", WORK_DIR);
-    let secure_size = config_get("cloud_agent", "secure_size")?;
 
     match check_mount(&secure_dir)? {
         false => {


### PR DESCRIPTION
This moves the entire used configuration into a struct called `KeylimeConfig` and makes the all the `config_get` functions private.

The goal of this change is to load the configuration only once during startup and to keep most of the functions behaviour independent from global state. I don't think that partial config reload during execution makes sense, because in most cases a change would require a complete restart of the agent (generating new AK with different algorithm for example).

The config struct is currently passed by reference where possible. It might be required to use an Arc instead if we allow it to be shared between threads.

We should discuss before this gets merged, when functions take the config struct and when they are just taking single arguments for values that are in the config struct. My rough idea is the following:
 
- If it is an abstraction of an TPM interaction: use tss specific types where possible and let the caller do the conversion
- If it is in the main module: you can pass the config struct if it uses more than one value
- If it is not in the main module: pass only the data required as arguments not the complete struct  (the current `revocation` module would violate this rule)

Related #233, #220, #164