### PR TITLE
Refactor async code synchronization

### DIFF
--- a/keylime-agent/src/common.rs
+++ b/keylime-agent/src/common.rs
@@ -121,7 +121,7 @@ where
 pub type KeySet = Vec<SymmKey>;
 
 // a key of len AES_128_KEY_LEN or AES_256_KEY_LEN
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SymmKey {
     bytes: Vec<u8>,
 }
@@ -192,7 +192,7 @@ impl TryFrom<&[u8]> for AuthTag {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EncryptedData {
     bytes: Vec<u8>,
 }

--- a/keylime-agent/src/error.rs
+++ b/keylime-agent/src/error.rs
@@ -85,6 +85,10 @@ pub(crate) enum Error {
     Join(#[from] tokio::task::JoinError),
     #[error("Asn1DerError: {0}")]
     PickyAsn1(#[from] picky_asn1_der::Asn1DerError),
+    #[error("Error sending internal message: {0}")]
+    Sender(String),
+    #[error("Error receiving internal message: {0}")]
+    Receiver(String),
     #[error("{0}")]
     Other(String),
 }

--- a/keylime-agent/src/keys_handler.rs
+++ b/keylime-agent/src/keys_handler.rs
@@ -4,15 +4,22 @@
 use crate::crypto;
 use crate::{
     common::{
-        JsonWrapper, KeySet, SymmKey, AES_BLOCK_SIZE, AGENT_UUID_LEN,
-        AUTH_TAG_LEN,
+        AuthTag, EncryptedData, JsonWrapper, KeySet, SymmKey, AES_BLOCK_SIZE,
+        AGENT_UUID_LEN, AUTH_TAG_LEN,
     },
+    config::KeylimeConfig,
+    payloads::{PayloadMessage, RunPayload},
     Error, QuoteData, Result,
 };
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use log::*;
 use serde::{Deserialize, Serialize};
-use std::{convert::TryInto, sync::Arc};
+use serde_json::json;
+use std::convert::TryInto;
+use tokio::sync::{
+    mpsc::{Receiver, Sender},
+    oneshot,
+};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct KeylimeUKey {
@@ -42,159 +49,262 @@ pub struct KeylimeHMAC {
     hmac: String,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct UKey {
+    decrypted_key: SymmKey,
+    auth_tag: AuthTag,
+    payload: Option<EncryptedData>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct VKey {
+    decrypted_key: SymmKey,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) enum KeyMessage {
+    UKey(UKey),
+    VKey(VKey),
+    Shutdown,
+    GetSymmKey,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) enum SymmKeyMessage {
+    SymmKey(Option<SymmKey>),
+}
+
 // Attempt to combine U and V keys into the payload decryption key. An HMAC over
 // the agent's UUID using the decryption key must match the provided authentication
 // tag. Returning None is okay here in case we are still waiting on another handler to
 // process data.
-pub(crate) fn try_combine_keys(
+fn try_combine_keys(
     keyset1: &mut KeySet,
     keyset2: &mut KeySet,
     uuid: &[u8],
-    auth_tag: &[u8; AUTH_TAG_LEN],
-) -> Result<Option<SymmKey>> {
+    auth_tag: &Option<AuthTag>,
+) -> Option<SymmKey> {
     // U, V keys and auth_tag must be present for this to succeed
-    if keyset1.is_empty()
-        || keyset2.is_empty()
-        || auth_tag == &[0u8; AUTH_TAG_LEN]
-    {
+    if keyset1.is_empty() || keyset2.is_empty() || auth_tag.is_none() {
         debug!("Still waiting on u or v key or auth_tag");
-        return Ok(None);
+        return None;
     }
 
     for key1 in keyset1.iter() {
         for key2 in keyset2.iter() {
-            let symm_key_out = key1.xor(key2)?;
-
-            // Computes HMAC over agent UUID with provided key (payload decryption key) and
-            // checks that this matches the provided auth_tag.
-            let auth_tag = hex::decode(auth_tag)?;
-            if crypto::verify_hmac(symm_key_out.bytes(), uuid, &auth_tag)
+            let symm_key_out = match key1.xor(key2) {
+                Ok(k) => k,
+                Err(e) => {
+                    continue;
+                }
+            };
+            if let Some(tag) = auth_tag {
+                // Computes HMAC over agent UUID with provided key (payload decryption key) and
+                // checks that this matches the provided auth_tag.
+                if crypto::verify_hmac(
+                    symm_key_out.as_ref(),
+                    uuid,
+                    tag.as_ref(),
+                )
                 .is_ok()
-            {
-                info!(
-                    "Successfully derived symmetric payload decryption key"
-                );
+                {
+                    info!(
+                        "Successfully derived symmetric payload decryption key"
+                    );
 
-                keyset1.clear();
-                keyset2.clear();
-                return Ok(Some(symm_key_out));
+                    keyset1.clear();
+                    keyset2.clear();
+                    return Some(symm_key_out);
+                }
             }
         }
     }
 
-    Err(Error::Other(
-        "HMAC check failed for all U and V key combinations".to_string(),
-    ))
+    warn!("HMAC check failed for all U and V key combinations");
+    None
 }
 
-pub async fn u_key(
+pub(crate) async fn u_key(
     body: web::Json<KeylimeUKey>,
     req: HttpRequest,
     quote_data: web::Data<QuoteData>,
 ) -> impl Responder {
     debug!("Received ukey");
 
-    // Use scope to unlock the mutexes before calling await
+    // get key and decode it from web data
+    let encrypted_key = match base64::decode(&body.encrypted_key)
+        .map_err(Error::from)
     {
-        // must unwrap when using lock
-        // https://github.com/rust-lang-nursery/failure/issues/192
-        let mut global_current_keyset = quote_data.ukeys.lock().unwrap(); //#[allow_ci]
-        let mut global_other_keyset = quote_data.vkeys.lock().unwrap(); //#[allow_ci]
-        let mut global_symm_key = quote_data.payload_symm_key.lock().unwrap(); //#[allow_ci]
-        let mut global_encr_payload = quote_data.encr_payload.lock().unwrap(); //#[allow_ci]
-        let mut global_auth_tag = quote_data.auth_tag.lock().unwrap(); //#[allow_ci]
-
-        // get key and decode it from web data
-        let encrypted_key =
-            base64::decode(&body.encrypted_key).map_err(Error::from)?;
-        // Uses NK (key for encrypting data from verifier or tenant to agent in transit) to
-        // decrypt U and V keys, which will be combined into one key that can decrypt the
-        // payload.
-        //
-        // Reference:
-        // https://github.com/keylime/keylime/blob/f3c31b411dd3dd971fd9d614a39a150655c6797c/ \
-        // keylime/crypto.py#L118
-        let decrypted_key =
-            crypto::rsa_oaep_decrypt(&quote_data.priv_key, &encrypted_key)?;
-
-        let decrypted_key: SymmKey =
-            decrypted_key.as_slice().try_into().unwrap(); //#[allow_ci]
-
-        global_current_keyset.push(decrypted_key);
-
-        // note: the auth_tag shouldn't be base64 decoded here
-        global_auth_tag.copy_from_slice(body.auth_tag.as_bytes());
-
-        if let Some(payload) = &body.payload {
-            let encr_payload =
-                base64::decode(payload).map_err(Error::from)?;
-            global_encr_payload.extend(encr_payload.iter());
+        Ok(k) => k,
+        Err(e) => {
+            warn!(
+                    "POST u_key returning 400 response. Invalid base64 encoding in encrypted_key: {e}"
+                );
+            return HttpResponse::BadRequest().json(JsonWrapper::error(
+                400,
+                format!("Invalid base64 encoding in encrypted_key: {e}"),
+            ));
         }
+    };
 
-        if let Some(symm_key) = try_combine_keys(
-            &mut global_current_keyset,
-            &mut global_other_keyset,
-            quote_data.agent_uuid.as_bytes(),
-            &global_auth_tag,
-        )? {
-            let _ = global_symm_key.replace(symm_key);
-            quote_data.payload_symm_key_cvar.notify_one();
+    // Uses NK (key for encrypting data from verifier or tenant to agent in transit) to
+    // decrypt U and V keys, which will be combined into one key that can decrypt the
+    // payload.
+    //
+    // Reference:
+    // https://github.com/keylime/keylime/blob/f3c31b411dd3dd971fd9d614a39a150655c6797c/ \
+    // keylime/crypto.py#L118
+    let decrypted_key = match crypto::rsa_oaep_decrypt(
+        &quote_data.priv_key,
+        &encrypted_key,
+    )
+    .map_err(Error::from)
+    {
+        Ok(k) => k,
+        Err(e) => {
+            warn!("POST u_key returning 400 response. Failed to decrypt encrypted_key: {e}");
+            return HttpResponse::BadRequest().json(JsonWrapper::error(
+                400,
+                format!("Failed to decrypt encrypted_key: {e}"),
+            ));
         }
+    };
+
+    let decrypted_key: SymmKey = match decrypted_key.as_slice().try_into() {
+        Ok(k) => k,
+        Err(e) => {
+            warn!("POST u_key returning 400 response. Invalid decrypted key: {e}");
+            return HttpResponse::BadRequest().json(JsonWrapper::error(
+                400,
+                format!("Invalid decrypted key: {e}"),
+            ));
+        }
+    };
+
+    let auth_tag = match hex::decode(&body.auth_tag).map_err(Error::from) {
+        Ok(t) => t,
+        Err(e) => {
+            warn!("POST u_key returning 400 response: Invalid hex encoding in auth_tag: {e}");
+            return HttpResponse::BadRequest().json(JsonWrapper::error(
+                400,
+                format!("Invalid hex encoding in auth_tag: {e}"),
+            ));
+        }
+    };
+
+    let auth_tag = match auth_tag.as_slice().try_into() {
+        Ok(t) => t,
+        Err(e) => {
+            warn!("POST u_key returning 400 response: {e}");
+            return HttpResponse::BadRequest()
+                .json(JsonWrapper::error(400, e));
+        }
+    };
+
+    let payload = match &body.payload {
+        Some(data) => match base64::decode(data).map_err(Error::from) {
+            Ok(d) => Some(d.into()),
+            Err(e) => {
+                warn!("POST u_key returning 400 response. Invalid base64 encoding in payload: {e}");
+                return HttpResponse::BadRequest().json(JsonWrapper::error(
+                    400,
+                    format!("Invalid base64 encoding in payload: {e}"),
+                ));
+            }
+        },
+        None => None,
+    };
+
+    let m = KeyMessage::UKey(UKey {
+        decrypted_key,
+        auth_tag,
+        payload,
+    });
+
+    debug!("Sending UKey message to keys worker");
+
+    if let Err(e) = quote_data.keys_tx.send((m, None)).await {
+        warn!("Failed to send UKey message to keys worker");
+        return HttpResponse::InternalServerError().json(JsonWrapper::error(
+            500,
+            "Failed to send UKey message to keys worker".to_string(),
+        ));
     }
-    HttpResponse::Ok().await
+
+    HttpResponse::Ok().json(JsonWrapper::success(()))
 }
 
-pub async fn v_key(
+pub(crate) async fn v_key(
     body: web::Json<KeylimeVKey>,
     req: HttpRequest,
     quote_data: web::Data<QuoteData>,
 ) -> impl Responder {
     debug!("Received vkey");
 
-    // Use scope to unlock the mutexes before calling await
+    // get key and decode it from web data
+    let encrypted_key = match base64::decode(&body.encrypted_key)
+        .map_err(Error::from)
     {
-        // must unwrap when using lock
-        // https://github.com/rust-lang-nursery/failure/issues/192
-        let mut global_current_keyset = quote_data.vkeys.lock().unwrap(); //#[allow_ci]
-        let mut global_other_keyset = quote_data.ukeys.lock().unwrap(); //#[allow_ci]
-        let mut global_symm_key = quote_data.payload_symm_key.lock().unwrap(); //#[allow_ci]
-        let mut global_encr_payload = quote_data.encr_payload.lock().unwrap(); //#[allow_ci]
-        let mut global_auth_tag = quote_data.auth_tag.lock().unwrap(); //#[allow_ci]
-
-        // get key and decode it from web data
-        let encrypted_key =
-            base64::decode(&body.encrypted_key).map_err(Error::from)?;
-
-        // Uses NK (key for encrypting data from verifier or tenant to agent in transit) to
-        // decrypt U and V keys, which will be combined into one key that can decrypt the
-        // payload.
-        //
-        // Reference:
-        // https://github.com/keylime/keylime/blob/f3c31b411dd3dd971fd9d614a39a150655c6797c/ \
-        // keylime/crypto.py#L118
-        let decrypted_key =
-            crypto::rsa_oaep_decrypt(&quote_data.priv_key, &encrypted_key)?;
-
-        let decrypted_key: SymmKey =
-            decrypted_key.as_slice().try_into().unwrap(); //#[allow_ci]
-
-        global_current_keyset.push(decrypted_key);
-
-        if let Some(symm_key) = try_combine_keys(
-            &mut global_current_keyset,
-            &mut global_other_keyset,
-            quote_data.agent_uuid.as_bytes(),
-            &global_auth_tag,
-        )? {
-            let _ = global_symm_key.replace(symm_key);
-            quote_data.payload_symm_key_cvar.notify_one();
+        Ok(k) => k,
+        Err(e) => {
+            warn!("POST v_key returning 400 response. Invalid base64 encoding in encrypted_key: {e}");
+            return HttpResponse::BadRequest().json(JsonWrapper::error(
+                400,
+                format!("Invalid base64 encoding in encrypted_key: {e}"),
+            ));
         }
+    };
+
+    // Uses NK (key for encrypting data from verifier or tenant to agent in transit) to
+    // decrypt U and V keys, which will be combined into one key that can decrypt the
+    // payload.
+    //
+    // Reference:
+    // https://github.com/keylime/keylime/blob/f3c31b411dd3dd971fd9d614a39a150655c6797c/ \
+    // keylime/crypto.py#L118
+    let decrypted_key = match crypto::rsa_oaep_decrypt(
+        &quote_data.priv_key,
+        &encrypted_key,
+    )
+    .map_err(Error::from)
+    {
+        Ok(k) => k,
+        Err(e) => {
+            warn!("POST v_key returning 400 response. Failed to decrypt encrypted_key: {e}");
+            return HttpResponse::BadRequest().json(JsonWrapper::error(
+                400,
+                format!("Failed to decrypt encrypted_key: {e}"),
+            ));
+        }
+    };
+
+    let decrypted_key: SymmKey = match decrypted_key.as_slice().try_into() {
+        Ok(k) => k,
+        Err(e) => {
+            warn!("POST v_key returning 400 response. Decrypted key is invalid: {e}");
+            return HttpResponse::BadRequest().json(JsonWrapper::error(
+                400,
+                format!("Decrypted key is invalid: {e}"),
+            ));
+        }
+    };
+
+    let m = KeyMessage::VKey(VKey { decrypted_key });
+
+    debug!("Sending VKey message to keys worker");
+
+    if let Err(e) = quote_data.keys_tx.send((m, None)).await {
+        warn!("Failed to send VKey message to keys worker");
+        return HttpResponse::InternalServerError().json(JsonWrapper::error(
+            500,
+            "Failed to send VKey message to keys worker".to_string(),
+        ));
     }
 
-    HttpResponse::Ok().await
+    HttpResponse::Ok().json(JsonWrapper::success(()))
 }
 
-pub async fn pubkey(
+pub(crate) async fn pubkey(
     req: HttpRequest,
     data: web::Data<QuoteData>,
 ) -> impl Responder {
@@ -215,7 +325,35 @@ pub async fn pubkey(
     }
 }
 
-pub async fn verify(
+async fn get_symm_key(
+    keys_tx: Sender<(KeyMessage, Option<oneshot::Sender<SymmKeyMessage>>)>,
+) -> Result<Option<SymmKey>> {
+    let (resp_tx, resp_rx) = oneshot::channel::<SymmKeyMessage>();
+
+    debug!("Sending GetSymmKey message to keys worker");
+
+    if let Err(e) =
+        keys_tx.send((KeyMessage::GetSymmKey, Some(resp_tx))).await
+    {
+        return Err(Error::Sender(format!(
+            "Failed to send GetSymmKey message: {e}"
+        )));
+    };
+
+    match resp_rx.await {
+        Ok(message) => match message {
+            SymmKeyMessage::SymmKey(symmkey) => Ok(symmkey),
+            _ => Err(Error::Receiver(
+                "Invalid response for GetSymmKey message".to_string(),
+            )),
+        },
+        Err(e) => Err(Error::Receiver(format!(
+            "Failed to receive SymmKey message: {e}"
+        ))),
+    }
+}
+
+pub(crate) async fn verify(
     param: web::Query<KeylimeChallenge>,
     req: HttpRequest,
     data: web::Data<QuoteData>,
@@ -239,35 +377,181 @@ pub async fn verify(
         ));
     }
 
-    let key_arc = Arc::clone(&data.payload_symm_key);
-    let mut key = key_arc.lock().unwrap(); //#[allow_ci]
+    // Send a message requesting the symmetric key
+    if let Ok(key) = get_symm_key(data.keys_tx.clone()).await {
+        let k = match key {
+            Some(k) => k,
+            None => {
+                warn!("GET key challenge returning 400 response. Bootstrap key not available");
+                return HttpResponse::BadRequest().json(JsonWrapper::error(
+                    400,
+                    "Bootstrap key not yet available.",
+                ));
+            }
+        };
 
-    if key.is_none() {
-        warn!("GET key challenge returning 400 response. Bootstrap key not available");
-        return HttpResponse::BadRequest().json(JsonWrapper::error(
-            400,
-            "Bootstrap key not yet available.",
-        ));
+        match crypto::compute_hmac(k.as_ref(), param.challenge.as_bytes()) {
+            Ok(hmac) => {
+                let response = JsonWrapper::success(KeylimeHMAC {
+                    hmac: hex::encode(hmac),
+                });
+
+                info!("GET key challenge returning 200 response.");
+                HttpResponse::Ok().json(response)
+            }
+            Err(e) => {
+                warn!("GET key challenge failed: {:?}", e);
+                HttpResponse::InternalServerError().json(JsonWrapper::error(
+                    500,
+                    "GET key challenge failed".to_string(),
+                ))
+            }
+        }
+    } else {
+        warn!("GET key challenge returning 500 response. Failed to get bootstrap key.");
+        HttpResponse::InternalServerError()
+            .json(JsonWrapper::error(500, "Failed to get bootstrap key."))
+    }
+}
+
+async fn request_run_payload(
+    payloads_tx: Sender<PayloadMessage>,
+    symm_key: SymmKey,
+    encrypted_payload: Option<EncryptedData>,
+) -> Result<()> {
+    if let Some(p) = &encrypted_payload {
+        let m = PayloadMessage::RunPayload(RunPayload {
+            symm_key,
+            encrypted_payload: p.clone(),
+        });
+        debug!("Sending RunPayload message to payloads worker");
+        if let Err(e) = payloads_tx.send(m).await {
+            warn!("Failed to send RunPayload message to payloads worker");
+            return Err(Error::Sender(
+                "Failed to send RunPayload message to payloads worker"
+                    .to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) async fn worker(
+    run_payload: bool,
+    uuid: String,
+    mut keys_rx: Receiver<(
+        KeyMessage,
+        Option<oneshot::Sender<SymmKeyMessage>>,
+    )>,
+    mut payloads_tx: Sender<PayloadMessage>,
+) -> Result<()> {
+    let mut ukeys: KeySet = Vec::new();
+    let mut vkeys: KeySet = Vec::new();
+    let mut auth_tag: Option<AuthTag> = None;
+    let mut encrypted_payload: Option<EncryptedData> = None;
+    let mut symm_key: Option<SymmKey> = None;
+
+    debug!("Starting keys worker");
+
+    // Receive message
+    while let Some((message, resp_tx)) = keys_rx.recv().await {
+        match message {
+            KeyMessage::GetSymmKey => {
+                if let Some(r) = resp_tx {
+                    if let Err(e) =
+                        r.send(SymmKeyMessage::SymmKey(symm_key.clone()))
+                    {
+                        debug!("Failed to send SymmKey message");
+                    }
+                } else {
+                    debug!("Empty receiver in GetSymmKey message");
+                }
+            }
+            KeyMessage::Shutdown => {
+                keys_rx.close();
+            }
+            KeyMessage::UKey(ukey) => {
+                // Store received data
+                encrypted_payload = ukey.payload;
+                auth_tag = Some(ukey.auth_tag);
+                ukeys.push(ukey.decrypted_key);
+
+                match try_combine_keys(
+                    &mut ukeys,
+                    &mut vkeys,
+                    uuid.as_bytes(),
+                    &auth_tag,
+                ) {
+                    Some(k) => {
+                        if run_payload {
+                            match request_run_payload(
+                                payloads_tx.clone(),
+                                k.clone(),
+                                encrypted_payload.clone(),
+                            )
+                            .await
+                            {
+                                Ok(_) => {
+                                    debug!("Sent RunPayload message to payloads worker");
+                                }
+                                Err(e) => {
+                                    warn!("Failed to send RunPayload message to payloads worker");
+                                }
+                            }
+                        } else {
+                            warn!("agent mTLS is disabled, and unless 'enable_insecure_payload' is set to 'True', payloads cannot be deployed'");
+                        }
+                        // Store combined key
+                        symm_key = Some(k);
+                    }
+                    None => {
+                        continue;
+                    }
+                }
+            }
+            KeyMessage::VKey(vkey) => {
+                // Store received data
+                vkeys.push(vkey.decrypted_key);
+
+                match try_combine_keys(
+                    &mut ukeys,
+                    &mut vkeys,
+                    uuid.as_bytes(),
+                    &auth_tag,
+                ) {
+                    Some(k) => {
+                        // Only run payload scripts if mTLS is enabled or 'enable_insecure_payload' option is set
+                        if run_payload {
+                            match request_run_payload(
+                                payloads_tx.clone(),
+                                k.clone(),
+                                encrypted_payload.clone(),
+                            )
+                            .await
+                            {
+                                Ok(_) => {
+                                    debug!("Sent RunPayload message to payloads worker");
+                                }
+                                Err(e) => {
+                                    warn!("Failed to send RunPayload message to payloads worker");
+                                }
+                            }
+                        } else {
+                            warn!("agent mTLS is disabled, and unless 'enable_insecure_payload' is set to 'True', payloads cannot be deployed'");
+                        }
+                        // Store combined key
+                        symm_key = Some(k);
+                    }
+                    None => {
+                        continue;
+                    }
+                }
+            }
+        }
     }
 
-    let key = key.as_ref().unwrap(); //#[allow_ci]
-    match crypto::compute_hmac(key.bytes(), param.challenge.as_bytes()) {
-        Ok(hmac) => {
-            let response = JsonWrapper::success(KeylimeHMAC {
-                hmac: hex::encode(hmac),
-            });
-
-            info!("GET key challenge returning 200 response.");
-            HttpResponse::Ok().json(response)
-        }
-        Err(e) => {
-            warn!("GET key challenge failed: {:?}", e);
-            HttpResponse::InternalServerError().json(JsonWrapper::error(
-                500,
-                "GET key challenge failed".to_string(),
-            ))
-        }
-    }
+    debug!("Shutting down keys worker");
+    Ok(())
 }
 
 #[cfg(test)]
@@ -281,6 +565,7 @@ mod tests {
         common::{AES_128_KEY_LEN, AES_256_KEY_LEN, API_VERSION},
         config::KeylimeConfig,
         crypto::compute_hmac,
+        payloads,
     };
     use actix_rt::Arbiter;
     use actix_web::{test, web, App};
@@ -288,10 +573,72 @@ mod tests {
         encrypt::Encrypter, hash::MessageDigest, pkey::PKey, rsa::Padding,
         sign::Signer,
     };
-    use std::env;
-    use std::fs;
-    use std::path::{Path, PathBuf};
-    use std::sync::Arc;
+    use std::{
+        env, fs,
+        path::{Path, PathBuf},
+    };
+    use tokio::sync::mpsc;
+
+    // Enough length for testing both AES-128 and AES-256
+    const U: &[u8; AES_256_KEY_LEN] = b"01234567890123456789012345678901";
+    const V: &[u8; AES_256_KEY_LEN] = b"ABCDEFGHIJABCDEFGHIJABCDEFGHIJAB";
+
+    fn test_combine_keys(key_len: usize) {
+        let u: SymmKey = U[..key_len][..].try_into().unwrap(); //#[allow_ci]
+        let v: SymmKey = V[..key_len][..].try_into().unwrap(); //#[allow_ci]
+        let mut ukeys = vec![u.clone()];
+        let mut vkeys = vec![v.clone()];
+        let k = u.xor(&v).unwrap(); //#[allow_ci]
+        let uuid = "test-uuid";
+        let hmac = compute_hmac(k.as_ref(), uuid.as_bytes()).unwrap(); //#[allow_ci]
+        let auth_tag: AuthTag = hmac.as_slice().try_into().unwrap(); //#[allow_ci]
+        let result = try_combine_keys(
+            &mut ukeys,
+            &mut vkeys,
+            uuid.as_bytes(),
+            &Some(auth_tag),
+        );
+        assert!(result.is_some());
+
+        // Check the keys list are emptied after a successful combination
+        assert!(ukeys.is_empty());
+        assert!(vkeys.is_empty());
+
+        // Check that missing ukeys, vkeys, or auth_tag makes it to return None
+        ukeys.push(u);
+        let auth_tag: AuthTag = vec![0u8; 48].as_slice().try_into().unwrap(); //#[allow_ci]
+        let result = try_combine_keys(
+            &mut ukeys,
+            &mut vkeys,
+            uuid.as_bytes(),
+            &Some(auth_tag.clone()),
+        );
+        assert!(result.is_none()); //#[allow_ci]
+
+        // Check that invalid auth_tag makes the combination to fail
+        vkeys.push(v);
+        let result = try_combine_keys(
+            &mut ukeys,
+            &mut vkeys,
+            uuid.as_bytes(),
+            &Some(auth_tag),
+        );
+        assert!(result.is_none());
+
+        // Check that the keys vecs are untouched
+        assert!(ukeys.len() == 1);
+        assert!(vkeys.len() == 1);
+    }
+
+    #[test]
+    async fn test_combine_keys_short() {
+        test_combine_keys(AES_128_KEY_LEN);
+    }
+
+    #[test]
+    async fn test_combine_keys_long() {
+        test_combine_keys(AES_256_KEY_LEN);
+    }
 
     #[cfg(feature = "testing")]
     async fn test_u_or_v_key(key_len: usize, payload: Option<&[u8]>) {
@@ -304,8 +651,21 @@ mod tests {
             PathBuf::from(&temp_workdir.path().join("tmpfs-dev"));
         fs::create_dir(&fixture.secure_mount).unwrap(); //#[allow_ci]
 
+        // Replace the channels on the fixture with some local ones
+        let (mut payload_tx, mut payload_rx) =
+            mpsc::channel::<PayloadMessage>(1);
+
+        let (mut keys_tx, mut keys_rx) = mpsc::channel::<(
+            KeyMessage,
+            Option<oneshot::Sender<SymmKeyMessage>>,
+        )>(1);
+
+        fixture.payload_tx = payload_tx.clone();
+        fixture.keys_tx = keys_tx.clone();
+
         let quotedata = web::Data::new(fixture);
 
+        // Run server
         let mut app = test::init_service(
             App::new()
                 .app_data(quotedata.clone())
@@ -316,40 +676,13 @@ mod tests {
                 .route(
                     &format!("/{API_VERSION}/keys/vkey"),
                     web::post().to(v_key),
+                )
+                .route(
+                    &format!("/{API_VERSION}/keys/verify"),
+                    web::get().to(verify),
                 ),
         )
         .await;
-
-        let arbiter = Arbiter::new();
-
-        let payload_symm_key_clone = Arc::clone(&quotedata.payload_symm_key);
-        let payload_symm_key_cvar_clone =
-            Arc::clone(&quotedata.payload_symm_key_cvar);
-        let encr_payload_clone = Arc::clone(&quotedata.encr_payload);
-        let test_config_clone = test_config.clone();
-        let secure_mount = PathBuf::from(&quotedata.secure_mount);
-
-        assert!(arbiter.spawn(Box::pin(async move {
-            let result = crate::run_encrypted_payload(
-                payload_symm_key_clone,
-                payload_symm_key_cvar_clone,
-                encr_payload_clone,
-                &test_config_clone,
-                &secure_mount,
-            )
-            .await;
-
-            if result.is_err() {
-                debug!("payload run failed: {:?}", result);
-            }
-            if !Arbiter::current().stop() {
-                debug!("couldn't stop current arbiter");
-            }
-        })));
-
-        // Enough length for testing both AES-128 and AES-256
-        const U: &[u8; AES_256_KEY_LEN] = b"01234567890123456789012345678901";
-        const V: &[u8; AES_256_KEY_LEN] = b"ABCDEFGHIJABCDEFGHIJABCDEFGHIJAB";
 
         let u: SymmKey = U[..key_len][..].try_into().unwrap(); //#[allow_ci]
         let v: SymmKey = V[..key_len][..].try_into().unwrap(); //#[allow_ci]
@@ -357,15 +690,58 @@ mod tests {
 
         let payload = payload.map(|payload| {
             let iv = b"ABCDEFGHIJKLMNOP";
-            encrypt_aead(k.bytes(), &iv[..], payload).unwrap() //#[allow_ci]
+            encrypt_aead(k.as_ref(), &iv[..], payload).unwrap() //#[allow_ci]
         });
 
-        let encrypted_key =
-            rsa_oaep_encrypt(&quotedata.pub_key, u.bytes()).unwrap(); //#[allow_ci]
-
         let auth_tag =
-            compute_hmac(k.bytes(), test_config.agent.uuid.as_bytes())
+            compute_hmac(k.as_ref(), test_config.agent.uuid.as_bytes())
                 .unwrap(); //#[allow_ci]
+
+        let arbiter = Arbiter::new();
+
+        let p_tx = payload_tx.clone();
+        // Run keys worker
+        assert!(arbiter.spawn(Box::pin(async move {
+            let result =
+                worker(true, test_config.agent.uuid.clone(), keys_rx, p_tx)
+                    .await;
+
+            if result.is_err() {
+                debug!("keys worker failed: {:?}", result);
+            }
+        })));
+
+        let k_clone = k.clone();
+        let p_clone = payload.clone();
+
+        // Run fake payloads worker
+        assert!(arbiter.spawn(Box::pin(async move {
+            while let Some(msg) = payload_rx.recv().await {
+                match msg {
+                    PayloadMessage::Shutdown => {
+                        payload_rx.close();
+                    }
+                    PayloadMessage::RunPayload(run_payload) => {
+                        assert!(
+                            run_payload.symm_key.as_ref() == k_clone.as_ref()
+                        );
+                        if let Some(ref p) = p_clone {
+                            assert!(
+                                run_payload.encrypted_payload.as_ref()
+                                    == p.as_slice()
+                            );
+                        }
+                    }
+                }
+            }
+
+            if !Arbiter::current().stop() {
+                debug!("couldn't stop current arbiter");
+            }
+        })));
+
+        let encrypted_key =
+            rsa_oaep_encrypt(&quotedata.pub_key, u.as_ref()).unwrap(); //#[allow_ci]
 
         let ukey = KeylimeUKey {
             encrypted_key: base64::encode(&encrypted_key),
@@ -382,7 +758,7 @@ mod tests {
         assert!(resp.status().is_success());
 
         let encrypted_key =
-            rsa_oaep_encrypt(&quotedata.pub_key, v.bytes()).unwrap(); //#[allow_ci]
+            rsa_oaep_encrypt(&quotedata.pub_key, v.as_ref()).unwrap(); //#[allow_ci]
 
         let vkey = KeylimeVKey {
             encrypted_key: base64::encode(&encrypted_key),
@@ -393,15 +769,46 @@ mod tests {
             .set_json(&vkey)
             .to_request();
 
+        // Check that while the key is not complete it is still ok to ask for the key
+        let result = get_symm_key(keys_tx.clone()).await;
+        assert!(result.is_ok());
+        let key = result.unwrap(); //#[allow_ci]
+        assert!(key.is_none());
+
         let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
 
-        {
-            let key = quotedata.payload_symm_key.lock().unwrap(); //#[allow_ci]
-            assert!(key.is_some());
-            assert_eq!(key.as_ref().unwrap().bytes(), k.bytes()); //#[allow_ci]
-        }
+        // Check that after sending both U and V keys, the key is properly combined
+        let result = get_symm_key(keys_tx.clone()).await;
+        assert!(result.is_ok());
+        let key = result.unwrap(); //#[allow_ci]
+        assert!(key.is_some());
+        if let Some(received) = key {
+            assert!(received.as_ref() == k.as_ref());
+        };
 
+        // Test verify which calculates an HMAC on the challenge using the combined key as key
+        let challenge = "1234567890ABCDEFGHIJ";
+        let expected =
+            compute_hmac(k.as_ref(), challenge.as_bytes()).unwrap(); //#[allow_ci]
+        let req = test::TestRequest::get()
+            .uri(&format!("/{API_VERSION}/keys/verify?challenge={challenge}"))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_success());
+
+        let result: JsonWrapper<KeylimeHMAC> =
+            test::read_body_json(resp).await;
+        let response_hmac = hex::decode(&result.results.hmac).unwrap(); //#[allow_ci]
+
+        assert_eq!(&response_hmac, &expected);
+
+        // Send Shutdown message to the workers for a graceful shutdown
+        keys_tx.send((KeyMessage::Shutdown, None)).await.unwrap(); //#[allow_ci]
+        payload_tx
+            .send(payloads::PayloadMessage::Shutdown)
+            .await
+            .unwrap(); //#[allow_ci]
         arbiter.join();
     }
 
@@ -415,21 +822,6 @@ mod tests {
     #[actix_rt::test]
     async fn test_u_or_v_key_long() {
         test_u_or_v_key(AES_256_KEY_LEN, None).await;
-    }
-
-    #[cfg(feature = "testing")]
-    #[actix_rt::test]
-    async fn test_u_or_v_key_with_payload() {
-        let payload_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("test-data")
-            .join("payload.zip");
-        let payload =
-            fs::read(&payload_path).expect("unable to read payload");
-        let dir = tempfile::tempdir().unwrap(); //#[allow_ci]
-        env::set_var("KEYLIME_TEST_DIR", dir.path());
-        test_u_or_v_key(AES_128_KEY_LEN, Some(payload.as_slice())).await;
-        let timestamp_path = dir.path().join("timestamp");
-        assert!(timestamp_path.exists());
     }
 
     #[cfg(feature = "testing")]
@@ -455,45 +847,5 @@ mod tests {
         assert!(pkey_pub_from_pem(&result.results.pubkey)
             .unwrap() //#[allow_ci]
             .public_eq(&quotedata.pub_key));
-    }
-
-    #[cfg(feature = "testing")]
-    #[actix_rt::test]
-    async fn test_verify() {
-        let mut quotedata = web::Data::new(QuoteData::fixture().unwrap()); //#[allow_ci]
-
-        let test_key: Vec<u8> = (0..32).collect();
-
-        {
-            let mut symkey = quotedata.payload_symm_key.lock().unwrap(); //#[allow_ci]
-            *symkey = Some(test_key.as_slice().try_into().unwrap()); //#[allow_ci]
-        }
-
-        let mut app =
-            test::init_service(App::new().app_data(quotedata.clone()).route(
-                &format!("/{API_VERSION}/keys/verify"),
-                web::get().to(verify),
-            ))
-            .await;
-
-        let challenge = "1234567890ABCDEFGHIJ";
-
-        let req = test::TestRequest::get()
-            .uri(&format!("/{API_VERSION}/keys/verify?challenge={challenge}"))
-            .to_request();
-
-        let resp = test::call_service(&app, req).await;
-        assert!(resp.status().is_success());
-
-        let result: JsonWrapper<KeylimeHMAC> =
-            test::read_body_json(resp).await;
-        let response_hmac = hex::decode(result.results.hmac).unwrap(); //#[allow_ci]
-
-        // The expected result is an HMAC-SHA384 using:
-        // key (hexadecimal): 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
-        // input: "1234567890ABCDEFGHIJ"
-        let expected = hex::decode("6d815226048e336305a3cf87dd5a205ae637ba1ece0716e29464ee887a04f0d784c8ace39c559dbfd65bccdd6fcb227a").unwrap(); //#[allow_ci]
-
-        assert_eq!(&response_hmac, &expected);
     }
 }

--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -39,6 +39,7 @@ mod error;
 mod errors_handler;
 mod keys_handler;
 mod notifications_handler;
+mod payloads;
 mod permissions;
 mod quotes_handler;
 mod registrar_agent;
@@ -50,7 +51,6 @@ mod version_handler;
 use actix_web::{dev::Service, http, middleware, rt, web, App, HttpServer};
 use clap::{Arg, Command as ClapApp};
 use common::*;
-use compress_tools::*;
 use error::{Error, Result};
 use futures::{
     future::{ok, TryFutureExt},
@@ -67,9 +67,7 @@ use std::{
     convert::TryFrom,
     fs,
     io::{BufReader, Read, Write},
-    os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
     str::FromStr,
     sync::{Arc, Condvar, Mutex},
     time::Duration,
@@ -117,225 +115,6 @@ pub struct QuoteData {
     measuredboot_ml_file: Option<Mutex<fs::File>>,
     ima_ml: Mutex<MeasurementList>,
     secure_mount: PathBuf,
-}
-
-// Parameters are based on Python codebase:
-// https://github.com/keylime/keylime/blob/1ed43ac8f75d5c3bc3a3bbbbb5037f20cf3c5a6a/ \
-// keylime/crypto.py#L189
-pub(crate) fn decrypt_payload(
-    encr: Arc<Mutex<Vec<u8>>>,
-    symm_key: &SymmKey,
-) -> Result<Vec<u8>> {
-    let payload = encr.lock().unwrap(); //#[allow_ci]
-
-    let decrypted = crypto::decrypt_aead(symm_key.bytes(), &payload)?;
-
-    info!("Successfully decrypted payload");
-    Ok(decrypted)
-}
-
-// sets up unzipped directory in secure mount location in preparation for
-// writing out symmetric key and encrypted payload. returns file paths for
-// both.
-pub(crate) fn setup_unzipped(
-    config: &config::KeylimeConfig,
-    mount: &Path,
-) -> Result<(PathBuf, PathBuf, PathBuf)> {
-    let unzipped = mount.join("unzipped");
-
-    // clear any old data
-    if Path::new(&unzipped).exists() {
-        fs::remove_dir_all(&unzipped)?;
-    }
-
-    let dec_payload_path = unzipped.join(&config.agent.dec_payload_file);
-    let key_path = unzipped.join(&config.agent.enc_keyname);
-
-    fs::create_dir(&unzipped)?;
-
-    Ok((unzipped, dec_payload_path, key_path))
-}
-
-// write symm key data and decrypted payload data out to specified files
-pub(crate) fn write_out_key_and_payload(
-    dec_payload: &[u8],
-    dec_payload_path: &Path,
-    key: &SymmKey,
-    key_path: &Path,
-) -> Result<()> {
-    let mut key_file = fs::File::create(key_path)?;
-    let bytes = key_file.write(key.bytes())?;
-    if bytes != key.bytes().len() {
-        return Err(Error::Other(format!("Error writing symm key to {:?}: key len is {}, but {} bytes were written", key_path, key.bytes().len(), bytes)));
-    }
-    info!("Wrote payload decryption key to {:?}", key_path);
-
-    let mut dec_payload_file = fs::File::create(dec_payload_path)?;
-    let bytes = dec_payload_file.write(dec_payload)?;
-    if bytes != dec_payload.len() {
-        return Err(Error::Other(format!("Error writing decrypted payload to {:?}: payload len is {}, but {} bytes were written", dec_payload_path, dec_payload.len(), bytes)));
-    }
-    info!("Wrote decrypted payload to {:?}", dec_payload_path);
-
-    Ok(())
-}
-
-// run a script (such as the init script, if any) and check the status
-pub(crate) fn run(dir: &Path, script: &str, uuid: &str) -> Result<()> {
-    let script_path = dir.join(script);
-    info!("Running script: {:?}", script_path);
-
-    if !script_path.exists() {
-        info!("No payload script {} found in {}", script, dir.display());
-        return Ok(());
-    }
-
-    if fs::set_permissions(&script_path, fs::Permissions::from_mode(0o700))
-        .is_err()
-    {
-        return Err(Error::Other(format!(
-            "unable to set {:?} as executable",
-            &script_path
-        )));
-    }
-
-    info!("Executing payload script: {}", script_path.display());
-
-    match Command::new("sh")
-        .arg("-c")
-        .arg(script_path.to_str().unwrap()) //#[allow_ci]
-        .current_dir(dir)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .status()
-    {
-        Ok(_) => {
-            info!("{:?} ran successfully", &script_path);
-            Ok(())
-        }
-        Err(e) => Err(Error::Other(format!(
-            "{:?} failed during run: {}",
-            &script_path, e
-        ))),
-    }
-}
-
-// checks if keylime-agent.conf indicates the payload should be unzipped, and does so if needed.
-// the input string is the directory where the unzipped file(s) should be stored.
-pub(crate) fn optional_unzip_payload(
-    unzipped: &Path,
-    config: &config::KeylimeConfig,
-) -> Result<()> {
-    if config.agent.extract_payload_zip {
-        let zipped_payload = &config.agent.dec_payload_file;
-        let zipped_payload_path = unzipped.join(zipped_payload);
-
-        info!("Unzipping payload {} to {:?}", &zipped_payload, unzipped);
-
-        let mut source = fs::File::open(zipped_payload_path)?;
-        uncompress_archive(&mut source, unzipped, Ownership::Ignore)?;
-    }
-
-    Ok(())
-}
-
-pub(crate) async fn run_encrypted_payload(
-    symm_key: Arc<Mutex<Option<SymmKey>>>,
-    symm_key_cvar: Arc<Condvar>,
-    payload: Arc<Mutex<Vec<u8>>>,
-    config: &config::KeylimeConfig,
-    mount: &Path,
-) -> Result<()> {
-    // do nothing until actix server's handlers have updated the symmetric key
-    let mut key = symm_key.lock().unwrap(); //#[allow_ci]
-    while key.is_none() {
-        key = symm_key_cvar.wait(key).unwrap(); //#[allow_ci]
-    }
-
-    let key = key.as_ref().unwrap(); //#[allow_ci]
-    let dec_payload = decrypt_payload(payload, key)?;
-
-    let (unzipped, dec_payload_path, key_path) =
-        setup_unzipped(config, mount)?;
-
-    write_out_key_and_payload(
-        &dec_payload,
-        &dec_payload_path,
-        key,
-        &key_path,
-    )?;
-
-    optional_unzip_payload(&unzipped, config)?;
-    // there may also be also a separate init script
-    match config.agent.payload_script.as_str() {
-        "" => {
-            info!("No payload script specified, skipping");
-        }
-        script => {
-            info!("Payload init script indicated: {}", script);
-            run(&unzipped, script, config.agent.uuid.as_str())?;
-        }
-    }
-
-    // Set execution permission for listed revocation actions
-    let action_file = unzipped.join("action_list");
-
-    if action_file.exists() {
-        let action_data = std::fs::read_to_string(&action_file)
-            .expect("unable to read action_list");
-
-        action_data
-            .split('\n')
-            .filter(|&script| !script.is_empty())
-            .map(|script| script.trim())
-            .map(|script| unzipped.join(script))
-            .filter(|script| script.exists())
-            .try_for_each(|script| {
-                if fs::set_permissions(
-                    &script,
-                    fs::Permissions::from_mode(0o700),
-                )
-                .is_err()
-                {
-                    error!(
-                        "Could not set permission for action {}",
-                        script.display()
-                    );
-                    Err(Error::Permission)
-                } else {
-                    info!("Permission set for action: {}", script.display());
-                    Ok(())
-                }
-            })?
-    }
-
-    Ok(())
-}
-
-async fn worker(
-    symm_key: Arc<Mutex<Option<SymmKey>>>,
-    symm_key_cvar: Arc<Condvar>,
-    payload: Arc<Mutex<Vec<u8>>>,
-    config: config::KeylimeConfig,
-    mount: PathBuf,
-) -> Result<()> {
-    // Only run payload scripts if mTLS is enabled or 'enable_insecure_payload' option is set
-    if config.agent.enable_agent_mtls || config.agent.enable_insecure_payload
-    {
-        run_encrypted_payload(
-            symm_key,
-            symm_key_cvar,
-            payload,
-            &config,
-            &mount,
-        )
-        .await?;
-    } else {
-        warn!("agent mTLS is disabled, and unless 'enable_insecure_payload' is set to 'True', payloads cannot be deployed'");
-    }
-
-    Ok(())
 }
 
 #[actix_web::main]
@@ -932,7 +711,7 @@ async fn main() -> Result<()> {
 
     let server_handle = server.handle();
     let server_task = rt::spawn(server).map_err(Error::from);
-    let worker_task = rt::spawn(worker(
+    let worker_task = rt::spawn(payloads::worker(
         symm_key,
         symm_key_cvar,
         payload,
@@ -1110,27 +889,5 @@ mod tests {
                 .expect("File doesn't exist"),
             String::from("Hello World!\n")
         );
-    }
-
-    #[test]
-    fn test_run() {
-        let dir = tempfile::tempdir().unwrap(); //#[allow_ci]
-        let script_path = dir.path().join("test-script.sh");
-        {
-            let mut script_file = fs::File::create(&script_path).unwrap(); //#[allow_ci]
-            let script = r#"
-#!/bin/sh
-
-echo hello > test-output
-"#;
-            let _ = script_file.write(script.as_bytes()).unwrap(); //#[allow_ci]
-        }
-        run(
-            dir.path(),
-            script_path.file_name().unwrap().to_str().unwrap(), //#[allow_ci]
-            "D432FBB3-D2F1-4A97-9EF7-75BD81C0000X",
-        )
-        .unwrap(); //#[allow_ci]
-        assert!(dir.path().join("test-output").exists());
     }
 }

--- a/keylime-agent/src/payloads.rs
+++ b/keylime-agent/src/payloads.rs
@@ -26,15 +26,15 @@ use std::{
 };
 use tokio::sync::mpsc::{Receiver, Sender};
 
-#[derive(Debug, Deserialize, Serialize)]
-pub(crate) struct RunPayload {
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub(crate) struct Payload {
     pub symm_key: SymmKey,
     pub encrypted_payload: EncryptedData,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub(crate) enum PayloadMessage {
-    RunPayload(RunPayload),
+    RunPayload(Payload),
     Shutdown,
 }
 

--- a/keylime-agent/src/payloads.rs
+++ b/keylime-agent/src/payloads.rs
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Keylime Authors
+
+use crate::{common::SymmKey, config, crypto, Error, Result};
+use compress_tools::*;
+use log::*;
+use std::{
+    fs,
+    io::{BufReader, Read, Write},
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::{Arc, Condvar, Mutex},
+};
+
+// Parameters are based on Python codebase:
+// https://github.com/keylime/keylime/blob/1ed43ac8f75d5c3bc3a3bbbbb5037f20cf3c5a6a/ \
+// keylime/crypto.py#L189
+fn decrypt_payload(
+    encr: Arc<Mutex<Vec<u8>>>,
+    symm_key: &SymmKey,
+) -> Result<Vec<u8>> {
+    let payload = encr.lock().unwrap(); //#[allow_ci]
+
+    let decrypted = crypto::decrypt_aead(symm_key.bytes(), &payload)?;
+
+    info!("Successfully decrypted payload");
+    Ok(decrypted)
+}
+
+// sets up unzipped directory in secure mount location in preparation for
+// writing out symmetric key and encrypted payload. returns file paths for
+// both.
+fn setup_unzipped(
+    config: &config::KeylimeConfig,
+    mount: &Path,
+) -> Result<(PathBuf, PathBuf, PathBuf)> {
+    let unzipped = mount.join("unzipped");
+
+    // clear any old data
+    if Path::new(&unzipped).exists() {
+        fs::remove_dir_all(&unzipped)?;
+    }
+
+    let dec_payload_path = unzipped.join(&config.agent.dec_payload_file);
+    let key_path = unzipped.join(&config.agent.enc_keyname);
+
+    fs::create_dir(&unzipped)?;
+
+    Ok((unzipped, dec_payload_path, key_path))
+}
+
+// write symm key data and decrypted payload data out to specified files
+fn write_out_key_and_payload(
+    dec_payload: &[u8],
+    dec_payload_path: &Path,
+    key: &SymmKey,
+    key_path: &Path,
+) -> Result<()> {
+    let mut key_file = fs::File::create(key_path)?;
+    let bytes = key_file.write(key.bytes())?;
+    if bytes != key.bytes().len() {
+        return Err(Error::Other(format!("Error writing symm key to {:?}: key len is {}, but {} bytes were written", key_path, key.bytes().len(), bytes)));
+    }
+    info!("Wrote payload decryption key to {:?}", key_path);
+
+    let mut dec_payload_file = fs::File::create(dec_payload_path)?;
+    let bytes = dec_payload_file.write(dec_payload)?;
+    if bytes != dec_payload.len() {
+        return Err(Error::Other(format!("Error writing decrypted payload to {:?}: payload len is {}, but {} bytes were written", dec_payload_path, dec_payload.len(), bytes)));
+    }
+    info!("Wrote decrypted payload to {:?}", dec_payload_path);
+
+    Ok(())
+}
+
+// run a script (such as the init script, if any) and check the status
+fn run(dir: &Path, script: &str, uuid: &str) -> Result<()> {
+    let script_path = dir.join(script);
+    info!("Running script: {:?}", script_path);
+
+    if !script_path.exists() {
+        info!("No payload script {} found in {}", script, dir.display());
+        return Ok(());
+    }
+
+    if fs::set_permissions(&script_path, fs::Permissions::from_mode(0o700))
+        .is_err()
+    {
+        return Err(Error::Other(format!(
+            "unable to set {:?} as executable",
+            &script_path
+        )));
+    }
+
+    info!("Executing payload script: {}", script_path.display());
+
+    match Command::new("sh")
+        .arg("-c")
+        .arg(script_path.to_str().unwrap()) //#[allow_ci]
+        .current_dir(dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .status()
+    {
+        Ok(_) => {
+            info!("{:?} ran successfully", &script_path);
+            Ok(())
+        }
+        Err(e) => Err(Error::Other(format!(
+            "{:?} failed during run: {}",
+            &script_path, e
+        ))),
+    }
+}
+
+// checks if keylime-agent.conf indicates the payload should be unzipped, and does so if needed.
+// the input string is the directory where the unzipped file(s) should be stored.
+fn optional_unzip_payload(
+    unzipped: &Path,
+    config: &config::KeylimeConfig,
+) -> Result<()> {
+    if config.agent.extract_payload_zip {
+        let zipped_payload = &config.agent.dec_payload_file;
+        let zipped_payload_path = unzipped.join(zipped_payload);
+
+        info!("Unzipping payload {} to {:?}", &zipped_payload, unzipped);
+
+        let mut source = fs::File::open(zipped_payload_path)?;
+        uncompress_archive(&mut source, unzipped, Ownership::Ignore)?;
+    }
+
+    Ok(())
+}
+
+async fn run_encrypted_payload(
+    symm_key: Arc<Mutex<Option<SymmKey>>>,
+    symm_key_cvar: Arc<Condvar>,
+    payload: Arc<Mutex<Vec<u8>>>,
+    config: &config::KeylimeConfig,
+    mount: &Path,
+) -> Result<()> {
+    // do nothing until actix server's handlers have updated the symmetric key
+    let mut key = symm_key.lock().unwrap(); //#[allow_ci]
+    while key.is_none() {
+        key = symm_key_cvar.wait(key).unwrap(); //#[allow_ci]
+    }
+
+    let key = key.as_ref().unwrap(); //#[allow_ci]
+    let dec_payload = decrypt_payload(payload, key)?;
+
+    let (unzipped, dec_payload_path, key_path) =
+        setup_unzipped(config, mount)?;
+
+    write_out_key_and_payload(
+        &dec_payload,
+        &dec_payload_path,
+        key,
+        &key_path,
+    )?;
+
+    optional_unzip_payload(&unzipped, config)?;
+    // there may also be also a separate init script
+    match config.agent.payload_script.as_str() {
+        "" => {
+            info!("No payload script specified, skipping");
+        }
+        script => {
+            info!("Payload init script indicated: {}", script);
+            run(&unzipped, script, config.agent.uuid.as_str())?;
+        }
+    }
+
+    // Set execution permission for listed revocation actions
+    let action_file = unzipped.join("action_list");
+
+    if action_file.exists() {
+        let action_data = std::fs::read_to_string(&action_file)
+            .expect("unable to read action_list");
+
+        action_data
+            .split('\n')
+            .filter(|&script| !script.is_empty())
+            .map(|script| script.trim())
+            .map(|script| unzipped.join(script))
+            .filter(|script| script.exists())
+            .try_for_each(|script| {
+                if fs::set_permissions(
+                    &script,
+                    fs::Permissions::from_mode(0o700),
+                )
+                .is_err()
+                {
+                    error!(
+                        "Could not set permission for action {}",
+                        script.display()
+                    );
+                    Err(Error::Permission)
+                } else {
+                    info!("Permission set for action: {}", script.display());
+                    Ok(())
+                }
+            })?
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn worker(
+    symm_key: Arc<Mutex<Option<SymmKey>>>,
+    symm_key_cvar: Arc<Condvar>,
+    payload: Arc<Mutex<Vec<u8>>>,
+    config: config::KeylimeConfig,
+    mount: impl AsRef<Path>,
+) -> Result<()> {
+    // Only run payload scripts if mTLS is enabled or 'enable_insecure_payload' option is set
+    if config.agent.enable_agent_mtls || config.agent.enable_insecure_payload
+    {
+        run_encrypted_payload(
+            symm_key,
+            symm_key_cvar,
+            payload,
+            &config,
+            mount.as_ref(),
+        )
+        .await?;
+    } else {
+        warn!("agent mTLS is disabled, and unless 'enable_insecure_payload' is set to 'True', payloads cannot be deployed'");
+    }
+
+    Ok(())
+}
+
+// Unit Testing
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run() {
+        let dir = tempfile::tempdir().unwrap(); //#[allow_ci]
+        let script_path = dir.path().join("test-script.sh");
+        {
+            let mut script_file = fs::File::create(&script_path).unwrap(); //#[allow_ci]
+            let script = r#"
+#!/bin/sh
+
+echo hello > test-output
+"#;
+            let _ = script_file.write(script.as_bytes()).unwrap(); //#[allow_ci]
+        }
+        run(
+            dir.path(),
+            script_path.file_name().unwrap().to_str().unwrap(), //#[allow_ci]
+            "D432FBB3-D2F1-4A97-9EF7-75BD81C0000X",
+        )
+        .unwrap(); //#[allow_ci]
+        assert!(dir.path().join("test-output").exists());
+    }
+}

--- a/keylime-agent/src/revocation.rs
+++ b/keylime-agent/src/revocation.rs
@@ -330,8 +330,8 @@ pub(crate) fn process_revocation(
 ///   Function: await_notifications
 #[cfg(feature = "with-zmq")]
 pub(crate) async fn run_revocation_service(
-    config: &KeylimeConfig,
-    mount: &Path,
+    config: KeylimeConfig,
+    mount: impl AsRef<Path>,
 ) -> Result<()> {
     let work_dir = Path::new(&config.agent.keylime_dir);
 
@@ -421,7 +421,7 @@ pub(crate) async fn run_revocation_service(
             actions_dir,
             config.agent.allow_payload_revocation_actions,
             work_dir,
-            mount,
+            mount.as_ref(),
         );
     }
     Ok(())


### PR DESCRIPTION
Use messages for synchronization instead of mutexes and condvar.  Add
separate workers for keys, payload, and revocation execution, as well as
a worker to handle the revocations coming from ZeroMQ channel.

The workers  hold the state locally instead of storing all data in server
context (QuoteData).

The keys worker holds the received U and K keys and is responsible for
combining them to obtain K.  It also provides the K key when requested
by the /keys/verify endpoint to prove that the resulting K is correct.

When the U and V keys combination is successful (the HMAC verification
is successful), the keys worker wakes the payloads worker sending the
obtained K key and the encrypted payload.

The payloads worker is responsible for decrypting and running the
payload sent by the keys worker.

After decrypting and running the payload, the payloads worker will send
messages to the revocation worker and ZMQ worker to start listening for
revocations.

This also implements graceful shutdown on Ctrl + C (SIGINT) signal.
A dedicated task is spawned to receive the signal and stop the other workers.

Unit tests were implemented for the changes.

Fixes: #363, #447