### PR TITLE
Prevent HMAC mismatch error from disabling rust agent.

### DIFF
--- a/keylime-agent/src/keys_handler.rs
+++ b/keylime-agent/src/keys_handler.rs
@@ -82,6 +82,9 @@ pub(crate) fn try_combine_keys(
         }
     }
 
+    // we have failed to decode the U/V keys. Clear keys to enable later attempts.
+    keyset1.clear();
+    keyset2.clear();
     Err(Error::Other(
         "HMAC check failed for all U and V key combinations".to_string(),
     ))


### PR DESCRIPTION
This is a trivial fix to prevent situations in which U/V key mismatches disable the keylime agent, putting it into a state where it is no longer possible to successfully activate it.

Because of the simplicity of the fix I didn't bother with a separate Issue to describe the problem, but here is a potted summary of it:

* The bug I'm attempting to fix can be produced by calling two `keylime_tenant -c add` commands in close succession on the same agent, causing the U key of the *second* `add` to mix with the V key from the verifier of the *first* `add`. This causes the HMAC check failure, and the agent now has populated U and V keys, ensuring that later calls to `u_key` or `v_key` will continue to cause this failure. Currently this can only be fixed by a forced re-start and re-registration of the keylime agent.

* The fix simply clears the U and V keys when HMAC failure is registered. No loss of actual information, since the system is broken on the verifier side -- the agent could not be activated. However, once the keys are cleared we are allowing a new tenant command to succeed, since now the HMAC check will be bypassed until both U and V are collected.

*Note* this fix does not deal with the state problems in the keylime verifier. It merely enables the keylime agent to recover from situations that the tenant/verifier should have never put it into. Separate fixes will be required to ensure the tenant and verifier behave well.

Signed-off-by: George Almasi <gheorghe@us.ibm.com>