### PR TITLE
main: Do not error if payload_script is not found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,8 @@ pub(crate) fn run(dir: &Path, script: &str, agent_uuid: &str) -> Result<()> {
     info!("Running script: {:?}", script_path);
 
     if !script_path.exists() {
-        return Err(Error::Other(format!("{:?} not found", &script_path)));
+        info!("No payload script {} found in {}", script, dir.display());
+        return Ok(());
     }
 
     if fs::set_permissions(&script_path, fs::Permissions::from_mode(0o700))
@@ -179,6 +180,8 @@ pub(crate) fn run(dir: &Path, script: &str, agent_uuid: &str) -> Result<()> {
             &script_path
         )));
     }
+
+    info!("Executing payload script: {}", script_path.display());
 
     match Command::new("sh")
         .arg("-c")


### PR DESCRIPTION
Follow python agent implementation and ignore `payload_script` if it is
set in configuration but it is not provided in the payload.

Fixes: #336 