### PR TITLE
Cargo.toml: tss-esapi bindings

### DIFF
--- a/keylime-ima-emulator/Cargo.toml
+++ b/keylime-ima-emulator/Cargo.toml
@@ -12,4 +12,4 @@ keylime = { path = "../keylime" }
 log = "0.4"
 openssl = "0.10.15"
 thiserror = "1.0"
-tss-esapi = "7.1.0"
+tss-esapi = {version = "7.1.0", features = ["generate-bindings"]}

--- a/keylime/Cargo.toml
+++ b/keylime/Cargo.toml
@@ -14,7 +14,7 @@ serde = "1.0.80"
 serde_derive = "1.0.80"
 static_assertions = "1"
 thiserror = "1.0"
-tss-esapi = "7.1.0"
+tss-esapi = {version = "7.1.0", features = ["generate-bindings"]}
 
 [dev-dependencies]
 tempfile = "3.0.4"


### PR DESCRIPTION
Generate the tss-esapi bindings during compilation time.  This will extend the ammount of supported architectures.

This is a regression done after the crate split, that was fixed before in #459.

Signed-off-by: Alberto Planas <aplanas@suse.com>