### PR TITLE
Remove unused option "openstack" for obtaining uuid

### DIFF
--- a/keylime-agent.conf
+++ b/keylime-agent.conf
@@ -6,7 +6,6 @@
 version = "2.0"
 
 # The agent's UUID.
-# Set to "openstack", it will try to get the UUID from the metadata service.
 # If you set this to "generate", Keylime will create a random UUID.
 # If you set this to "hash_ek", Keylime will set the UUID to the result
 # of 'SHA256(public EK in PEM format)'.

--- a/keylime-agent/src/config.rs
+++ b/keylime-agent/src/config.rs
@@ -601,10 +601,6 @@ fn config_get_file_path(
 
 fn get_uuid(agent_uuid_config: &str) -> String {
     match agent_uuid_config {
-        "openstack" => {
-            info!("Openstack placeholder...");
-            "openstack".into()
-        }
         "hash_ek" => {
             info!("Using hashed EK as UUID");
             // DO NOT change this to something else. It is used later to set the correct value.
@@ -728,7 +724,6 @@ mod tests {
 
     #[test]
     fn test_get_uuid() {
-        assert_eq!(get_uuid("openstack"), "openstack");
         assert_eq!(get_uuid("hash_ek"), "hash_ek");
         let _ = Uuid::parse_str(&get_uuid("generate")).unwrap(); //#[allow_ci]
         assert_eq!(


### PR DESCRIPTION
For python agent was openstack option already removed, and in rust agent is stil placeholder for this option, but won't be used. [1] Remove related unit test and notes about openstack method in agent conf. Can be confusing for user to see openstack option as method for obtaining uuid.

[1] https://github.com/keylime/keylime/commit/c9f7906a0d254a4fceef8e9b0c612b378c27d6e4

Signed-off-by: Patrik Koncity <pkoncity@redhat.com>