### PR TITLE
Add agent and faked_measured_boot_log tests context

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -8,6 +8,8 @@
 
   context:
     swtpm: yes
+    agent: rust
+    faked_measured_boot_log: true
 
   prepare:
     how: shell


### PR DESCRIPTION
These context are to be used for proper test case filtering.
Current upstream plan installs modified Rust agent which
reads faked measured boot log, enabling measured boot testing
on systems with runtime swtpm emulation.
Distribution RPMs are not modified this way and undefined context
faked_measured_boot_log gives as a way how to avoid running measured
boot test that would fail.

Signed-off-by: Karel Srot <ksrot@redhat.com>