### PR TITLE
Skip serialization of optional fields

### DIFF
--- a/src/keys_handler.rs
+++ b/src/keys_handler.rs
@@ -18,6 +18,7 @@ use std::{convert::TryInto, sync::Arc};
 pub struct KeylimeUKey {
     auth_tag: String,
     encrypted_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     payload: Option<String>,
 }
 

--- a/src/registrar_agent.rs
+++ b/src/registrar_agent.rs
@@ -22,8 +22,11 @@ struct Register<'a> {
     ek_tpm: &'a [u8],
     #[serde(serialize_with = "serialize_as_base64")]
     aik_tpm: &'a [u8],
+    #[serde(skip_serializing_if = "Option::is_none")]
     mtls_cert: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     port: Option<u32>,
 }
 


### PR DESCRIPTION
Add the `#[serde(skip_serializing_if = "Option::is_none")]` annotation to
all optional fields serialized using `serde`.  This makes `serde` to skip
serializing optional fields when the value is `None`.

Fixes: #380

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>