### PR TITLE
Add API to verify derived key

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -549,6 +549,10 @@ async fn main() -> Result<()> {
                 web::resource("/version".to_string())
                     .route(web::get().to(version_handler::version)),
             )
+            .service(
+                web::resource(format!("/{}/keys/verify", API_VERSION))
+                    .route(web::get().to(keys_handler::verify)),
+            )
     })
     .bind_openssl(
         format!("{}:{}", config.agent_ip, config.agent_port),


### PR DESCRIPTION
Add the handler to the agent for GET requests to '/keys/verify' endpoint.

The handler expects the 'challenge' parameter as 20 alphanumeric characters string and responds with a JSON structure containing the resulting hex-encoded HMAC-SHA384 calculated using the symmetric key derived from U and V keys and the challenge as the input.

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>