### PR TITLE
Add GitLeaks configuration to ignore RSA key used for testing

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+#
+# GitLeaks Repo Specific Configuration
+#
+# This allowlist is used to help Red Hat ignore false positives during its code
+# scans.
+
+[allowlist]
+  paths = [
+    '''test-data/test-rsa.pem''',
+  ]


### PR DESCRIPTION
Signed-off-by: Daiki Ueno <dueno@redhat.com>