### PR TITLE
Specify API version of Python components

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -19,7 +19,10 @@ use uuid::Uuid;
 /*
  * Constants and static variables
  */
-pub const API_VERSION: &str = "v2.1";
+// expected API version of verifier, registrar, tenant
+pub const PYTHON_API_VERSION: &str = "v2.0";
+// API version of agent
+pub const AGENT_API_VERSION: &str = "v2.1";
 pub const STUB_VTPM: bool = false;
 pub const STUB_IMA: bool = true;
 pub const TPM_DATA_PCR: usize = 16;

--- a/src/keys_handler.rs
+++ b/src/keys_handler.rs
@@ -225,7 +225,7 @@ pub async fn pubkey(
 mod tests {
     use super::*;
     use crate::common::{
-        KeylimeConfig, AES_128_KEY_LEN, AES_256_KEY_LEN, API_VERSION,
+        KeylimeConfig, AES_128_KEY_LEN, AES_256_KEY_LEN, PYTHON_API_VERSION,
     };
     use crate::crypto::compute_hmac;
     #[cfg(feature = "testing")]
@@ -251,11 +251,11 @@ mod tests {
             App::new()
                 .app_data(quotedata.clone())
                 .route(
-                    &format!("/{}/keys/ukey", API_VERSION),
+                    &format!("/{}/keys/ukey", PYTHON_API_VERSION),
                     web::post().to(u_key),
                 )
                 .route(
-                    &format!("/{}/keys/vkey", API_VERSION),
+                    &format!("/{}/keys/vkey", PYTHON_API_VERSION),
                     web::post().to(v_key),
                 ),
         )
@@ -313,7 +313,7 @@ mod tests {
         };
 
         let req = test::TestRequest::post()
-            .uri(&format!("/{}/keys/ukey", API_VERSION,))
+            .uri(&format!("/{}/keys/ukey", PYTHON_API_VERSION,))
             .set_json(&ukey)
             .to_request();
 
@@ -328,7 +328,7 @@ mod tests {
         };
 
         let req = test::TestRequest::post()
-            .uri(&format!("/{}/keys/vkey", API_VERSION,))
+            .uri(&format!("/{}/keys/vkey", PYTHON_API_VERSION,))
             .set_json(&vkey)
             .to_request();
 
@@ -377,13 +377,13 @@ mod tests {
         let quotedata = web::Data::new(QuoteData::fixture().unwrap()); //#[allow_ci]
         let mut app =
             test::init_service(App::new().app_data(quotedata.clone()).route(
-                &format!("/{}/keys/pubkey", API_VERSION),
+                &format!("/{}/keys/pubkey", PYTHON_API_VERSION),
                 web::get().to(pubkey),
             ))
             .await;
 
         let req = test::TestRequest::get()
-            .uri(&format!("/{}/keys/pubkey", API_VERSION,))
+            .uri(&format!("/{}/keys/pubkey", PYTHON_API_VERSION,))
             .to_request();
 
         let resp = test::call_service(&mut app, req).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,7 +330,11 @@ async fn main() -> Result<()> {
         warn!("INSECURE: Only use Keylime in this mode for testing or debugging purposes.");
     }
 
-    info!("Starting server with API version {}...", API_VERSION);
+    info!("Starting server with API version {}...", AGENT_API_VERSION);
+    info!(
+        "Supporting verifier, registrar, tenant API version {}...",
+        PYTHON_API_VERSION
+    );
 
     // Load config
     let config = KeylimeConfig::build()?;
@@ -500,30 +504,36 @@ async fn main() -> Result<()> {
         App::new()
             .app_data(quotedata.clone())
             .service(
-                web::resource(format!("/{}/keys/ukey", API_VERSION))
+                web::resource(format!("/{}/keys/ukey", PYTHON_API_VERSION))
                     .route(web::post().to(keys_handler::u_key)),
             )
             .service(
                 // the double slash may be a typo on the python side
-                web::resource(format!("/{}/keys/vkey", API_VERSION))
+                web::resource(format!("/{}/keys/vkey", PYTHON_API_VERSION))
                     .route(web::post().to(keys_handler::v_key)),
             )
             .service(
-                web::resource(format!("/{}/keys/pubkey", API_VERSION))
+                web::resource(format!("/{}/keys/pubkey", PYTHON_API_VERSION))
                     .route(web::get().to(keys_handler::pubkey)),
             )
             .service(
-                web::resource(format!("/{}/quotes/identity", API_VERSION))
-                    .route(web::get().to(quotes_handler::identity)),
+                web::resource(format!(
+                    "/{}/quotes/identity",
+                    PYTHON_API_VERSION
+                ))
+                .route(web::get().to(quotes_handler::identity)),
             )
             .service(
-                web::resource(format!("/{}/quotes/integrity", API_VERSION))
-                    .route(web::get().to(quotes_handler::integrity)),
+                web::resource(format!(
+                    "/{}/quotes/integrity",
+                    PYTHON_API_VERSION
+                ))
+                .route(web::get().to(quotes_handler::integrity)),
             )
             .service(
                 web::resource(format!(
                     "/{}/notifications/revocation",
-                    API_VERSION
+                    PYTHON_API_VERSION
                 ))
                 .route(web::post().to(notifications_handler::revocation)),
             )

--- a/src/notifications_handler.rs
+++ b/src/notifications_handler.rs
@@ -50,7 +50,7 @@ pub async fn revocation(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::{KeylimeConfig, API_VERSION};
+    use crate::common::{KeylimeConfig, PYTHON_API_VERSION};
     use actix_web::{test, web, App};
     use serde_json::json;
     use std::{fs, path::Path};
@@ -72,7 +72,7 @@ mod tests {
 
         let mut app =
             test::init_service(App::new().app_data(quotedata.clone()).route(
-                &format!("/{}/notifications/revocation", API_VERSION),
+                &format!("/{}/notifications/revocation", PYTHON_API_VERSION),
                 web::post().to(revocation),
             ))
             .await;
@@ -92,7 +92,9 @@ mod tests {
         };
 
         let req = test::TestRequest::post()
-            .uri(&format!("/{}/notifications/revocation", API_VERSION,))
+            .uri(
+                &format!("/{}/notifications/revocation", PYTHON_API_VERSION,),
+            )
             .set_json(&revocation)
             .to_request();
 

--- a/src/quotes_handler.rs
+++ b/src/quotes_handler.rs
@@ -304,7 +304,7 @@ mod tests {
         let quotedata = web::Data::new(QuoteData::fixture().unwrap()); //#[allow_ci]
         let mut app =
             test::init_service(App::new().app_data(quotedata.clone()).route(
-                &format!("/{}/quotes/identity", API_VERSION),
+                &format!("/{}/quotes/identity", PYTHON_API_VERSION),
                 web::get().to(identity),
             ))
             .await;
@@ -312,7 +312,7 @@ mod tests {
         let req = test::TestRequest::get()
             .uri(&format!(
                 "/{}/quotes/identity?nonce=1234567890ABCDEFHIJ",
-                API_VERSION,
+                PYTHON_API_VERSION,
             ))
             .to_request();
 
@@ -343,7 +343,7 @@ mod tests {
         let quotedata = web::Data::new(QuoteData::fixture().unwrap()); //#[allow_ci]
         let mut app =
             test::init_service(App::new().app_data(quotedata.clone()).route(
-                &format!("/{}/quotes/integrity", API_VERSION),
+                &format!("/{}/quotes/integrity", PYTHON_API_VERSION),
                 web::get().to(integrity),
             ))
             .await;
@@ -351,7 +351,7 @@ mod tests {
         let req = test::TestRequest::get()
             .uri(&format!(
                 "/{}/quotes/integrity?nonce=1234567890ABCDEFHIJ&mask=0x408000&vmask=0x808000&partial=0",
-                API_VERSION,
+                PYTHON_API_VERSION,
             ))
             .to_request();
 
@@ -387,7 +387,7 @@ mod tests {
         let quotedata = web::Data::new(QuoteData::fixture().unwrap()); //#[allow_ci]
         let mut app =
             test::init_service(App::new().app_data(quotedata.clone()).route(
-                &format!("/{}/quotes/integrity", API_VERSION),
+                &format!("/{}/quotes/integrity", PYTHON_API_VERSION),
                 web::get().to(integrity),
             ))
             .await;
@@ -395,7 +395,7 @@ mod tests {
         let req = test::TestRequest::get()
             .uri(&format!(
                 "/{}/quotes/integrity?nonce=1234567890ABCDEFHIJ&mask=0x408000&vmask=0x808000&partial=1",
-                API_VERSION,
+                PYTHON_API_VERSION,
             ))
             .to_request();
 

--- a/src/registrar_agent.rs
+++ b/src/registrar_agent.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 
-use crate::common::API_VERSION;
+use crate::common::PYTHON_API_VERSION;
 use crate::serialization::*;
 use log::*;
 use openssl::x509::X509;
@@ -62,7 +62,7 @@ pub(crate) async fn do_activate_agent(
     #[cfg(not(test))]
     let addr = format!(
         "http://{}:{}/{}/agents/{}",
-        registrar_ip, registrar_port, API_VERSION, agent_uuid
+        registrar_ip, registrar_port, PYTHON_API_VERSION, agent_uuid
     );
 
     info!(
@@ -113,7 +113,7 @@ pub(crate) async fn do_register_agent(
     #[cfg(not(test))]
     let addr = format!(
         "http://{}:{}/{}/agents/{}",
-        registrar_ip, registrar_port, API_VERSION, agent_uuid
+        registrar_ip, registrar_port, PYTHON_API_VERSION, agent_uuid
     );
 
     info!(


### PR DESCRIPTION
Since the Rust agent and Python components can and have diverged
by a minor version, the handlers should expect the API version of
the Python components, not the API version of the Rust agent.

Related to #340, but does not fix it until a change goes in on the Python side as well.

Is there some better method to make sure the `PYTHON_API_VERSION` stays in sync with the Python repo's API version, other than manually? I can't think of one.