### PR TITLE
Make support for legacy python revocation actions optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,14 @@ wiremock = "0.5"
 
 [features]
 # The features enabled by default
-default = ["with-zmq"]
+default = ["with-zmq", "legacy-python-actions"]
 # this should change to dev-dependencies when we have integration testing
 testing = []
 # Whether the agent should be compiled with support to listen for notification
 # messages on ZeroMQ
 with-zmq = ["zmq"]
+# Whether the agent should be compiled with support for python revocation
+# actions loaded as modules, which is the only kind supported by the python
+# agent (unless the enhancement-55 is implemented). See:
+# https://github.com/keylime/enhancements/blob/master/55_revocation_actions_without_python.md
+legacy-python-actions = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,15 +424,19 @@ async fn main() -> Result<()> {
         warn!("INSECURE: Only use Keylime in this mode for testing or debugging purposes.");
     }
 
-    // Verify if the python shim is installed in the expected location
-    let python_shim =
-        PathBuf::from(&config.revocation_actions_dir).join("shim.py");
-    if !python_shim.exists() {
-        error!("Could not find python shim at {}", python_shim.display());
-        return Err(Error::Configuration(format!(
-            "Could not find python shim at {}",
-            python_shim.display()
-        )));
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "legacy-python-actions")] {
+            // Verify if the python shim is installed in the expected location
+            let python_shim =
+                PathBuf::from(&config.revocation_actions_dir).join("shim.py");
+            if !python_shim.exists() {
+                error!("Could not find python shim at {}", python_shim.display());
+                return Err(Error::Configuration(format!(
+                    "Could not find python shim at {}",
+                    python_shim.display()
+                )));
+            }
+        }
     }
 
     // Gather EK values and certs

--- a/tests/actions/local_action_stand_alone.py
+++ b/tests/actions/local_action_stand_alone.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2021 Keylime Authors
+'''
+
+import argparse
+import json
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('json_file')
+    args = parser.parse_args()
+
+    with open(args.json_file, 'r') as f:
+        input_json = json.load(f)
+        value = input_json['hello']
+
+    print(value)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/unzipped/action_list
+++ b/tests/unzipped/action_list
@@ -1,4 +1,2 @@
 local_action_rev_script1.py
 local_action_rev_script2.py
-local_action_payload
-local_action_hello


### PR DESCRIPTION
Add the 'legacy-python-actions' feature, enabled by default, to control
whether the agent supports python revocation actions loaded as modules.

Note that this is the only kind of revocation actions script supported
by the python agent implementation, which means that removing this
feature will make existing revocation actions unusable.

Disabling the 'legacy-python-actions' feature will not disable the
support for running stand-alone python revocation action scripts, i.e.
executable python scripts can be used as a revocation actions scripts,
as well as any other executable.

Fixes: #368

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>