### PR TITLE
Use Path and PathBuf consistently to represent paths

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -12,6 +12,7 @@ use openssl::{
     x509::X509,
 };
 use std::fs;
+use std::path::Path;
 use std::string::String;
 
 use crate::{
@@ -20,8 +21,8 @@ use crate::{
 
 // Reads an X509 cert chain (provided by the tenant with the --cert command) and outputs
 // its public key.
-pub(crate) fn import_x509(input_key_path: String) -> Result<PKey<Public>> {
-    let contents = fs::read_to_string(&input_key_path[..])?;
+pub(crate) fn import_x509(input_key_path: &Path) -> Result<PKey<Public>> {
+    let contents = fs::read_to_string(input_key_path)?;
     let mut cert_chain = X509::stack_from_pem(contents.as_bytes())?;
 
     if cert_chain.len() != 1 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,6 +67,8 @@ pub(crate) enum Error {
     Algorithm(#[from] algorithms::AlgorithmError),
     #[error("Error converting number: {0}")]
     TryFromInt(#[from] std::num::TryFromIntError),
+    #[error("C string is not NUL-terminated: {0}")]
+    Nul(#[from] std::ffi::NulError),
     #[error("{0}")]
     Other(String),
 }


### PR DESCRIPTION
We previously used different types (&str, String, etc) to represent
filesystem paths and converted between them and Path back and forth.

This standardizes those to use Path and PathBuf consistently.

Signed-off-by: Daiki Ueno <dueno@redhat.com>