### PR TITLE
add support for cargo deb

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,16 @@ Then you should be able to start the service with:
 ```console
 $ sudo systemctl start keylime_agent
 ```
+
+## Building Debian package with cargo-deb
+
+Cargo deb requires Rust 1.60, so on Debian you need to install it first from rustup.rs.
+
+```shell
+# Install cargo-deb
+rustup update
+cargo install cargo-deb
+
+# Build Debian package
+cargo deb -p keylime_agent
+```

--- a/debian/keylime_agent.postinst
+++ b/debian/keylime_agent.postinst
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -e
+
+
+keylime_setup_group_user ()
+{
+    # creating tss group if he isn't already there
+    if ! getent group tss >/dev/null; then
+        addgroup --system tss
+    fi
+
+    # creating tss user if he isn't already there
+    if ! getent passwd tss >/dev/null; then
+        adduser --system --ingroup tss --shell /bin/false \
+                --home /var/lib/tpm --no-create-home \
+                --gecos "TPM software stack" \
+                tss
+    fi
+
+    # creating keylime user if he isn't already there
+    if ! getent passwd keylime >/dev/null; then
+        adduser --system --ingroup tss --shell /bin/false \
+                --home /var/lib/keylime --no-create-home \
+                --gecos "Keylime remote attestation" \
+                keylime
+    fi
+}
+
+case "$1" in
+    configure)
+    # Setup the keylime user and the tss group
+    keylime_setup_group_user
+
+    mkdir -p /var/lib/keylime
+
+    # Setting owner
+    if [ -d /var/lib/keylime ] && ! dpkg-statoverride --list /var/lib/keylime >/dev/null && getent passwd keylime >/dev/null; then
+        chown -R keylime:tss /var/lib/keylime
+    fi
+
+    ;;
+
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+#DEBHELPER#

--- a/keylime-agent/Cargo.toml
+++ b/keylime-agent/Cargo.toml
@@ -56,3 +56,14 @@ with-zmq = ["zmq"]
 # agent (unless the enhancement-55 is implemented). See:
 # https://github.com/keylime/enhancements/blob/master/55_revocation_actions_without_python.md
 legacy-python-actions = []
+
+[package.metadata.deb]
+section = "net"
+assets = [
+  ["target/release/keylime_agent", "usr/bin/", "755"],
+  ["../README.md", "usr/share/doc/keylime-agent/README", "644"],
+  ["../keylime-agent.conf", "/etc/keylime/agent.conf", "640"],
+  ["../dist/systemd/system/var-lib-keylime-secure.mount", "lib/systemd/system/var-lib-keylime-secure.mount", "644"],
+]
+maintainer-scripts = "../debian/"
+systemd-units = { unit-scripts = "../dist/systemd/system/", enable = true }


### PR DESCRIPTION
This adds the required files and options to build the agent using cargo deb.
