### PR TITLE
Update tokio minimum version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde_derive = "1.0.80"
 serde_json = { version = "1.0", features = ["raw_value"] }
 static_assertions = "1"
 tempfile = "3.0.4"
-tokio = {version = "1", features = ["full"]}
+tokio = {version = "1.13.1", features = ["full"]}
 tss-esapi = "7.1.0"
 thiserror = "1.0"
 uuid = {version = "0.8", features = ["v4"]}


### PR DESCRIPTION
To reduce the risk of being compiled with an outdated vulnerable
version, update the tokio minimum required version.

This is to avoid tokio < 1.13.1, which is affected by:
https://rustsec.org/advisories/RUSTSEC-2021-0124.html

This solves the possible vulnerability listed in:
https://deps.rs/repo/github/keylime/rust-keylime

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>