### PR TITLE
Use JSON wrapper on error responses

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -6,6 +6,7 @@ use crate::error::{Error, Result};
 use ini::Ini;
 use log::*;
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 use std::convert::TryFrom;
 use std::env;
 use std::ffi::CString;
@@ -76,6 +77,16 @@ pub(crate) struct JsonWrapper<A> {
     pub code: u32,
     pub status: String,
     pub results: A,
+}
+
+impl JsonWrapper<Value> {
+    pub(crate) fn bad_request(status: String) -> JsonWrapper<Value> {
+        JsonWrapper {
+            code: 400,
+            status,
+            results: json!({}),
+        }
+    }
 }
 
 impl<'de, A> JsonWrapper<A>

--- a/src/keys_handler.rs
+++ b/src/keys_handler.rs
@@ -222,16 +222,18 @@ pub async fn verify(
             "GET key challenge returning 400 response. No challenge provided"
         );
         return HttpResponse::BadRequest()
-            .body("No challenge provided.".to_string())
+            .json(JsonWrapper::bad_request(
+                "No challenge provided.".to_string(),
+            ))
             .await;
     }
 
     if !param.challenge.chars().all(char::is_alphanumeric) {
         return HttpResponse::BadRequest()
-            .body(format!(
+            .json(JsonWrapper::bad_request(format!(
                 "Parameters should be strictly alphanumeric: {}",
                 param.challenge
-            ))
+            )))
             .await;
     }
 
@@ -241,7 +243,9 @@ pub async fn verify(
     if key.is_none() {
         info!("GET key challenge returning 400 response. bootstrap key not available");
         return HttpResponse::BadRequest()
-            .body("Bootstrap key not yet available.".to_string())
+            .json(JsonWrapper::bad_request(
+                "Bootstrap key not yet available.".to_string(),
+            ))
             .await;
     }
 

--- a/src/quotes_handler.rs
+++ b/src/quotes_handler.rs
@@ -55,10 +55,10 @@ pub async fn identity(
     if !param.nonce.chars().all(char::is_alphanumeric) {
         warn!("Get quote returning 400 response. Parameters should be strictly alphanumeric");
         return HttpResponse::BadRequest()
-            .body(format!(
+            .json(JsonWrapper::bad_request(format!(
                 "Parameters should be strictly alphanumeric: {}",
                 param.nonce
-            ))
+            )))
             .await;
     }
 
@@ -68,11 +68,11 @@ pub async fn identity(
               param.nonce.len()
         );
         return HttpResponse::BadRequest()
-            .body(format!(
+            .json(JsonWrapper::bad_request(format!(
                 "Nonce is too long (max size {}): {}",
                 tpm::MAX_NONCE_SIZE,
                 param.nonce
-            ))
+            )))
             .await;
     }
 
@@ -113,20 +113,20 @@ pub async fn integrity(
     if !param.nonce.chars().all(char::is_alphanumeric) {
         warn!("Get quote returning 400 response. Parameters should be strictly alphanumeric");
         return HttpResponse::BadRequest()
-            .body(format!(
+            .json(JsonWrapper::bad_request(format!(
                 "nonce should be strictly alphanumeric: {}",
                 param.nonce
-            ))
+            )))
             .await;
     }
 
     if !param.mask.chars().all(char::is_alphanumeric) {
         warn!("Get quote returning 400 response. Parameters should be strictly alphanumeric");
         return HttpResponse::BadRequest()
-            .body(format!(
+            .json(JsonWrapper::bad_request(format!(
                 "mask should be strictly alphanumeric: {}",
                 param.mask
-            ))
+            )))
             .await;
     }
 
@@ -136,11 +136,11 @@ pub async fn integrity(
               param.nonce.len()
         );
         return HttpResponse::BadRequest()
-            .body(format!(
+            .json(JsonWrapper::bad_request(format!(
                 "Nonce is too long (max size: {}): {}",
                 tpm::MAX_NONCE_SIZE,
                 param.nonce.len()
-            ))
+            )))
             .await;
     }
 
@@ -158,7 +158,10 @@ pub async fn integrity(
         _ => {
             warn!("Get quote returning 400 response. uri must contain key 'partial' and value '0' or '1'");
             return HttpResponse::BadRequest()
-                .body("uri must contain key 'partial' and value '0' or '1'")
+                .json(JsonWrapper::bad_request(
+                    "uri must contain key 'partial' and value '0' or '1'"
+                        .to_string(),
+                ))
                 .await;
         }
     };


### PR DESCRIPTION
The response for requests should always be wrapped in the JSON structure, including in error cases.
    
Without this, the rust agent returns malformed responses on error cases, advertising `content-type: application/json` on the header, but sending plaintext on the body, which caused JSON parsing errors.

This was found during implementation of https://github.com/keylime/keylime/pull/947.