### PR TITLE
Use shared JSON wrapper for HTTP responses

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::env;
 use std::ffi::CString;
+use std::fmt::Debug;
 use std::fs::File;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
@@ -66,6 +67,26 @@ cfg_if::cfg_if! {
 
         pub(crate) fn ima_ml_path_get() -> PathBuf {
             Path::new(IMA_ML).to_path_buf()
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct JsonWrapper<A> {
+    pub code: u32,
+    pub status: String,
+    pub results: A,
+}
+
+impl<'de, A> JsonWrapper<A>
+where
+    A: Deserialize<'de> + Serialize + Debug,
+{
+    pub(crate) fn new(results: A) -> JsonWrapper<A> {
+        JsonWrapper {
+            code: 200,
+            status: String::from("Success"),
+            results,
         }
     }
 }

--- a/src/notifications_handler.rs
+++ b/src/notifications_handler.rs
@@ -13,13 +13,6 @@ struct KeylimeRevocation {
     signature: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-struct JsonRevocationWrapper {
-    code: u32,
-    status: String,
-    results: KeylimeRevocation,
-}
-
 // This is Revocation request from the cloud verifier via REST API
 pub async fn revocation(
     body: web::Bytes,

--- a/src/version_handler.rs
+++ b/src/version_handler.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 Keylime Authors
 
-use crate::common::API_VERSION;
+use crate::common::{JsonWrapper, API_VERSION};
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use log::*;
 use serde::{Deserialize, Serialize};
@@ -9,23 +9,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug)]
 struct KeylimeVersion {
     supported_version: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct JsonVersionWrapper {
-    code: u32,
-    status: String,
-    results: KeylimeVersion,
-}
-
-impl JsonVersionWrapper {
-    fn new(results: KeylimeVersion) -> Self {
-        JsonVersionWrapper {
-            code: 200,
-            status: String::from("Success"),
-            results,
-        }
-    }
 }
 
 // This is the handler for the GET request for the API version
@@ -36,7 +19,7 @@ pub async fn version(req: HttpRequest) -> impl Responder {
         req.uri()
     );
 
-    let response = JsonVersionWrapper::new(KeylimeVersion {
+    let response = JsonWrapper::new(KeylimeVersion {
         supported_version: API_VERSION[1..].to_string(),
     });
 
@@ -61,7 +44,8 @@ mod tests {
         let resp = test::call_service(&mut app, req).await;
         assert!(resp.status().is_success());
 
-        let body: JsonVersionWrapper = test::read_body_json(resp).await;
+        let body: JsonWrapper<KeylimeVersion> =
+            test::read_body_json(resp).await;
         assert_eq!(body.results.supported_version, API_VERSION[1..]);
     }
 }


### PR DESCRIPTION
Use a generic JSON wrapper implementation for HTTP responses instead of implementing a specific wrapper for each JSON content.

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>