### PR TITLE
Revert API version to 2.0

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 /*
  * Constants and static variables
  */
-pub const API_VERSION: &str = "v2.1";
+pub const API_VERSION: &str = "v2.0";
 pub const STUB_VTPM: bool = false;
 pub const STUB_IMA: bool = true;
 pub const TPM_DATA_PCR: usize = 16;


### PR DESCRIPTION
It was updated to 2.1 based on Keylime enhancement #53
(agent-local revocation), but this broke communication
with the Python components. We have [decided](https://github.com/keylime/keylime/pull/907) that the
Rust agent should not have its own API version, but
rather follow API versioning from the Python components.

Signed-off-by: Lily Sturmann <lsturman@redhat.com>