### PR TITLE
Bump versions of some dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "actix-service",
  "actix-threadpool",
  "actix-utils",
- "base64 0.13.0",
+ "base64",
  "bitflags",
  "brotli2",
  "bytes 0.5.6",
@@ -366,7 +366,7 @@ dependencies = [
  "actix-http",
  "actix-rt 1.1.1",
  "actix-service",
- "base64 0.13.0",
+ "base64",
  "bytes 0.5.6",
  "cfg-if 1.0.0",
  "derive_more",
@@ -385,12 +385,6 @@ name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
-name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -508,9 +502,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compress-tools"
-version = "0.11.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c7af15fac888edf71f08e0718f722099d4a21d3b9e2e6cf6b95edc1d6575be"
+checksum = "5a315608976a6f38f7dfa5cdd0b22f0fd059675a2963b1fe2dbce8bdd6b153f6"
 dependencies = [
  "derive_more",
  "libc",
@@ -991,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f072413d126e57991455e0a922b31e4c8ba7c2ffbebf6b78b4f8521397d65cd"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -1110,7 +1104,7 @@ checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
 dependencies = [
  "anyhow",
  "async-channel",
- "base64 0.13.0",
+ "base64",
  "futures-lite",
  "http",
  "infer",
@@ -1184,7 +1178,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.9",
+ "h2 0.3.11",
  "http",
  "http-body 0.4.4",
  "httparse",
@@ -1311,7 +1305,7 @@ version = "0.1.0"
 dependencies = [
  "actix-rt 2.5.0",
  "actix-web",
- "base64 0.12.3",
+ "base64",
  "cfg-if 1.0.0",
  "compress-tools",
  "flate2",
@@ -1327,7 +1321,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "static_assertions 0.2.5",
+ "static_assertions",
  "tempfile",
  "thiserror",
  "tokio 0.2.25",
@@ -1360,7 +1354,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "ryu",
- "static_assertions 1.1.0",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2003,7 +1997,7 @@ version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
@@ -2272,12 +2266,6 @@ checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
  "version_check",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ doc = false
 
 [dependencies]
 actix-web = "3"
-base64 = "0.12"
+base64 = "0.13"
 cfg-if = "1"
-compress-tools = "0.11.2"
+compress-tools = "0.12"
 flate2 = "1.0.4"
 futures = "0.3.6"
 hex = "0.4"
@@ -35,7 +35,7 @@ rustc-serialize = "0.3.24"
 serde = "1.0.80"
 serde_derive = "1.0.80"
 serde_json = { version = "1.0", features = ["raw_value"] }
-static_assertions = "0.2.3"
+static_assertions = "1"
 tempfile = "3.0.4"
 tokio = {version = "0.2", features = ["full"]}
 tokio-io = "0.1"

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -155,8 +155,8 @@ create_marshal_fn!(
 create_marshal_fn!(tpms_att_to_vec, TPMS_ATTEST, Tss2_MU_TPMS_ATTEST_Marshal);
 
 // Ensure that TPML_PCR_SELECTION and TPML_DIGEST have known sizes
-assert_eq_size!(TPML_PCR_SELECTION; TPML_PCR_SELECTION, [u8; 132]);
-assert_eq_size!(TPML_DIGEST; TPML_DIGEST, [u8; 532]);
+assert_eq_size!(TPML_PCR_SELECTION, [u8; 132]);
+assert_eq_size!(TPML_DIGEST, [u8; 532]);
 
 // Recreate how tpm2-tools creates the PCR out file. Roughly, this is a
 // TPML_PCR_SELECTION + number of TPML_DIGESTS + TPML_DIGESTs.


### PR DESCRIPTION
This updates the version requirements for the following crates, to
catch up with the set of packaged dependencies in Fedora:

- base64: 0.12 → 0.13
- compress-tools: 0.11.2 → 0.12
- static_assertions: 0.2.3 → 1

Signed-off-by: Daiki Ueno <dueno@redhat.com>