### PR TITLE
Fix typo in listen_notifications option in keylime.conf

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -65,7 +65,7 @@ extract_payload_zip = True
 agent_uuid = d432fbb3-d2f1-4a97-9ef7-75bd81c00000
 
 # Whether to listen for revocation notifications from the verifier or not.
-listen_notfications = True
+listen_notifications = True
 
 # The path to the certificate to verify revocation messages received from the
 # verifier.  The path is relative to $keylime_dir unless an absolute path is


### PR DESCRIPTION
The compatibility part has been already addressed in
https://github.com/keylime/rust-keylime/pull/320
but keylime.conf itself hasn't been updated yet.

Signed-off-by: Karel Srot <ksrot@redhat.com>