### PR TITLE
keylime-agent: remove const_err deny

### DIFF
--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -3,7 +3,6 @@
 
 #![deny(
     nonstandard_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,


### PR DESCRIPTION
In 1.66 / 1.66.1 const_err is already a hard error, and was enabled as such as long ago. New compilers will complain in case that this is still used:

  warning: lint `const_err` has been removed: converted into hard error

More info:
  https://github.com/rust-lang/rust/issues/71800