### PR TITLE
Add build script to set `feature=testing` cfg

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    if let Ok(val) = std::env::var("KEYLIME_TEST") {
+        if val == "true" || val == "True" {
+            println!("cargo:rustc-cfg=`feature=\"testing\"`");
+        }
+    }
+}


### PR DESCRIPTION
This is necessary when running the `keylime/keylime` CI with `run_local.sh`, which indicates a test with the env var `KEYLIME_TEST` set to `'true'` (as a string). Otherwise, the `MOUNT_SECURE` flag in `common.rs` is set incorrectly when running this with the CI as opposed to in a Rust-based testing environment.

Related to #441 