### PR TITLE
Rename JSON wrapper methods

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -93,7 +93,7 @@ impl<'de, A> JsonWrapper<A>
 where
     A: Deserialize<'de> + Serialize + Debug,
 {
-    pub(crate) fn new(results: A) -> JsonWrapper<A> {
+    pub(crate) fn success(results: A) -> JsonWrapper<A> {
         JsonWrapper {
             code: 200,
             status: String::from("Success"),

--- a/src/common.rs
+++ b/src/common.rs
@@ -80,9 +80,9 @@ pub(crate) struct JsonWrapper<A> {
 }
 
 impl JsonWrapper<Value> {
-    pub(crate) fn bad_request(status: String) -> JsonWrapper<Value> {
+    pub(crate) fn error(code: u32, status: String) -> JsonWrapper<Value> {
         JsonWrapper {
-            code: 400,
+            code,
             status,
             results: json!({}),
         }

--- a/src/keys_handler.rs
+++ b/src/keys_handler.rs
@@ -222,7 +222,8 @@ pub async fn verify(
             "GET key challenge returning 400 response. No challenge provided"
         );
         return HttpResponse::BadRequest()
-            .json(JsonWrapper::bad_request(
+            .json(JsonWrapper::error(
+                400,
                 "No challenge provided.".to_string(),
             ))
             .await;
@@ -230,10 +231,13 @@ pub async fn verify(
 
     if !param.challenge.chars().all(char::is_alphanumeric) {
         return HttpResponse::BadRequest()
-            .json(JsonWrapper::bad_request(format!(
-                "Parameters should be strictly alphanumeric: {}",
-                param.challenge
-            )))
+            .json(JsonWrapper::error(
+                400,
+                format!(
+                    "Parameters should be strictly alphanumeric: {}",
+                    param.challenge
+                ),
+            ))
             .await;
     }
 
@@ -243,7 +247,8 @@ pub async fn verify(
     if key.is_none() {
         info!("GET key challenge returning 400 response. bootstrap key not available");
         return HttpResponse::BadRequest()
-            .json(JsonWrapper::bad_request(
+            .json(JsonWrapper::error(
+                400,
                 "Bootstrap key not yet available.".to_string(),
             ))
             .await;

--- a/src/keys_handler.rs
+++ b/src/keys_handler.rs
@@ -200,7 +200,7 @@ pub async fn pubkey(
     )
     .map_err(Error::from)?;
 
-    let response = JsonWrapper::new(KeylimePubkey { pubkey });
+    let response = JsonWrapper::success(KeylimePubkey { pubkey });
     info!("GET pubkey returning 200 response.");
 
     HttpResponse::Ok().json(response).await
@@ -257,7 +257,7 @@ pub async fn verify(
     let key = key.as_ref().unwrap(); //#[allow_ci]
     let hmac = crypto::compute_hmac(key.bytes(), param.challenge.as_bytes())?;
 
-    let response = JsonWrapper::new(KeylimeHMAC {
+    let response = JsonWrapper::success(KeylimeHMAC {
         hmac: hex::encode(hmac),
     });
 

--- a/src/quotes_handler.rs
+++ b/src/quotes_handler.rs
@@ -55,10 +55,13 @@ pub async fn identity(
     if !param.nonce.chars().all(char::is_alphanumeric) {
         warn!("Get quote returning 400 response. Parameters should be strictly alphanumeric");
         return HttpResponse::BadRequest()
-            .json(JsonWrapper::bad_request(format!(
-                "Parameters should be strictly alphanumeric: {}",
-                param.nonce
-            )))
+            .json(JsonWrapper::error(
+                400,
+                format!(
+                    "Parameters should be strictly alphanumeric: {}",
+                    param.nonce
+                ),
+            ))
             .await;
     }
 
@@ -68,11 +71,14 @@ pub async fn identity(
               param.nonce.len()
         );
         return HttpResponse::BadRequest()
-            .json(JsonWrapper::bad_request(format!(
-                "Nonce is too long (max size {}): {}",
-                tpm::MAX_NONCE_SIZE,
-                param.nonce
-            )))
+            .json(JsonWrapper::error(
+                400,
+                format!(
+                    "Nonce is too long (max size {}): {}",
+                    tpm::MAX_NONCE_SIZE,
+                    param.nonce
+                ),
+            ))
             .await;
     }
 
@@ -113,20 +119,26 @@ pub async fn integrity(
     if !param.nonce.chars().all(char::is_alphanumeric) {
         warn!("Get quote returning 400 response. Parameters should be strictly alphanumeric");
         return HttpResponse::BadRequest()
-            .json(JsonWrapper::bad_request(format!(
-                "nonce should be strictly alphanumeric: {}",
-                param.nonce
-            )))
+            .json(JsonWrapper::error(
+                400,
+                format!(
+                    "nonce should be strictly alphanumeric: {}",
+                    param.nonce
+                ),
+            ))
             .await;
     }
 
     if !param.mask.chars().all(char::is_alphanumeric) {
         warn!("Get quote returning 400 response. Parameters should be strictly alphanumeric");
         return HttpResponse::BadRequest()
-            .json(JsonWrapper::bad_request(format!(
-                "mask should be strictly alphanumeric: {}",
-                param.mask
-            )))
+            .json(JsonWrapper::error(
+                400,
+                format!(
+                    "mask should be strictly alphanumeric: {}",
+                    param.mask
+                ),
+            ))
             .await;
     }
 
@@ -136,11 +148,14 @@ pub async fn integrity(
               param.nonce.len()
         );
         return HttpResponse::BadRequest()
-            .json(JsonWrapper::bad_request(format!(
-                "Nonce is too long (max size: {}): {}",
-                tpm::MAX_NONCE_SIZE,
-                param.nonce.len()
-            )))
+            .json(JsonWrapper::error(
+                400,
+                format!(
+                    "Nonce is too long (max size: {}): {}",
+                    tpm::MAX_NONCE_SIZE,
+                    param.nonce.len()
+                ),
+            ))
             .await;
     }
 
@@ -158,7 +173,8 @@ pub async fn integrity(
         _ => {
             warn!("Get quote returning 400 response. uri must contain key 'partial' and value '0' or '1'");
             return HttpResponse::BadRequest()
-                .json(JsonWrapper::bad_request(
+                .json(JsonWrapper::error(
+                    400,
                     "uri must contain key 'partial' and value '0' or '1'"
                         .to_string(),
                 ))

--- a/src/quotes_handler.rs
+++ b/src/quotes_handler.rs
@@ -94,7 +94,7 @@ pub async fn identity(
         .map_err(KeylimeError::from)?,
     );
 
-    let response = JsonWrapper::new(quote);
+    let response = JsonWrapper::success(quote);
     info!("GET identity quote returning 200 response");
     HttpResponse::Ok().json(response).await
 }
@@ -229,7 +229,7 @@ pub async fn integrity(
         ..id_quote
     };
 
-    let response = JsonWrapper::new(quote);
+    let response = JsonWrapper::success(quote);
     info!("GET integrity quote returning 200 response");
     HttpResponse::Ok().json(response).await
 }

--- a/src/version_handler.rs
+++ b/src/version_handler.rs
@@ -19,7 +19,7 @@ pub async fn version(req: HttpRequest) -> impl Responder {
         req.uri()
     );
 
-    let response = JsonWrapper::new(KeylimeVersion {
+    let response = JsonWrapper::success(KeylimeVersion {
         supported_version: API_VERSION[1..].to_string(),
     });
 


### PR DESCRIPTION
Rename `JsonWrapper::new` as `JsonWrapper::success` to clarify the purpose which is to wrap the content with the JSON structure with success status code.

Also replace `JsonWrapper::bad_request` with `JsonWrapper::error` which receives the error status code as a parameter, allowing wrapping the error message with different error status codes.