### PR TITLE
quotes_handler: Rewind measured boot log file

### DIFF
--- a/src/quotes_handler.rs
+++ b/src/quotes_handler.rs
@@ -221,6 +221,15 @@ pub async fn integrity(
             if let Some(measuredboot_ml_file) = &data.measuredboot_ml_file {
                 let mut ml = Vec::<u8>::new();
                 let mut f = measuredboot_ml_file.lock().unwrap(); //#[allow_ci]
+                if let Err(e) = f.rewind() {
+                    debug!("Failed to rewind measured boot file: {}", e);
+                    return HttpResponse::InternalServerError().json(
+                        JsonWrapper::error(
+                            500,
+                            "Unable to retrieve quote".to_string(),
+                        ),
+                    );
+                }
                 mb_measurement_list = match f.read_to_end(&mut ml) {
                     Ok(_) => Some(base64::encode(ml)),
                     Err(e) => {


### PR DESCRIPTION
Rewind the file before reading its content.

Fixes: #383 

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>