### PR TITLE
tpm: Respect ek_handle from config

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -34,6 +34,8 @@
        - /functional/basic-attestation-with-ima-signatures
        - /functional/basic-attestation-without-mtls
        - /functional/basic-attestation-with-unpriviledged-agent
+       - /functional/ek-cert-use-ek_check_script
+       - /functional/ek-cert-use-ek_handle-custom-ca_certs
        - /functional/install-rpm-with-ima-signature
        - /functional/keylime_tenant-commands-on-localhost
        - /functional/db-postgresql-sanity-on-localhost

--- a/src/common.rs
+++ b/src/common.rs
@@ -290,6 +290,8 @@ pub(crate) struct KeylimeConfig {
     pub mtls_enabled: bool,
     pub enable_insecure_payload: bool,
     pub run_as: Option<String>,
+    pub tpm_ownerpassword: Option<String>,
+    pub ek_handle: Option<String>,
 }
 
 impl KeylimeConfig {
@@ -501,6 +503,16 @@ impl KeylimeConfig {
             Err(_) => false,
         };
 
+        let tpm_ownerpassword =
+            config_get(&conf_name, &conf, "cloud_agent", "tpm_ownerpassword")
+                .ok()
+                .filter(|s| s != "generate");
+
+        let ek_handle =
+            config_get(&conf_name, &conf, "cloud_agent", "ek_handle")
+                .ok()
+                .filter(|s| s != "generate");
+
         Ok(KeylimeConfig {
             agent_ip,
             agent_port,
@@ -531,6 +543,8 @@ impl KeylimeConfig {
             mtls_enabled,
             enable_insecure_payload,
             run_as,
+            tpm_ownerpassword,
+            ek_handle,
         })
     }
 
@@ -592,6 +606,8 @@ impl Default for KeylimeConfig {
             mtls_enabled: true,
             enable_insecure_payload: false,
             run_as,
+            tpm_ownerpassword: None,
+            ek_handle: None,
         }
     }
 }


### PR DESCRIPTION
Previously it always generated new EK handle even if the "ek_handle"
option is set to use the existing key.

Signed-off-by: Daiki Ueno <dueno@redhat.com>