### PR TITLE
Add tpm_ownerpassword option to keylime.conf

### DIFF
--- a/keylime-agent.conf
+++ b/keylime-agent.conf
@@ -128,6 +128,10 @@ tpm_signing_alg = rsassa
 # create a new EK upon startup, and neither will it flush the EK upon exit.
 ek_handle = generate
 
+# Use this option to state the existing TPM ownerpassword. This option should
+# be set only when ek_handle option points to an existing EK.
+tpm_ownerpassword =
+
 # The user account to switch to to drop privileges when started as root
 # If left empty, the agent will keep running with high privileges.
 # The user and group specified here must allow the user to access the


### PR DESCRIPTION
The option has been introduced in
https://github.com/keylime/rust-keylime/pull/426
but keylime.conf has not been updated with it.

Signed-off-by: Karel Srot <ksrot@redhat.com>