### PR TITLE
Set working directory via KEYLIME_DIR env variable

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -28,16 +28,20 @@ registrar_port = 8890
 # The name of the RSA key that Keylime should use for protecting shares of U/V.
 rsa_keyname = tci_rsa_key
 
+# The keylime working directory.  Can be overriden by setting the KEYLIME_DIR
+# environment variable. The default value is /var/lib/keylime
+# keylime_dir = /var/lib/keylime
+
 # The CA that signs the client certificates of the tenant and verifier.
-# If set to default it tries to use /var/lib/keylime/cv_ca/cacert.crt
+# If set to default it tries to use $keylime_dir/cv_ca/cacert.crt
 keylime_ca = default
 
 # The name that should be used for the encryption key, placed in the
-# /var/lib/keylime/secure/ directory.
+# $keylime_dir/secure/ directory.
 enc_keyname = derived_tci_key
 
 # The name that should be used for the optional decrypted payload, placed in
-# the /var/lib/keylime/secure directory.
+# the $keylime_dir/secure directory.
 dec_payload_file = decrypted_payload
 
 # The size of the memory-backed tmpfs partition where Keylime stores crypto keys.
@@ -52,7 +56,7 @@ tpm_ownerpassword = keylime
 
 # Whether to allow the cloud_agent to automatically extract a zip file in
 # the delivered payload after it has been decrypted, or not. Defaults to "true".
-# After decryption, the archive will be unzipped to a directory in /var/lib/keylime/secure.
+# After decryption, the archive will be unzipped to a directory in $keylime_dir/secure.
 # Note: the limits on the size of the tmpfs partition set above with the 'secure_size'
 # option will affect this.
 extract_payload_zip = True
@@ -72,7 +76,8 @@ agent_uuid = d432fbb3-d2f1-4a97-9ef7-75bd81c00000
 listen_notfications = True
 
 # The path to the certificate to verify revocation messages received from the
-# verifier.  The path is relative to /var/lib/keylime.
+# verifier.  The path is relative to $keylime_dir unless an absolute path is
+# provided (i.e. starts with '/').
 # If set to "default", Keylime will use the file RevocationNotifier-cert.crt
 # from the unzipped contents provided by the tenant.
 revocation_cert = default
@@ -89,7 +94,7 @@ revocation_actions=
 
 # A script to execute after unzipping the tenant payload.  This is like
 # cloud-init lite =)  Keylime will run it with a /bin/sh environment and
-# with a working directory of /var/lib/keylime/secure/unzipped.
+# with a working directory of $keylime_dir/secure/unzipped.
 payload_script=autorun.sh
 
 # The path to the directory containing the pre-installed revocation action

--- a/src/common.rs
+++ b/src/common.rs
@@ -31,7 +31,8 @@ pub static IMA_ML: &str =
     "/sys/kernel/security/ima/ascii_runtime_measurements";
 pub static MEASUREDBOOT_ML: &str =
     "/sys/kernel/security/tpm0/binary_bios_measurements";
-pub static DEFAULT_CA_PATH: &str = "/var/lib/keylime/cv_ca/cacert.crt";
+// The DEFAULT_CA_PATH is relative from WORK_DIR
+pub static DEFAULT_CA_PATH: &str = "cv_ca/cacert.crt";
 pub static KEY: &str = "secret";
 pub static WORK_DIR: &str = "/var/lib/keylime";
 pub static TPM_DATA: &str = "tpmdata.json";
@@ -43,18 +44,31 @@ pub static REV_ACTIONS_DIR: &str = "/usr/libexec/keylime";
 pub static REV_ACTIONS: &str = "";
 pub static ALLOW_PAYLOAD_REV_ACTIONS: bool = true;
 
-// Secure mount of tpmfs (False is generally used for development environments)
-#[cfg(not(feature = "testing"))]
-pub static MOUNT_SECURE: bool = true;
-
-#[cfg(feature = "testing")]
-pub static MOUNT_SECURE: bool = false;
-
 pub const AGENT_UUID_LEN: usize = 36;
 pub const AUTH_TAG_LEN: usize = 96;
 pub const AES_128_KEY_LEN: usize = 16;
 pub const AES_256_KEY_LEN: usize = 32;
 pub const AES_BLOCK_SIZE: usize = 16;
+
+cfg_if::cfg_if! {
+    if #[cfg(any(test, feature = "testing"))] {
+        // Secure mount of tpmfs (False is generally used for development environments)
+        pub static MOUNT_SECURE: bool = false;
+
+        pub(crate) fn ima_ml_path_get() -> PathBuf {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("test-data")
+                .join("ima")
+                .join("ascii_runtime_measurements")
+        }
+    } else {
+        pub static MOUNT_SECURE: bool = true;
+
+        pub(crate) fn ima_ml_path_get() -> PathBuf {
+            Path::new(IMA_ML).to_path_buf()
+        }
+    }
+}
 
 // a vector holding keys
 pub type KeySet = Vec<SymmKey>;
@@ -146,6 +160,7 @@ pub(crate) struct KeylimeConfig {
     pub enc_alg: EncryptionAlgorithm,
     pub sign_alg: SignAlgorithm,
     pub tpm_data: Option<TpmData>,
+    pub tpm_data_path: String,
     pub run_revocation: bool,
     pub revocation_cert: String,
     pub revocation_ip: String,
@@ -159,6 +174,9 @@ pub(crate) struct KeylimeConfig {
     pub revocation_actions: String,
     pub revocation_actions_dir: String,
     pub allow_payload_revocation_actions: bool,
+    pub work_dir: String,
+    pub ima_ml_path: String,
+    pub measuredboot_ml_path: String,
 }
 
 impl KeylimeConfig {
@@ -190,14 +208,6 @@ impl KeylimeConfig {
         let sign_alg = SignAlgorithm::try_from(
             config_get("cloud_agent", "tpm_signing_alg")?.as_str(),
         )?;
-        let tpm_data_path = tpm_data_path_get();
-        let mut tpm_data = None;
-        if tpm_data_path.exists() {
-            match TpmData::load(&tpm_data_path) {
-                Ok(data) => tpm_data = Some(data),
-                Err(e) => warn!("Could not load TPM data"),
-            }
-        }
         // There was a typo in Python Keylime and this accounts for having a version
         // of Keylime installed that still has this typo. TODO: Remove later
         let run_revocation = bool::from_str(
@@ -221,9 +231,33 @@ impl KeylimeConfig {
             &config_get("cloud_agent", "extract_payload_zip")?.to_lowercase(),
         )?;
 
+        let work_dir =
+            config_get_env("cloud_agent", "keylime_dir", "KEYLIME_DIR")
+                .or_else::<Error, _>(|_| Ok(String::from(WORK_DIR)))?;
+
+        let tpm_data_path = PathBuf::from(&work_dir).join(TPM_DATA);
+        let tpm_data = if tpm_data_path.exists() {
+            match TpmData::load(&tpm_data_path) {
+                Ok(data) => Some(data),
+                Err(e) => {
+                    warn!("Could not load TPM data");
+                    None
+                }
+            }
+        } else {
+            warn!(
+                "TPM2 event log not available: {}",
+                tpm_data_path.display()
+            );
+            None
+        };
+
         let mut keylime_ca_path = config_get("cloud_agent", "keylime_ca")?;
         if keylime_ca_path == "default" {
-            keylime_ca_path = DEFAULT_CA_PATH.to_string()
+            keylime_ca_path = Path::new(&work_dir)
+                .join(DEFAULT_CA_PATH)
+                .display()
+                .to_string();
         }
         let revocation_actions =
             config_get("cloud_agent", "revocation_actions")
@@ -238,6 +272,8 @@ impl KeylimeConfig {
             Ok(s) => bool::from_str(&s.to_lowercase())?,
             Err(_) => ALLOW_PAYLOAD_REV_ACTIONS,
         };
+        let ima_ml_path = ima_ml_path_get();
+        let measuredboot_ml_path = Path::new(MEASUREDBOOT_ML).to_path_buf();
 
         Ok(KeylimeConfig {
             agent_ip,
@@ -251,6 +287,7 @@ impl KeylimeConfig {
             enc_alg,
             sign_alg,
             tpm_data,
+            tpm_data_path: tpm_data_path.display().to_string(),
             run_revocation,
             revocation_cert,
             revocation_ip,
@@ -264,6 +301,9 @@ impl KeylimeConfig {
             revocation_actions,
             revocation_actions_dir,
             allow_payload_revocation_actions,
+            work_dir,
+            ima_ml_path: ima_ml_path.display().to_string(),
+            measuredboot_ml_path: measuredboot_ml_path.display().to_string(),
         })
     }
 }
@@ -284,6 +324,10 @@ impl Default for KeylimeConfig {
             enc_alg: EncryptionAlgorithm::Rsa,
             sign_alg: SignAlgorithm::RsaSsa,
             tpm_data: None,
+            tpm_data_path: Path::new(WORK_DIR)
+                .join(TPM_DATA)
+                .display()
+                .to_string(),
             run_revocation: true,
             revocation_cert: "default".to_string(),
             revocation_ip: "127.0.0.1".to_string(),
@@ -297,6 +341,9 @@ impl Default for KeylimeConfig {
             revocation_actions: "".to_string(),
             revocation_actions_dir: "/usr/libexec/keylime".to_string(),
             allow_payload_revocation_actions: true,
+            work_dir: WORK_DIR.to_string(),
+            ima_ml_path: IMA_ML.to_string(),
+            measuredboot_ml_path: MEASUREDBOOT_ML.to_string(),
         }
     }
 }
@@ -470,29 +517,6 @@ pub(crate) fn chownroot(path: &Path) -> Result<()> {
         info!("Changed file {:?} owner to root.", &path);
         Ok(())
     }
-}
-
-cfg_if::cfg_if! {
-    if #[cfg(feature = "testing")] {
-        pub(crate) fn ima_ml_path_get() -> PathBuf {
-            Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("test-data")
-                .join("ima")
-                .join("ascii_runtime_measurements")
-        }
-    } else {
-        pub(crate) fn ima_ml_path_get() -> PathBuf {
-            Path::new(IMA_ML).to_path_buf()
-        }
-    }
-}
-
-pub(crate) fn tpm_data_path_get() -> PathBuf {
-    Path::new(WORK_DIR).join(TPM_DATA)
-}
-
-pub(crate) fn measuredboot_ml_path_get() -> PathBuf {
-    Path::new(MEASUREDBOOT_ML).to_path_buf()
 }
 
 // Unit Testing

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,9 @@ pub struct QuoteData {
     revocation_actions_dir: PathBuf,
     allow_payload_revocation_actions: bool,
     secure_size: String,
+    work_dir: PathBuf,
+    ima_ml_path: PathBuf,
+    measuredboot_ml_path: PathBuf,
 }
 
 // Parameters are based on Python codebase:
@@ -122,7 +125,8 @@ pub(crate) fn decrypt_payload(
 pub(crate) fn setup_unzipped(
     config: &KeylimeConfig,
 ) -> Result<(PathBuf, PathBuf, PathBuf)> {
-    let mount = secure_mount::mount(&config.secure_size)?;
+    let work_dir = Path::new(&config.work_dir);
+    let mount = secure_mount::mount(work_dir, &config.secure_size)?;
     let unzipped = mount.join("unzipped");
 
     // clear any old data
@@ -399,7 +403,7 @@ async fn main() -> Result<()> {
                 ak_sign_alg: config.sign_alg,
                 ak_context: tpm::store_ak(&mut ctx, new_ak.0)?,
             }
-            .store(&tpm_data_path_get())?;
+            .store(Path::new(&config.tpm_data_path))?;
             new_ak
         }
     };
@@ -471,7 +475,11 @@ async fn main() -> Result<()> {
 
     let revocation_cert = revocation::get_revocation_cert_path(&config)?;
     let actions_dir =
-        PathBuf::from(&config.revocation_actions_dir).canonicalize()?;
+        Path::new(&config.revocation_actions_dir).canonicalize()?;
+    let work_dir = Path::new(&config.work_dir).canonicalize()?;
+    let ima_ml_path = Path::new(&config.ima_ml_path).to_path_buf();
+    let measuredboot_ml_path =
+        Path::new(&config.measuredboot_ml_path).to_path_buf();
 
     let quotedata = web::Data::new(QuoteData {
         tpmcontext: Mutex::new(ctx),
@@ -494,6 +502,9 @@ async fn main() -> Result<()> {
         allow_payload_revocation_actions: config
             .allow_payload_revocation_actions,
         secure_size: config.secure_size.clone(),
+        work_dir,
+        ima_ml_path,
+        measuredboot_ml_path,
     });
 
     let actix_server = HttpServer::new(move || {
@@ -608,6 +619,16 @@ mod testing {
             let actions_dir =
                 Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/actions/");
 
+            let work_dir =
+                Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+
+            let ima_ml_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("test-data/ima/ascii_runtime_measurements");
+
+            let measuredboot_ml_path = Path::new(
+                "/sys/kernel/security/tpm0/binary_bios_measurements",
+            );
+
             Ok(QuoteData {
                 tpmcontext: Mutex::new(ctx),
                 priv_key: nk_priv,
@@ -629,6 +650,9 @@ mod testing {
                 allow_payload_revocation_actions: test_config
                     .allow_payload_revocation_actions,
                 secure_size: test_config.secure_size,
+                work_dir,
+                ima_ml_path,
+                measuredboot_ml_path: measuredboot_ml_path.to_path_buf(),
             })
         }
     }

--- a/src/notifications_handler.rs
+++ b/src/notifications_handler.rs
@@ -34,6 +34,7 @@ pub async fn revocation(
     let revocation_actions = &data.revocation_actions;
     let actions_dir = PathBuf::from(&data.revocation_actions_dir);
     let payload_actions_allowed = data.allow_payload_revocation_actions;
+    let work_dir = PathBuf::from(&data.work_dir);
 
     let result = revocation::process_revocation(
         json_body,
@@ -42,6 +43,7 @@ pub async fn revocation(
         revocation_actions,
         &actions_dir,
         payload_actions_allowed,
+        &work_dir,
     )?;
 
     HttpResponse::Ok().await

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -4,7 +4,7 @@
 #[macro_use]
 use log::*;
 
-use crate::common::{KeylimeConfig, REV_CERT, WORK_DIR};
+use crate::common::{KeylimeConfig, REV_CERT};
 use crate::crypto;
 use crate::error::*;
 use crate::secure_mount;
@@ -83,13 +83,8 @@ pub(crate) fn run_action(
     action: &str,
     json: Value,
     allow_payload_actions: bool,
+    work_dir: &Path,
 ) -> Result<Output> {
-    #[cfg(not(test))]
-    let work_dir = PathBuf::from(WORK_DIR);
-
-    #[cfg(test)]
-    let work_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
-
     // Lookup for command and get command line
     let (command, is_python, is_payload) = lookup_action(
         payload_dir,
@@ -102,7 +97,7 @@ pub(crate) fn run_action(
 
     // Write JSON argument to a temporary file
     let raw_json = serde_json::value::to_raw_value(&json)?;
-    let mut json_dump = tempfile::NamedTempFile::new_in(&work_dir)?;
+    let mut json_dump = tempfile::NamedTempFile::new_in(work_dir)?;
     json_dump.write_all(raw_json.get().as_bytes());
 
     //TODO check if it is possible to not keep the file when passing to another process
@@ -168,12 +163,9 @@ pub(crate) fn run_revocation_actions(
     config_actions: &str,
     actions_dir: &Path,
     allow_payload_actions: bool,
+    work_dir: &Path,
 ) -> Result<Vec<Output>> {
-    #[cfg(test)]
-    let mount = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
-
-    #[cfg(not(test))]
-    let mount = secure_mount::mount(secure_size)?;
+    let mount = secure_mount::mount(work_dir, secure_size)?;
 
     // The actions from the configuration file takes precedence over the actions from the
     // actions_list file
@@ -228,6 +220,7 @@ pub(crate) fn run_revocation_actions(
                 action,
                 json.clone(),
                 allow_payload_actions,
+                work_dir,
             ) {
                 Ok(output) => {
                     outputs.push(output);
@@ -263,7 +256,8 @@ pub(crate) fn run_revocation_actions(
 pub(crate) fn get_revocation_cert_path(
     config: &KeylimeConfig,
 ) -> Result<PathBuf> {
-    let default_path = &format!("{}/secure/unzipped/{}", WORK_DIR, REV_CERT);
+    let default_path =
+        &format!("{}/secure/unzipped/{}", &config.work_dir, REV_CERT);
 
     // Unlike the python agent we do not attempt lazy loading. We either
     // have the certificate, or we don't. If we don't have a key or can't load
@@ -282,7 +276,7 @@ pub(crate) fn get_revocation_cert_path(
     // If the path is not absolute, expand from the WORK_DIR
     if cert_path_buf.as_path().is_relative() {
         let rel_path = cert_path_buf;
-        cert_path_buf = PathBuf::from(WORK_DIR);
+        cert_path_buf = PathBuf::from(&config.work_dir);
         cert_path_buf.push(rel_path);
     }
 
@@ -297,6 +291,7 @@ pub(crate) fn process_revocation(
     config_actions: &str,
     actions_dir: &Path,
     allow_payload_revocation_actions: bool,
+    work_dir: &Path,
 ) -> Result<()> {
     // Ensure we have a signature, otherwise continue the loop
     let signature = match body["signature"].as_str() {
@@ -355,6 +350,7 @@ pub(crate) fn process_revocation(
                 config_actions,
                 actions_dir,
                 allow_payload_revocation_actions,
+                work_dir,
             )?;
 
             for output in outputs {
@@ -388,7 +384,8 @@ pub(crate) fn process_revocation(
 pub(crate) async fn run_revocation_service(
     config: &KeylimeConfig,
 ) -> Result<()> {
-    let mount = secure_mount::mount(&config.secure_size)?;
+    let work_dir = Path::new(&config.work_dir);
+    let mount = secure_mount::mount(work_dir, &config.secure_size)?;
 
     // Connect to the service via 0mq
     let context = zmq::Context::new();
@@ -433,6 +430,7 @@ pub(crate) async fn run_revocation_service(
             &config.revocation_actions,
             &actions_dir,
             config.allow_payload_revocation_actions,
+            work_dir,
         );
     }
     Ok(())
@@ -442,6 +440,9 @@ pub(crate) async fn run_revocation_service(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // Used to create symbolic links
+    use std::os::unix::fs::symlink;
 
     #[test]
     fn revocation_scripts_ok() {
@@ -453,13 +454,20 @@ mod tests {
         let json_str = std::fs::read_to_string(json_file).unwrap(); //#[allow_ci]
         let json = serde_json::from_str(&json_str).unwrap(); //#[allow_ci]
         let actions_dir =
-            &PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/actions/");
+            &Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/actions/");
+        let work_dir = tempfile::tempdir().unwrap(); //#[allow_ci]
+        let tmpfs_dir = work_dir.path().join("tmpfs-dev"); //#[allow_ci]
+        fs::create_dir(&tmpfs_dir).unwrap(); //#[allow_ci]
+        let unzipped_dir =
+            &Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/unzipped");
+        symlink(unzipped_dir, tmpfs_dir.join("unzipped")).unwrap(); //#[allow_ci]
         let outputs = run_revocation_actions(
             json,
             &test_config.secure_size,
             &test_config.revocation_actions,
             actions_dir,
             true,
+            work_dir.path(),
         );
 
         assert!(outputs.is_ok());
@@ -485,13 +493,20 @@ mod tests {
         let json_str = std::fs::read_to_string(json_file).unwrap(); //#[allow_ci]
         let json = serde_json::from_str(&json_str).unwrap(); //#[allow_ci]
         let actions_dir =
-            &PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/actions/");
+            &Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/actions/");
+        let work_dir = tempfile::tempdir().unwrap(); //#[allow_ci]
+        let tmpfs_dir = work_dir.path().join("tmpfs-dev"); //#[allow_ci]
+        fs::create_dir(&tmpfs_dir).unwrap(); //#[allow_ci]
+        let unzipped_dir =
+            &Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/unzipped");
+        symlink(unzipped_dir, tmpfs_dir.join("unzipped")).unwrap(); //#[allow_ci]
         let outputs = run_revocation_actions(
             json,
             &test_config.secure_size,
             &test_config.revocation_actions,
             actions_dir,
             true,
+            work_dir.path(),
         );
         assert!(outputs.is_err());
     }
@@ -508,13 +523,20 @@ mod tests {
         let json_str = std::fs::read_to_string(json_file).unwrap(); //#[allow_ci]
         let json = serde_json::from_str(&json_str).unwrap(); //#[allow_ci]
         let actions_dir =
-            &PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/actions/");
+            &Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/actions/");
+        let work_dir = tempfile::tempdir().unwrap(); //#[allow_ci]
+        let tmpfs_dir = work_dir.path().join("tmpfs-dev"); //#[allow_ci]
+        fs::create_dir(&tmpfs_dir).unwrap(); //#[allow_ci]
+        let unzipped_dir =
+            &Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/unzipped");
+        symlink(unzipped_dir, tmpfs_dir.join("unzipped")).unwrap(); //#[allow_ci]
         let outputs = run_revocation_actions(
             json,
             &test_config.secure_size,
             &test_config.revocation_actions,
             actions_dir,
             true,
+            work_dir.path(),
         );
 
         assert!(outputs.is_ok());
@@ -535,7 +557,7 @@ mod tests {
         let test_config = KeylimeConfig::default();
         let revocation_cert_path =
             get_revocation_cert_path(&test_config).unwrap(); //#[allow_ci]
-        let mut expected = PathBuf::from(WORK_DIR);
+        let mut expected = PathBuf::from(&test_config.work_dir);
         expected.push("secure/unzipped/");
         expected.push(REV_CERT);
         assert_eq!(*revocation_cert_path, expected);
@@ -560,8 +582,7 @@ mod tests {
         };
         let revocation_cert_path =
             get_revocation_cert_path(&test_config).unwrap(); //#[allow_ci]
-        let mut expected = PathBuf::from(WORK_DIR);
-        expected.push("cert.crt");
+        let mut expected = Path::new(&test_config.work_dir).join("cert.crt");
         assert_eq!(revocation_cert_path, expected);
     }
 
@@ -580,8 +601,8 @@ mod tests {
     #[test]
     fn test_lookup_action() {
         let work_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
-        let payload_dir = PathBuf::from(&work_dir.join("unzipped/"));
-        let actions_dir = PathBuf::from(&work_dir.join("actions/"));
+        let payload_dir = Path::new(&work_dir).join("unzipped/");
+        let actions_dir = Path::new(&work_dir).join("actions/");
 
         // Test local python action
         let expected = format!("{}", &actions_dir.join("shim.py").display(),);
@@ -704,6 +725,8 @@ mod tests {
         let actions_dir =
             Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/actions");
 
+        let work_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+
         let result = process_revocation(
             body,
             &cert_path,
@@ -711,6 +734,7 @@ mod tests {
             &test_config.revocation_actions,
             &actions_dir,
             test_config.allow_payload_revocation_actions,
+            &work_dir,
         );
 
         assert!(result.is_ok());

--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -58,12 +58,12 @@ fn check_mount(secure_dir: &Path) -> Result<bool> {
  * implementation as the original python version, but the chown/geteuid
  * functions are unsafe function in Rust to use.
  */
-pub(crate) fn mount(secure_size: &str) -> Result<PathBuf> {
+pub(crate) fn mount(work_dir: &Path, secure_size: &str) -> Result<PathBuf> {
     // Use /tmpfs-dev directory if MOUNT_SECURE flag is not set. This
     // is for development environment and does not mount to the system.
     if !MOUNT_SECURE {
         warn!("Using /tmpfs-dev (dev environment)");
-        let secure_dir_path = Path::new(WORK_DIR).join("tmpfs-dev");
+        let secure_dir_path = Path::new(work_dir).join("tmpfs-dev");
         if !secure_dir_path.exists() {
             fs::create_dir(&secure_dir_path).map_err(|e| {
                 Error::SecureMount(format!(
@@ -78,7 +78,7 @@ pub(crate) fn mount(secure_size: &str) -> Result<PathBuf> {
     }
 
     // Mount the directory to file system
-    let secure_dir_path = Path::new(WORK_DIR).join("secure");
+    let secure_dir_path = Path::new(work_dir).join("secure");
 
     // If the directory is not mount to file system, mount the directory to
     // file system.


### PR DESCRIPTION
The working directory can be set via the KEYLIME_DIR environment
variable or keylime_dir configuration option.

When the working directory is set, the expected location for the
certificates and secure mount are also modified and are relative to the
location set via KEYLIME_DIR.

The DEFAULT_CA_PATH is now relative to the working directory.

Consolidate the conditional change of the secure mount location when
testing to a single location.

Modify the revocation tests to use a temporary directory as the working
directory.

Fixes: #333