### PR TITLE
Disable dnf-makecache.service to save RAM

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -15,6 +15,8 @@
     how: shell
     script:
      - ln -s $(pwd) /var/tmp/rust-keylime_sources
+     - systemctl disable --now dnf-makecache.service || true
+     - systemctl disable --now dnf-makecache.timer || true
 
   discover:
     how: fmf


### PR DESCRIPTION
This service running on background can consume a lot of memory, resulting in OOM killer interrupting tests.

Signed-off-by: Karel Srot <ksrot@redhat.com>