### PR TITLE
Add support for iterative attestation

### DIFF
--- a/src/ima.rs
+++ b/src/ima.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
+#[macro_use]
+use log::*;
+
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::Error;
+use std::io::SeekFrom;
+use std::path::Path;
+use std::str;
+
+use tempfile::NamedTempFile;
+
+/// IMAMeasurementList models the IMA measurement lists's last two known
+/// numbers of entries in the log and filesizes at that point
+#[derive(Debug)]
+pub(crate) struct ImaMeasurementList {
+    entries: HashSet<(u64, u64)>,
+}
+
+pub type IMAError = Result<(String, u64, u64), Error>;
+
+impl ImaMeasurementList {
+    pub(crate) fn new() -> ImaMeasurementList {
+        let mut iml = ImaMeasurementList {
+            entries: HashSet::new(),
+        };
+        let _ = iml.reset();
+        iml
+    }
+
+    fn reset(&mut self) {
+        self.entries = HashSet::new();
+    }
+
+    fn update(&mut self, num_entries: u64, filesize: u64) {
+        if self.entries.len() > 32 {
+            let e = self.entries.iter().next().cloned().unwrap();
+            let _ = self.entries.remove(&e);
+        }
+        let _ = self.entries.insert((num_entries, filesize));
+    }
+
+    fn find(&self, nth_entry: u64) -> (u64, u64) {
+        let mut best = (0, 0);
+        for entry in self.entries.iter() {
+            if entry.0 > best.0 && entry.0 < nth_entry {
+                best = *entry
+            }
+        }
+        return best;
+    }
+}
+
+/// Read the IMA measurement list starting from a given entry.
+/// The entry may be of any value 0 <= entry <= entries_in_log where
+/// entries_in_log + 1 indicates that the client wants to read the next entry
+/// once available. If the entry is outside this range, the function will
+/// automatically read from the 0-th entry.
+/// This function returns the measurement list and the entry from where it
+/// was read and the current number of entries in the file.
+pub(crate) fn read_measurement_list(
+    ima_ml: &mut ImaMeasurementList,
+    filename: &Path,
+    nth_entry: u64,
+) -> IMAError {
+    let mut nth_entry = nth_entry;
+
+    // Try to find the closest entry to the nth_entry
+    let (mut num_entries, filesize) = ima_ml.find(nth_entry);
+
+    let mut ml = None;
+    let mut filedata = String::new();
+
+    if !Path::new(filename).exists() {
+        let _ = ima_ml.reset();
+        nth_entry = 0;
+        log::warn!(
+            "IMA measurement list not available: {}",
+            filename.to_str().unwrap()
+        );
+    } else {
+        let mut file = File::open(filename)?;
+        let _ = file.seek(SeekFrom::Start(filesize))?;
+        let _ = file.read_to_string(&mut filedata)?;
+
+        let mut offset: usize = 0;
+        loop {
+            if nth_entry == num_entries {
+                ml = Some(&filedata[offset..]);
+            }
+            let s = &filedata[offset..];
+            let idx = match s.find('\n') {
+                None => break,
+                Some(i) => i,
+            };
+            offset = offset + idx + 1;
+            num_entries += 1;
+        }
+        ima_ml.update(num_entries, filesize + offset as u64);
+
+        match ml {
+            None => return read_measurement_list(ima_ml, filename, 0),
+            Some(_) => (),
+        }
+    }
+    return Ok((String::from(ml.unwrap()), nth_entry, num_entries));
+}
+
+#[test]
+fn read_measurement_list_test() {
+    let mut ima_ml = ImaMeasurementList::new();
+
+    let filedata = "0-entry\n1-entry\n2-entry\n";
+    let mut tf = match NamedTempFile::new() {
+        Ok(tf) => tf,
+        Err(_) => panic!("Could not create temp file"),
+    };
+    tf.write_all(filedata.as_bytes());
+    tf.flush();
+
+    // Request the 2nd entry, which is available
+    let (ml, nth_entry, num_entries) =
+        match read_measurement_list(&mut ima_ml, tf.path(), 2) {
+            Err(v) => panic!("Reading measurement list failed: {}", v),
+            Ok((ml, nth_entry, num_entries)) => (ml, nth_entry, num_entries),
+        };
+    assert_eq!(num_entries, 3);
+    assert_eq!(nth_entry, 2);
+    assert_eq!(ml.find("2-entry").unwrap(), 0);
+
+    // Request the 3rd entry, which is not available yet, thus we get an empty list
+    let (ml, nth_entry, num_entries) =
+        match read_measurement_list(&mut ima_ml, tf.path(), 3) {
+            Err(v) => panic!("Reading measurement list failed: {}", v),
+            Ok((ml, nth_entry, num_entries)) => (ml, nth_entry, num_entries),
+        };
+    assert_eq!(num_entries, 3);
+    assert_eq!(nth_entry, 3);
+    assert_eq!(ml.len(), 0);
+
+    // Request the 4th entry, which is beyond the next entry; since this is wrong,
+    // we expect the entire list now.
+    let (ml, nth_entry, num_entries) =
+        match read_measurement_list(&mut ima_ml, tf.path(), 4) {
+            Err(v) => panic!("Reading measurement list failed: {}", v),
+            Ok((ml, nth_entry, num_entries)) => (ml, nth_entry, num_entries),
+        };
+    assert_eq!(num_entries, 3);
+    assert_eq!(nth_entry, 0);
+    assert_eq!(ml.find("0-entry").unwrap(), 0);
+}

--- a/src/ima.rs
+++ b/src/ima.rs
@@ -51,7 +51,7 @@ impl ImaMeasurementList {
                 best = *entry
             }
         }
-        return best;
+        best
     }
 }
 
@@ -107,7 +107,7 @@ pub(crate) fn read_measurement_list(
             Some(_) => (),
         }
     }
-    return Ok((String::from(ml.unwrap()), nth_entry, num_entries));
+    Ok((String::from(ml.unwrap()), nth_entry, num_entries))
 }
 
 #[test]

--- a/src/ima.rs
+++ b/src/ima.rs
@@ -1,18 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2021 Keylime Authors
 
-#[macro_use]
 use log::*;
-
-use std::collections::HashSet;
-use std::fs::File;
-use std::io::prelude::*;
-use std::io::Error;
-use std::io::SeekFrom;
-use std::path::Path;
-use std::str;
-
-use tempfile::NamedTempFile;
+use std::{
+    collections::HashSet,
+    fs::File,
+    io::{prelude::*, Error, SeekFrom},
+    path::Path,
+};
 
 /// IMAMeasurementList models the IMA measurement lists's last two known
 /// numbers of entries in the log and filesizes at that point
@@ -25,33 +20,31 @@ pub type IMAError = Result<(String, u64, u64), Error>;
 
 impl ImaMeasurementList {
     pub(crate) fn new() -> ImaMeasurementList {
-        let mut iml = ImaMeasurementList {
+        ImaMeasurementList {
             entries: HashSet::new(),
-        };
-        let _ = iml.reset();
-        iml
+        }
     }
 
     fn reset(&mut self) {
         self.entries = HashSet::new();
     }
 
-    fn update(&mut self, num_entries: u64, filesize: u64) {
+    fn update(&mut self, num_entries: u64, filesize: u64) -> Option<bool> {
         if self.entries.len() > 32 {
-            let e = self.entries.iter().next().cloned().unwrap();
+            let e = *self.entries.iter().next()?;
             let _ = self.entries.remove(&e);
         }
-        let _ = self.entries.insert((num_entries, filesize));
+        Some(self.entries.insert((num_entries, filesize)))
     }
 
     fn find(&self, nth_entry: u64) -> (u64, u64) {
-        let mut best = (0, 0);
-        for entry in self.entries.iter() {
+        self.entries.iter().fold((0, 0), |best, entry| {
             if entry.0 > best.0 && entry.0 < nth_entry {
-                best = *entry
+                *entry
+            } else {
+                best
             }
-        }
-        best
+        })
     }
 }
 
@@ -67,6 +60,12 @@ pub(crate) fn read_measurement_list(
     filename: &Path,
     nth_entry: u64,
 ) -> IMAError {
+    if !Path::new(filename).exists() {
+        let _ = ima_ml.reset();
+        warn!("IMA measurement list not available: {}", filename.display());
+        return Ok(("".to_string(), 0, 0));
+    }
+
     let mut nth_entry = nth_entry;
 
     // Try to find the closest entry to the nth_entry
@@ -74,82 +73,65 @@ pub(crate) fn read_measurement_list(
 
     let mut ml = None;
     let mut filedata = String::new();
+    let mut file = File::open(filename)?;
+    let _ = file.seek(SeekFrom::Start(filesize))?;
+    let _ = file.read_to_string(&mut filedata)?;
+    let mut offset: usize = 0;
 
-    if !Path::new(filename).exists() {
-        let _ = ima_ml.reset();
-        nth_entry = 0;
-        log::warn!(
-            "IMA measurement list not available: {}",
-            filename.to_str().unwrap()
-        );
-    } else {
-        let mut file = File::open(filename)?;
-        let _ = file.seek(SeekFrom::Start(filesize))?;
-        let _ = file.read_to_string(&mut filedata)?;
-
-        let mut offset: usize = 0;
-        loop {
-            if nth_entry == num_entries {
-                ml = Some(&filedata[offset..]);
-            }
-            let s = &filedata[offset..];
-            let idx = match s.find('\n') {
-                None => break,
-                Some(i) => i,
-            };
-            offset = offset + idx + 1;
-            num_entries += 1;
+    loop {
+        if nth_entry == num_entries {
+            ml = Some(&filedata[offset..]);
         }
-        ima_ml.update(num_entries, filesize + offset as u64);
-
-        match ml {
-            None => return read_measurement_list(ima_ml, filename, 0),
-            Some(_) => (),
-        }
+        let s = &filedata[offset..];
+        let idx = match s.find('\n') {
+            None => break,
+            Some(i) => i,
+        };
+        offset = offset + idx + 1;
+        num_entries += 1;
     }
-    Ok((String::from(ml.unwrap()), nth_entry, num_entries))
+
+    let _ = ima_ml.update(num_entries, filesize + offset as u64);
+
+    match ml {
+        None => read_measurement_list(ima_ml, filename, 0),
+        Some(slice) => Ok((String::from(slice), nth_entry, num_entries)),
+    }
 }
 
-#[test]
-fn read_measurement_list_test() {
-    let mut ima_ml = ImaMeasurementList::new();
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
 
-    let filedata = "0-entry\n1-entry\n2-entry\n";
-    let mut tf = match NamedTempFile::new() {
-        Ok(tf) => tf,
-        Err(_) => panic!("Could not create temp file"),
-    };
-    tf.write_all(filedata.as_bytes());
-    tf.flush();
+    #[test]
+    fn read_measurement_list_test() {
+        let mut ima_ml = ImaMeasurementList::new();
 
-    // Request the 2nd entry, which is available
-    let (ml, nth_entry, num_entries) =
-        match read_measurement_list(&mut ima_ml, tf.path(), 2) {
-            Err(v) => panic!("Reading measurement list failed: {}", v),
-            Ok((ml, nth_entry, num_entries)) => (ml, nth_entry, num_entries),
-        };
-    assert_eq!(num_entries, 3);
-    assert_eq!(nth_entry, 2);
-    assert_eq!(ml.find("2-entry").unwrap(), 0);
+        let filedata = "0-entry\n1-entry\n2-entry\n";
+        let mut tf = NamedTempFile::new().unwrap(); //#[allow_ci]
+        tf.write_all(filedata.as_bytes());
+        tf.flush();
 
-    // Request the 3rd entry, which is not available yet, thus we get an empty list
-    let (ml, nth_entry, num_entries) =
-        match read_measurement_list(&mut ima_ml, tf.path(), 3) {
-            Err(v) => panic!("Reading measurement list failed: {}", v),
-            Ok((ml, nth_entry, num_entries)) => (ml, nth_entry, num_entries),
-        };
-    assert_eq!(num_entries, 3);
-    assert_eq!(nth_entry, 3);
-    assert_eq!(ml.len(), 0);
+        // Request the 2nd entry, which is available
+        let (ml, nth_entry, num_entries) =
+            read_measurement_list(&mut ima_ml, tf.path(), 2).unwrap(); //#[allow_ci]
+        assert_eq!(num_entries, 3);
+        assert_eq!(nth_entry, 2);
+        assert_eq!(ml.find("2-entry").unwrap(), 0); //#[allow_ci]
 
-    // Request the 4th entry, which is beyond the next entry; since this is wrong,
-    // we expect the entire list now.
-    let (ml, nth_entry, num_entries) =
-        match read_measurement_list(&mut ima_ml, tf.path(), 4) {
-            Err(v) => panic!("Reading measurement list failed: {}", v),
-            Ok((ml, nth_entry, num_entries)) => (ml, nth_entry, num_entries),
-        };
-    assert_eq!(num_entries, 3);
-    assert_eq!(nth_entry, 0);
-    assert_eq!(ml.find("0-entry").unwrap(), 0);
+        // Request the 3rd entry, which is not available yet, thus we get an empty list
+        let (ml, nth_entry, num_entries) =
+            read_measurement_list(&mut ima_ml, tf.path(), 3).unwrap(); //#[allow_ci]
+        assert_eq!(num_entries, 3);
+        assert_eq!(nth_entry, 3);
+        assert_eq!(ml.len(), 0);
+
+        // Request the 4th entry, which is beyond the next entry; since this is wrong,
+        // we expect the entire list now.
+        let (ml, nth_entry, num_entries) =
+            read_measurement_list(&mut ima_ml, tf.path(), 4).unwrap(); //#[allow_ci]
+        assert_eq!(num_entries, 3);
+        assert_eq!(nth_entry, 0);
+        assert_eq!(ml.find("0-entry").unwrap(), 0); //#[allow_ci]
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ mod algorithms;
 mod common;
 mod crypto;
 mod error;
+mod ima;
 mod keys_handler;
 mod notifications_handler;
 mod quotes_handler;
@@ -69,6 +70,7 @@ use tss_esapi::{
     handles::KeyHandle, interface_types::algorithm::AsymmetricAlgorithm,
     Context,
 };
+use ima::ImaMeasurementList;
 use uuid::Uuid;
 
 #[macro_use]
@@ -102,6 +104,7 @@ pub struct QuoteData {
     work_dir: PathBuf,
     ima_ml_path: PathBuf,
     measuredboot_ml_path: PathBuf,
+    ima_ml: Mutex<ImaMeasurementList>,
 }
 
 // Parameters are based on Python codebase:
@@ -507,6 +510,7 @@ async fn main() -> Result<()> {
         work_dir,
         ima_ml_path,
         measuredboot_ml_path,
+        ima_ml: Mutex::new(ImaMeasurementList::new()),
     });
 
     let actix_server = HttpServer::new(move || {
@@ -655,6 +659,7 @@ mod testing {
                 work_dir,
                 ima_ml_path,
                 measuredboot_ml_path: measuredboot_ml_path.to_path_buf(),
+                ima_ml: Mutex::new(ImaMeasurementList::new()),
             })
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ use common::*;
 use compress_tools::*;
 use error::{Error, Result};
 use futures::{future::TryFutureExt, try_join};
+use ima::ImaMeasurementList;
 use log::*;
 use openssl::pkey::{PKey, Private, Public};
 use std::{
@@ -70,7 +71,6 @@ use tss_esapi::{
     handles::KeyHandle, interface_types::algorithm::AsymmetricAlgorithm,
     Context,
 };
-use ima::ImaMeasurementList;
 use uuid::Uuid;
 
 #[macro_use]

--- a/src/quotes_handler.rs
+++ b/src/quotes_handler.rs
@@ -3,8 +3,8 @@
 
 use crate::{tpm, Error as KeylimeError, QuoteData};
 
-use crate::serialization::serialize_maybe_base64;
 use crate::ima::read_measurement_list;
+use crate::serialization::serialize_maybe_base64;
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use log::*;
 use serde::{Deserialize, Serialize};
@@ -249,7 +249,7 @@ pub async fn integrity(
                 .await;
         };
 
-        let ima_ml_entry = req.uri().query().unwrap();
+        let ima_ml_entry = req.uri().query().unwrap(); //#[allow_ci]
         let nth_entry = match ima_ml_entry.find("ima_ml_entry=") {
             None => 0,
             Some(idx) => {
@@ -281,8 +281,11 @@ pub async fn integrity(
         }
 
         let ima_ml_path = &data.ima_ml_path;
-        let (ima_ml, nth_entry, num_entries) =
-            read_measurement_list(&mut data.ima_ml.lock().unwrap(), &ima_ml_path, nth_entry)?;
+        let (ima_ml, nth_entry, num_entries) = read_measurement_list(
+            &mut data.ima_ml.lock().unwrap(), //#[allow_ci]
+            ima_ml_path,
+            nth_entry,
+        )?;
 
         if partial == 0 {
             let quote = KeylimeIntegrityQuotePreAttestation::from_id_quote(


### PR DESCRIPTION
Rebase the changes proposed in #277 on top of current master.

Small changes were added:
- Applied changes suggested by `cargo fmt` and `cargo clippy`
- Avoid using `unwrap()`, `panic!()`, and cloning when possible
- Move added unit test to a module