### PR TITLE
Update fmf plans to run test with IMA policy

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -19,11 +19,23 @@
        - /setup/configure_tpm_emulator
        - /setup/install_upstream_keylime
        - /setup/install_upstream_rust_keylime
+       # change IMA policy to simple and run one attestation scenario
+       # this is to utilize also a different parser
+       - /setup/configure_kernel_ima_module/ima_policy_simple
+       - /functional/basic-attestation-on-localhost
+       # now change IMA policy to signing and run all tests
+       - /setup/configure_kernel_ima_module/ima_policy_signing
        - /functional/basic-attestation-on-localhost
        - /functional/basic-attestation-with-custom-certificates
+       - /functional/basic-attestation-with-ima-signatures
        - /functional/basic-attestation-without-mtls
        - /functional/basic-attestation-with-unpriviledged-agent
+       - /functional/install-rpm-with-ima-signature
        - /functional/keylime_tenant-commands-on-localhost
+       - /functional/db-postgresql-sanity-on-localhost
+       - /functional/db-mariadb-sanity-on-localhost
+       - /functional/db-mysql-sanity-on-localhost
+       - /functional/tenant-allowlist-sanity
        - /functional/measured-boot-swtpm-sanity
 
   adjust:


### PR DESCRIPTION
Update fmf plans for enabling run test with simple
IMA policy. With simple IMA policy will be run one
test. Then update IMA policy to signing policy and
run all tests.

Signed-off-by: Patrik Koncity <pkoncity@redhat.com>