### PR TITLE
main: Use cfg_if to disable ZeroMQ feature code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -327,9 +327,12 @@ async fn worker(
     }
 
     // If with-zmq feature is enabled, run the service listening for ZeroMQ messages
-    #[cfg(feature = "with-zmq")]
-    if config.run_revocation {
-        return revocation::run_revocation_service(&config, &mount).await;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "with-zmq")] {
+            if config.run_revocation {
+                return revocation::run_revocation_service(&config, &mount).await
+            }
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Use cfg_if to disable code enabled by 'with_zmq' feature.

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>