### PR TITLE
Remove revocation actions naming restriction

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -77,14 +77,13 @@ listen_notfications = True
 # from the unzipped contents provided by the tenant.
 revocation_cert = default
 
-# A comma-separated list of Python scripts to run upon receiving a revocation
-# message. Keylime will verify the signature first, then call these Python
-# scripts with the json revocation message.  The scripts must be located in
-# the 'revocation_actions' directory.
+# A comma-separated list of executables to run upon receiving a revocation
+# message. Keylime will verify the signature first, then call these executables
+# with the json revocation message.  The executables must be located in the
+# 'revocation_actions' directory.
 #
 # Keylime will also get the list of revocation actions from the file
 # action_list in the unzipped contents provided by the verifier.
-# All actions must be named local_action_[some name].
 revocation_actions=
 
 # A script to execute after unzipping the tenant payload.  This is like

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,20 +267,19 @@ pub(crate) async fn run_encrypted_payload(
             .split('\n')
             .filter(|&script| !script.is_empty())
             .map(|script| script.trim())
-            .inspect(|&script| {
-                // Enforce the name restriction
-                if !script.starts_with("local_action_") {
-                    warn!("Invalid local action: {}. Must start with local_action_", script)
-                }
-            })
-            .filter(|&script| script.starts_with("local_action_"))
             .map(|script| unzipped.join(script))
             .filter(|script| script.exists())
             .try_for_each(|script| {
-                if fs::set_permissions(&script, fs::Permissions::from_mode(0o700))
-                    .is_err()
+                if fs::set_permissions(
+                    &script,
+                    fs::Permissions::from_mode(0o700),
+                )
+                .is_err()
                 {
-                    error!("Could not set permission for action {}", script.display());
+                    error!(
+                        "Could not set permission for action {}",
+                        script.display()
+                    );
                     Err(Error::Permission)
                 } else {
                     info!("Permission set for action: {}", script.display());

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -181,16 +181,6 @@ pub(crate) fn run_revocation_actions(
         .split(',')
         .map(|script| script.trim())
         .filter(|script| !script.is_empty())
-        .inspect(|script| {
-            // Enforce the name restriction
-            if !script.starts_with("local_action_") {
-                warn!(
-                    "Invalid local action: {}. Must start with local_action_",
-                    script
-                )
-            }
-        })
-        .filter(|script| script.starts_with("local_action_"))
         .collect::<Vec<&str>>();
 
     let action_data;
@@ -204,14 +194,7 @@ pub(crate) fn run_revocation_actions(
         let file_actions = action_data
             .split('\n')
             .map(|script| script.trim())
-            .filter(|script| !script.is_empty())
-            .inspect(|script| {
-                // Enforce the name restriction
-                if !script.starts_with("local_action_") {
-                    warn!("Invalid local action will not be executed: {}. Must start with local_action_", script)
-                }
-            })
-            .filter(|script| script.starts_with("local_action_"));
+            .filter(|script| !script.is_empty());
 
         action_list.extend(file_actions);
     } else {


### PR DESCRIPTION
The revocation actions names are no longer required to start with
'local_action_'.

This implements the enhancement amendment added via:
https://github.com/keylime/enhancements/pull/63