### PR TITLE
keys_handler: Fix test for 256-bits keys

### DIFF
--- a/src/keys_handler.rs
+++ b/src/keys_handler.rs
@@ -339,7 +339,7 @@ mod tests {
     #[cfg(feature = "testing")]
     #[actix_rt::test]
     async fn test_u_or_v_key_long() {
-        test_u_or_v_key(AES_128_KEY_LEN, None).await;
+        test_u_or_v_key(AES_256_KEY_LEN, None).await;
     }
 
     #[cfg(feature = "testing")]


### PR DESCRIPTION
The test_u_or_v_key_long() was using a 128 bits long key instead of 256
bits.

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>