### PR TITLE
Bump tss-esapi crate to 7.0.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,18 +695,18 @@ dependencies = [
 
 [[package]]
 name = "enumflags2"
-version = "0.6.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8d82922337cd23a15f88b70d8e4ef5f11da38dd7cdb55e84dd5de99695da0"
+checksum = "a25c90b056b3f84111cf183cbeddef0d3a0bbe9a674f057e1a1533c315f24def"
 dependencies = [
  "enumflags2_derive",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.6.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
+checksum = "144ec79496cbab6f84fa125dc67be9264aef22eb8a28da8454d9c33f15108da4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1410,12 +1410,12 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "mbox"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3ae5479d6f010bca840f945a5ca2f3c343a74cccc98fcd13d62e176cf22361"
+checksum = "0f88d5c34d63aad11aa4321ef55ccb064af58b3ad8091079ae22bf83e5eb75d6"
 dependencies = [
  "libc",
- "rustc_version 0.2.3",
+ "rustc_version 0.3.3",
  "stable_deref_trait",
 ]
 
@@ -1718,6 +1718,15 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "pin-project"
@@ -2064,6 +2073,15 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
@@ -2122,7 +2140,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -2136,6 +2163,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -2647,8 +2683,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tss-esapi"
-version = "7.0.0-alpha.1"
-source = "git+https://github.com/parallaxsecond/rust-tss-esapi.git#a6ae84793e73b10dd672b613ada820566c84fe85"
+version = "7.0.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c207ea1313496a86048b20cf145b2da8f5b833fd6f6a30bd6db55a46665bac"
 dependencies = [
  "bitfield",
  "enumflags2",
@@ -2666,8 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi-sys"
-version = "0.2.0"
-source = "git+https://github.com/parallaxsecond/rust-tss-esapi.git#a6ae84793e73b10dd672b613ada820566c84fe85"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e2f37914ec4d494d145cfa18bb8429498b238d63c47a08b89d09c1ec2545ff0"
 dependencies = [
  "pkg-config",
  "target-lexicon",
@@ -2678,6 +2716,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ static_assertions = "1"
 tempfile = "3.0.4"
 tokio = {version = "0.2", features = ["full"]}
 tokio-io = "0.1"
-tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi.git" }
+tss-esapi = "7.0.0-beta.1"
 thiserror = "1.0"
 zmq = "0.9.2"
 uuid = {version = "0.8", features = ["v4"]}

--- a/src/ima_emulator.rs
+++ b/src/ima_emulator.rs
@@ -127,7 +127,7 @@ fn main() -> std::result::Result<(), ImaEmulatorError> {
     // check if pcr is clean
     let pcr_list = PcrSelectionListBuilder::new()
         .with_selection(HashingAlgorithm::Sha1, &[PcrSlot::Slot10])
-        .build();
+        .build()?;
     let pcr_data = context
         .execute_without_session(|ctx| pcr::read_all(ctx, pcr_list))?;
     let digest = pcr_data

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -44,7 +44,7 @@ use tss_esapi::{
     },
     structures::{
         Attest, AttestInfo, Digest, DigestValues, EncryptedSecret,
-        HashScheme, IDObject, Name, PcrSelectionList,
+        HashScheme, IdObject, Name, PcrSelectionList,
         PcrSelectionListBuilder, PcrSlot, Signature, SignatureScheme,
     },
     tcti_ldr::TctiNameConf,
@@ -101,7 +101,7 @@ pub(crate) fn create_ek(
         }
     };
     let (tpm_pub, _, _) = context.read_public(handle)?;
-    let tpm_pub_vec = pub_to_vec(tpm_pub.into());
+    let tpm_pub_vec = pub_to_vec(tpm_pub.try_into()?);
 
     Ok((handle, cert, tpm_pub_vec))
 }
@@ -228,7 +228,7 @@ pub(crate) fn create_ak(
     let ak =
         ak::create_ak(ctx, handle, hash_alg, sign_alg, None, DefaultKey)?;
     let ak_tpm2b_pub = ak.out_public.clone();
-    let tpm2_pub_vec = pub_to_vec(ak_tpm2b_pub.into());
+    let tpm2_pub_vec = pub_to_vec(ak_tpm2b_pub.try_into()?);
     let ak_handle =
         ak::load_ak(ctx, handle, None, ak.out_private, ak.out_public)?;
     let (_, name, _) = ctx.read_public(ak_handle)?;
@@ -250,7 +250,7 @@ pub(crate) fn load_ak(
     let ak_handle: KeyHandle = ctx.context_load(ak)?.into();
 
     let (ak_public, ak_name, _) = ctx.read_public(ak_handle)?;
-    let ak_pub_vec = pub_to_vec(ak_public.into());
+    let ak_pub_vec = pub_to_vec(ak_public.try_into()?);
     Ok((ak_handle, ak_name, ak_pub_vec))
 }
 
@@ -258,7 +258,7 @@ const TSS_MAGIC: u32 = 3135029470;
 
 fn parse_cred_and_secret(
     keyblob: Vec<u8>,
-) -> Result<(IDObject, EncryptedSecret)> {
+) -> Result<(IdObject, EncryptedSecret)> {
     let magic = u32::from_be_bytes(keyblob[0..4].try_into().unwrap()); //#[allow_ci]
     let version = u32::from_be_bytes(keyblob[4..8].try_into().unwrap()); //#[allow_ci]
 
@@ -282,7 +282,7 @@ fn parse_cred_and_secret(
     let credential = &keyblob[10..(10 + credsize as usize)];
     let secret = &keyblob[(12 + credsize as usize)..];
 
-    let credential = IDObject::try_from(credential)?;
+    let credential = IdObject::try_from(credential)?;
     let secret = EncryptedSecret::try_from(secret)?;
 
     Ok((credential, secret))
@@ -516,7 +516,7 @@ pub(crate) fn build_pcr_list(
 
     let mut pcrlist = PcrSelectionListBuilder::new();
     pcrlist = pcrlist.with_selection(hash_alg, &pcrs);
-    let pcrlist = pcrlist.build();
+    let pcrlist = pcrlist.build()?;
 
     Ok(pcrlist)
 }
@@ -604,7 +604,7 @@ fn perform_quote_and_pcr_read(
     sign_scheme: SignatureScheme,
     hash_alg: HashingAlgorithm,
 ) -> Result<(Attest, Signature, PcrSelectionList, PcrData)> {
-    let nonce = nonce.try_into()?;
+    let nonce: tss_esapi::structures::Data = nonce.try_into()?;
 
     for attempt in 0..NUM_ATTESTATION_ATTEMPTS {
         // TSS ESAPI quote does not create pcr blob, so create it separately
@@ -613,7 +613,7 @@ fn perform_quote_and_pcr_read(
         // create quote
         let (attestation, sig) = context.quote(
             ak_handle,
-            &nonce,
+            nonce.clone(),
             sign_scheme,
             pcrs_read.clone(),
         )?;
@@ -827,7 +827,7 @@ pub mod testing {
         hasher.update(att.value())?;
         let digest = hasher.finish()?;
         let digest: Digest = digest.as_ref().try_into().unwrap(); //#[allow_ci]
-        match context.verify_signature(ak_handle, &digest, sig) {
+        match context.verify_signature(ak_handle, digest, sig) {
             Ok(ticket) if ticket.tag() == StructureTag::Verified => {}
             _ => {
                 return Err(KeylimeError::Other(


### PR DESCRIPTION
The stable release is expected soon, but let's bump first to the beta
to catch any errors.

Signed-off-by: Daiki Ueno <dueno@redhat.com>