### PR TITLE
Simplify integrity quotes structures

### DIFF
--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -59,6 +59,8 @@ use tss_esapi::{
     Context,
 };
 
+pub const MAX_NONCE_SIZE: usize = 64;
+
 /*
  * Input: None
  * Return: Connection context


### PR DESCRIPTION
Unify `KeylimeIdQuote`, `KeylimeIntegrityQuotePreAttestation`, and `KeylimeIntegrityQuotePostAttestation` structures into the single `KeylimeQuote` structure, using `Option` for optional fields.