### PR TITLE
.github/dependabot.yml: prevent updates that require manifest change

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
By default dependabot creates PRs that update each dependency to the
latest possible version.  That would be problematic if we use crates
packaged in distributions such as Fedora.  This forces the
"lockfile-only" strategy to only allow minor updates:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy

Signed-off-by: Daiki Ueno <dueno@redhat.com>