### PR TITLE
Drop privileges after startup

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -26,6 +26,8 @@ install: build
 	install -D -t ${DESTDIR}/usr/bin "${TARGETDIR}/${PROFILE}/keylime_ima_emulator"
 	install -D -m 644 -t ${DESTDIR}$(systemdsystemunitdir) dist/systemd/system/keylime_agent.service
 	install -D -m 644 -t ${DESTDIR}$(systemdsystemunitdir) dist/systemd/system/var-lib-keylime-secure.mount
+	# Remove when https://github.com/keylime/rust-keylime/issues/325 is fixed
+	install -D -t ${DESTDIR}/usr/libexec/keylime tests/actions/shim.py
 
 # This only runs tests without TPM access. See tests/run.sh for
 # running full testsuite with swtpm.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,6 +25,7 @@ install: build
 	install -D -t ${DESTDIR}/usr/bin "${TARGETDIR}/${PROFILE}/keylime_agent"
 	install -D -t ${DESTDIR}/usr/bin "${TARGETDIR}/${PROFILE}/keylime_ima_emulator"
 	install -D -m 644 -t ${DESTDIR}$(systemdsystemunitdir) dist/systemd/system/keylime_agent.service
+	install -D -m 644 -t ${DESTDIR}$(systemdsystemunitdir) dist/systemd/system/var-lib-keylime-secure.mount
 
 # This only runs tests without TPM access. See tests/run.sh for
 # running full testsuite with swtpm.

--- a/dist/systemd/system/keylime_agent.service
+++ b/dist/systemd/system/keylime_agent.service
@@ -1,15 +1,25 @@
 [Unit]
 Description=The Keylime compute agent
+StartLimitInterval=10s
+StartLimitBurst=5
+Requires=var-lib-keylime-secure.mount
+After=var-lib-keylime-secure.mount
+Wants=tpm2-abrmd.service
+After=tpm2-abrmd.service
+# If the service should start only when hardware TPMs are available, uncomment the below lines
+#ConditionPathExistsGlob=/dev/tpm[0-9]*
+#ConditionPathExistsGlob=/dev/tpmrm[0-9]*
 
 [Service]
-# To run the agent as a non-root user, setup the environment following
-# the procedure at:
-# https://github.com/keylime/keylime/blob/master/agent_non_root_condition.sh
-# and uncomment the following lines:
-# User=keylime
-# Group=tss
 ExecStart=/usr/bin/keylime_agent
 KillSignal=SIGINT
+TimeoutSec=60s
+Restart=on-failure
+RestartSec=120s
+Environment="RUST_LOG=keylime_agent=info"
+# If using swtpm with tpm2-abrmd service, uncomment the line below to set TCTI
+# variable on the service environment
+#Environment="TCTI=tabrmd:"
 
 [Install]
 WantedBy=default.target

--- a/dist/systemd/system/var-lib-keylime-secure.mount
+++ b/dist/systemd/system/var-lib-keylime-secure.mount
@@ -1,0 +1,12 @@
+[Unit]
+Description=Keylime configuration filesystem
+Before=keylime_agent.service
+
+[Mount]
+What=tmpfs
+Where=/var/lib/keylime/secure
+Type=tmpfs
+Options=mode=0700,size=1m,uid=keylime,gid=tss
+
+[Install]
+WantedBy=multi-user.target

--- a/src/common.rs
+++ b/src/common.rs
@@ -224,8 +224,6 @@ pub(crate) struct KeylimeConfig {
     pub revocation_actions_dir: String,
     pub allow_payload_revocation_actions: bool,
     pub work_dir: String,
-    pub ima_ml_path: String,
-    pub measuredboot_ml_path: String,
     pub mtls_enabled: bool,
     pub enable_insecure_payload: bool,
 }
@@ -323,8 +321,6 @@ impl KeylimeConfig {
             Ok(s) => bool::from_str(&s.to_lowercase())?,
             Err(_) => ALLOW_PAYLOAD_REV_ACTIONS,
         };
-        let ima_ml_path = ima_ml_path_get();
-        let measuredboot_ml_path = Path::new(MEASUREDBOOT_ML).to_path_buf();
 
         let mtls_enabled =
             match config_get("cloud_agent", "mtls_cert_enabled") {
@@ -367,8 +363,6 @@ impl KeylimeConfig {
             revocation_actions_dir,
             allow_payload_revocation_actions,
             work_dir,
-            ima_ml_path: ima_ml_path.display().to_string(),
-            measuredboot_ml_path: measuredboot_ml_path.display().to_string(),
             mtls_enabled,
             enable_insecure_payload,
         })
@@ -409,8 +403,6 @@ impl Default for KeylimeConfig {
             revocation_actions_dir: "/usr/libexec/keylime".to_string(),
             allow_payload_revocation_actions: true,
             work_dir: WORK_DIR.to_string(),
-            ima_ml_path: IMA_ML.to_string(),
-            measuredboot_ml_path: MEASUREDBOOT_ML.to_string(),
             mtls_enabled: true,
             enable_insecure_payload: false,
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -13,7 +13,6 @@ use std::env;
 use std::ffi::CString;
 use std::fmt::Debug;
 use std::fs::File;
-use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use tss_esapi::{structures::PcrSlot, utils::TpmsContext};
@@ -572,33 +571,6 @@ fn config_get_env(section: &str, key: &str, env: &str) -> Result<String> {
             }
         }
         _ => config_get(section, key),
-    }
-}
-
-/*
- * Input: path directory to be changed owner to root
- *
- * If privilege requirement is met, change the owner of the path to root
- * This function is unsafely using libc. Result is returned indicating
- * execution result.
- */
-pub(crate) fn chownroot(path: &Path) -> Result<()> {
-    unsafe {
-        // check privilege
-        if libc::geteuid() != 0 {
-            error!("Privilege level unable to change ownership to root for file: {:?}", &path);
-            return Err(Error::Permission);
-        }
-
-        // change directory owner to root
-        let c_path = CString::new(path.as_os_str().as_bytes())?;
-        if libc::chown(c_path.as_ptr(), 0, 0) != 0 {
-            error!("Failed to change file {:?} owner.", &path);
-            return Err(Error::Permission);
-        }
-
-        info!("Changed file {:?} owner to root.", &path);
-        Ok(())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,8 @@ pub(crate) enum Error {
     Infallible(#[from] std::convert::Infallible),
     #[error("Compress tools error: {0}")]
     CompressTools(#[from] compress_tools::Error),
+    #[error("Conversion error: {0}")]
+    Conversion(String),
     #[error("Configuration error: {0}")]
     Configuration(String),
     #[error("Reqwest error: {0}")]

--- a/src/keys_handler.rs
+++ b/src/keys_handler.rs
@@ -280,13 +280,22 @@ mod tests {
     };
     use std::env;
     use std::fs;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
     #[cfg(feature = "testing")]
     async fn test_u_or_v_key(key_len: usize, payload: Option<&[u8]>) {
         let test_config = KeylimeConfig::default();
-        let quotedata = web::Data::new(QuoteData::fixture().unwrap()); //#[allow_ci]
+        let mut fixture = QuoteData::fixture().unwrap(); //#[allow_ci]
+
+        // Create temporary working directory and secure mount
+        let temp_workdir = tempfile::tempdir().unwrap(); //#[allow_ci]
+        fixture.secure_mount =
+            PathBuf::from(&temp_workdir.path().join("tmpfs-dev"));
+        fs::create_dir(&fixture.secure_mount).unwrap(); //#[allow_ci]
+
+        let quotedata = web::Data::new(fixture);
+
         let mut app = test::init_service(
             App::new()
                 .app_data(quotedata.clone())
@@ -308,18 +317,20 @@ mod tests {
             Arc::clone(&quotedata.payload_symm_key_cvar);
         let encr_payload_clone = Arc::clone(&quotedata.encr_payload);
         let test_config_clone = test_config.clone();
+        let secure_mount = PathBuf::from(&quotedata.secure_mount);
 
         assert!(arbiter.spawn(Box::pin(async move {
-            if crate::run_encrypted_payload(
+            let result = crate::run_encrypted_payload(
                 payload_symm_key_clone,
                 payload_symm_key_cvar_clone,
                 encr_payload_clone,
                 &test_config_clone,
+                &secure_mount,
             )
-            .await
-            .is_err()
-            {
-                debug!("payload run failed");
+            .await;
+
+            if result.is_err() {
+                debug!("payload run failed: {:?}", result);
             }
             if !Arbiter::current().stop() {
                 debug!("couldn't stop current arbiter");

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,7 +226,7 @@ pub(crate) fn optional_unzip_payload(
         info!("Unzipping payload {} to {:?}", &zipped_payload, unzipped);
 
         let mut source = fs::File::open(&zipped_payload_path)?;
-        uncompress_archive(&mut source, unzipped, Ownership::Preserve)?;
+        uncompress_archive(&mut source, unzipped, Ownership::Ignore)?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ mod errors_handler;
 mod ima;
 mod keys_handler;
 mod notifications_handler;
+mod permissions;
 mod quotes_handler;
 mod registrar_agent;
 mod revocation;
@@ -404,6 +405,12 @@ async fn main() -> Result<()> {
 
     let work_dir = Path::new(&config.work_dir);
     let mount = secure_mount::mount(work_dir, &config.secure_size)?;
+
+    // Drop privileges
+    if let Some(user_group) = &config.run_as {
+        permissions::chown(user_group, &mount);
+        permissions::run_as(user_group);
+    }
 
     info!("Starting server with API version {}...", API_VERSION);
 

--- a/src/notifications_handler.rs
+++ b/src/notifications_handler.rs
@@ -27,7 +27,8 @@ pub async fn revocation(
     let revocation_actions = &data.revocation_actions;
     let actions_dir = PathBuf::from(&data.revocation_actions_dir);
     let payload_actions_allowed = data.allow_payload_revocation_actions;
-    let work_dir = PathBuf::from(&data.work_dir);
+    let work_dir = &data.work_dir;
+    let mount = &data.secure_mount;
 
     let result = revocation::process_revocation(
         json_body,
@@ -36,7 +37,8 @@ pub async fn revocation(
         revocation_actions,
         &actions_dir,
         payload_actions_allowed,
-        &work_dir,
+        work_dir,
+        mount,
     )?;
 
     HttpResponse::Ok().await

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
+use crate::error::{Error, Result};
+use libc::{gid_t, uid_t};
+use log::*;
+use std::os::unix::ffi::OsStrExt;
+use std::{
+    convert::{TryFrom, TryInto},
+    ffi::CString,
+    io,
+    path::Path,
+    ptr,
+};
+
+#[derive(Debug)]
+pub(crate) struct UserIds {
+    uid: uid_t,
+    gid: gid_t,
+}
+
+pub(crate) fn get_gid() -> gid_t {
+    unsafe { libc::getgid() }
+}
+
+pub(crate) fn get_uid() -> uid_t {
+    unsafe { libc::getuid() }
+}
+
+pub(crate) fn get_euid() -> uid_t {
+    unsafe { libc::geteuid() }
+}
+
+impl TryFrom<&str> for UserIds {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self> {
+        let parts = value.split(':').collect::<Vec<&str>>();
+
+        if parts.len() != 2 {
+            let e = format!("Invalid parameter format: {} cannot be parsed as 'user:group'", value);
+            error!("{}", e);
+            return Err(Error::Conversion(e));
+        }
+
+        let user = parts[0];
+        let group = parts[1];
+
+        // Get gid from group name
+        let gid = if let Ok(g_cstr) = CString::new(group.as_bytes()) {
+            let p = unsafe { libc::getgrnam(g_cstr.as_ptr()) };
+            if p.is_null() {
+                let e = io::Error::last_os_error();
+                error!("Could not get group {}: {}", group, e);
+                return Err(Error::Conversion(e.to_string()));
+            }
+            unsafe { (*p).gr_gid }
+        } else {
+            return Err(Error::Conversion(format!(
+                "Failed to convert {} to CString",
+                group
+            )));
+        };
+
+        // Get uid from user name
+        let uid = if let Ok(u_cstr) = CString::new(user.as_bytes()) {
+            let p = unsafe { libc::getpwnam(u_cstr.as_ptr()) };
+            if p.is_null() {
+                let e = io::Error::last_os_error();
+                error!("Could not get user {}: {}", user, e);
+                return Err(Error::Conversion(e.to_string()));
+            }
+            unsafe { (*p).pw_uid }
+        } else {
+            return Err(Error::Conversion(format!(
+                "Failed to convert {} to CString",
+                user
+            )));
+        };
+
+        Ok(UserIds { uid, gid })
+    }
+}
+
+// Drop the process privileges and run under the provided user and group.  The correct order of
+// operations are: drop supplementary groups, set gid, then set uid.
+// See: POS36-C and CWE-696
+pub(crate) fn run_as(user_group: &str) -> Result<()> {
+    let ids: UserIds = user_group.try_into()?;
+
+    // Drop supplementary groups
+    if unsafe { libc::setgroups(0, ptr::null()) } != 0 {
+        let e = io::Error::last_os_error();
+        error!("Could not drop supplementary groups: {}", e);
+        return Err(Error::Permission);
+    }
+
+    // Set gid
+    if unsafe { libc::setgid(ids.gid) } != 0 {
+        let e = io::Error::last_os_error();
+        error!("Could not set group id: {}", e);
+        return Err(Error::Permission);
+    }
+
+    // Set uid
+    if unsafe { libc::setuid(ids.uid) } != 0 {
+        let e = io::Error::last_os_error();
+        error!("Could not set user id: {}", e);
+        return Err(Error::Permission);
+    }
+
+    info!("Dropped privileges to run as {}", user_group);
+
+    Ok(())
+}
+
+pub(crate) fn chown(user_group: &str, path: &Path) -> Result<()> {
+    let ids: UserIds = user_group.try_into()?;
+
+    // check privilege
+    if get_euid() != 0 {
+        error!(
+            "Privilege level unable to change file {} ownership",
+            path.display()
+        );
+        return Err(Error::Permission);
+    }
+
+    // change directory owner to root
+    let c_path = CString::new(path.as_os_str().as_bytes())?;
+    if unsafe { libc::chown(c_path.as_ptr(), ids.uid, ids.gid) } != 0 {
+        error!("Failed to change file {} owner.", path.display());
+        return Err(Error::Permission);
+    }
+
+    info!("Changed file {} owner to {}.", path.display(), user_group);
+    Ok(())
+}

--- a/src/quotes_handler.rs
+++ b/src/quotes_handler.rs
@@ -10,7 +10,10 @@ use crate::serialization::serialize_maybe_base64;
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use log::*;
 use serde::{Deserialize, Serialize};
-use std::fs::{read, read_to_string};
+use std::{
+    fs::{read, read_to_string},
+    io::{Read, Seek},
+};
 use tss_esapi::structures::PcrSlot;
 
 #[derive(Deserialize)]
@@ -211,16 +214,16 @@ pub async fn integrity(
     let mut mb_measurement_list = None;
     match tpm::check_mask(&param.mask, &PcrSlot::Slot0) {
         Ok(true) => {
-            let measuredboot_ml = read(&data.measuredboot_ml_path);
-            mb_measurement_list = match measuredboot_ml {
-                Ok(ml) => Some(base64::encode(ml)),
-                Err(e) => {
-                    warn!(
-                        "TPM2 event log not available: {}",
-                        data.measuredboot_ml_path.display()
-                    );
-                    None
-                }
+            if let Some(measuredboot_ml_file) = &data.measuredboot_ml_file {
+                let mut ml = Vec::<u8>::new();
+                let mut f = measuredboot_ml_file.lock().unwrap(); //#[allow_ci]
+                mb_measurement_list = match f.read_to_end(&mut ml) {
+                    Ok(_) => Some(base64::encode(ml)),
+                    Err(e) => {
+                        warn!("Could not read TPM2 event log: {}", e);
+                        None
+                    }
+                };
             }
         }
         Err(e) => {
@@ -236,23 +239,26 @@ pub async fn integrity(
     }
 
     // Generate the measurement list
-    let ima_ml_path = &data.ima_ml_path;
     let (ima_measurement_list, ima_measurement_list_entry, num_entries) =
-        match read_measurement_list(
-            &mut data.ima_ml.lock().unwrap(), //#[allow_ci]
-            ima_ml_path,
-            nth_entry,
-        ) {
-            Ok(result) => result,
-            Err(e) => {
-                debug!("Unable to read measurement list: {:?}", e);
-                return HttpResponse::InternalServerError().json(
-                    JsonWrapper::error(
-                        500,
-                        "Unable to retrieve quote".to_string(),
-                    ),
-                );
+        if let Some(ima_file) = &data.ima_ml_file {
+            match read_measurement_list(
+                &mut data.ima_ml.lock().unwrap(), //#[allow_ci]
+                &mut ima_file.lock().unwrap(),    //#[allow_ci]
+                nth_entry,
+            ) {
+                Ok(result) => result,
+                Err(e) => {
+                    debug!("Unable to read measurement list: {:?}", e);
+                    return HttpResponse::InternalServerError().json(
+                        JsonWrapper::error(
+                            500,
+                            "Unable to retrieve quote".to_string(),
+                        ),
+                    );
+                }
             }
+        } else {
+            (None, None, None)
         };
 
     // Generate the final quote based on the ID quote
@@ -349,22 +355,32 @@ mod tests {
                 .public_eq(&quotedata.pub_key)
         );
 
-        let ima_ml_path = &quotedata.ima_ml_path;
-        let ima_ml = read_to_string(ima_ml_path).unwrap(); //#[allow_ci]
-        assert_eq!(
-            result.results.ima_measurement_list.unwrap().as_str(), //#[allow_ci]
-            ima_ml
-        );
-        assert!(result.results.quote.starts_with('r'));
+        if let Some(ima_mutex) = &quotedata.ima_ml_file {
+            let mut ima_ml_file = ima_mutex.lock().unwrap(); //#[allow_ci]
+            ima_ml_file.rewind().unwrap(); //#[allow_ci]
+            let mut ima_ml = String::new();
+            match ima_ml_file.read_to_string(&mut ima_ml) {
+                Ok(_) => {
+                    assert_eq!(
+                        result.results.ima_measurement_list.unwrap().as_str(), //#[allow_ci]
+                        ima_ml
+                    );
+                    assert!(result.results.quote.starts_with('r'));
 
-        let mut context = quotedata.tpmcontext.lock().unwrap(); //#[allow_ci]
-        tpm::testing::check_quote(
-            &mut context,
-            quotedata.ak_handle,
-            &result.results.quote,
-            b"1234567890ABCDEFHIJ",
-        )
-        .expect("unable to verify quote");
+                    let mut context = quotedata.tpmcontext.lock().unwrap(); //#[allow_ci]
+                    tpm::testing::check_quote(
+                        &mut context,
+                        quotedata.ak_handle,
+                        &result.results.quote,
+                        b"1234567890ABCDEFHIJ",
+                    )
+                    .expect("unable to verify quote");
+                }
+                Err(e) => panic!("Could not read IMA file: {}", e), //#[allow_ci]
+            }
+        } else {
+            panic!("IMA file was None"); //#[allow_ci]
+        }
     }
 
     #[actix_rt::test]
@@ -393,13 +409,23 @@ mod tests {
         assert_eq!(result.results.enc_alg.as_str(), "rsa");
         assert_eq!(result.results.sign_alg.as_str(), "rsassa");
 
-        let ima_ml_path = &quotedata.ima_ml_path;
-        let ima_ml = read_to_string(&ima_ml_path).unwrap(); //#[allow_ci]
-        assert_eq!(
-            result.results.ima_measurement_list.unwrap().as_str(), //#[allow_ci]
-            ima_ml
-        );
-        assert!(result.results.quote.starts_with('r'));
+        if let Some(ima_mutex) = &quotedata.ima_ml_file {
+            let mut ima_ml_file = ima_mutex.lock().unwrap(); //#[allow_ci]
+            ima_ml_file.rewind().unwrap(); //#[allow_ci]
+            let mut ima_ml = String::new();
+            match ima_ml_file.read_to_string(&mut ima_ml) {
+                Ok(_) => {
+                    assert_eq!(
+                        result.results.ima_measurement_list.unwrap().as_str(), //#[allow_ci]
+                        ima_ml
+                    );
+                    assert!(result.results.quote.starts_with('r'));
+                }
+                Err(e) => panic!("Could not read IMA file: {}", e), //#[allow_ci]
+            }
+        } else {
+            panic!("IMA file was None"); //#[allow_ci]
+        }
 
         let mut context = quotedata.tpmcontext.lock().unwrap(); //#[allow_ci]
         tpm::testing::check_quote(

--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -130,21 +130,6 @@ pub(crate) fn mount(work_dir: &Path, secure_size: &str) -> Result<PathBuf> {
             &secure_dir_path
         );
 
-        // change the secure path directory owner to root
-        match chownroot(&secure_dir_path) {
-            Ok(_) => {
-                info!("Changed path {:?} owner to root.", &secure_dir_path);
-            }
-            Err(e) => {
-                return Err(Error::SecureMount(
-                    format!(
-                        "unable to change secure path dir owner to root: received exit code {}",
-                        e.exe_code()?.unwrap() //#[allow_ci] : because this is an Option
-                    ),
-                ));
-            }
-        }
-
         // mount tmpfs with secure directory
         match Command::new("mount")
             .args([

--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -63,7 +63,7 @@ pub(crate) fn mount(work_dir: &Path, secure_size: &str) -> Result<PathBuf> {
     // is for development environment and does not mount to the system.
     if !MOUNT_SECURE {
         warn!("Using /tmpfs-dev (dev environment)");
-        let secure_dir_path = Path::new(work_dir).join("tmpfs-dev");
+        let secure_dir_path = work_dir.join("tmpfs-dev");
         if !secure_dir_path.exists() {
             fs::create_dir(&secure_dir_path).map_err(|e| {
                 Error::SecureMount(format!(


### PR DESCRIPTION
After finishing operations that require privileges, drop the privileges to run as a normal user.

This adds support to the `run_as` configuration option to select the `user:group` under which the keylime agent will run.

This also rewrites `check_mount()` to use the information from `/proc/self/mountinfo` instead of the mount output file to check if `secure` is mounted. The implementation was based on python agent.

Fixes: #343, #317, #344