### PR TITLE
Use revocation certificate according to configuration

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -141,6 +141,7 @@ pub(crate) struct KeylimeConfig {
     pub sign_alg: SignAlgorithm,
     pub tpm_data: Option<TpmData>,
     pub run_revocation: bool,
+    pub revocation_cert: String,
     pub revocation_ip: String,
     pub revocation_port: String,
     pub secure_size: String,
@@ -190,6 +191,7 @@ impl KeylimeConfig {
         let run_revocation = bool::from_str(
             &config_get("cloud_agent", "listen_notfications")?.to_lowercase(),
         )?;
+        let revocation_cert = config_get("cloud_agent", "revocation_cert")?;
         let revocation_ip = config_get("general", "receive_revocation_ip")?;
         let revocation_port =
             config_get("general", "receive_revocation_port")?;
@@ -215,6 +217,7 @@ impl KeylimeConfig {
             sign_alg,
             tpm_data,
             run_revocation,
+            revocation_cert,
             revocation_ip,
             revocation_port,
             secure_size,
@@ -243,6 +246,7 @@ impl Default for KeylimeConfig {
             sign_alg: SignAlgorithm::RsaSsa,
             tpm_data: None,
             run_revocation: true,
+            revocation_cert: "default".to_string(),
             revocation_ip: "127.0.0.1".to_string(),
             revocation_port: "8992".to_string(),
             secure_size: "1m".to_string(),


### PR DESCRIPTION
The certificate to be used can be set through the ``revocation_cert`` entry in ``cloud_agent`` section of the configuration file.

Following the python agent behavior:

- If the ``revocation_cert`` is set as ``default``, use the default certificate path
- If the ``revocation_cert`` is an absolute path, use the provided path to obtain the certificate
- If the ``revocation_cert`` is a relative path, expand the path from the ``WORK_DIR``
- If the ``revocation_cert`` is empty, return an error

Fixes: #300 