### PR TITLE
config: Fix overriding options with env vars

### DIFF
--- a/keylime-agent.conf
+++ b/keylime-agent.conf
@@ -1,36 +1,61 @@
+# All configuration options can be overridden by environment variables.
+# The environment variables used to override options are composed by the
+# 'KEYLIME_AGENT_' prefix followed by the option to be set in upper case.
+# For example, to override the 'registrar_ip' option, set the
+# KEYLIME_AGENT_REGISTRAR_IP environment variable.
+
 #=============================================================================
 [agent]
 #=============================================================================
 
 # The configuration file version
+#
+# To override, set KEYLIME_AGENT_VERSION environment variable.
 version = "2.0"
 
 # The agent's UUID.
 # If you set this to "generate", Keylime will create a random UUID.
 # If you set this to "hash_ek", Keylime will set the UUID to the result
 # of 'SHA256(public EK in PEM format)'.
+#
+# To override, set KEYLIME_AGENT_UUID environment variable.
 uuid = "d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
 
-# The binding address and port for the agent server
+# The binding IP address and port for the agent server
+#
+# To override ip, set KEYLIME_AGENT_IP environment variable.
+# To override port, set KEYLIME_AGENT_PORT environment variable.
 ip = "127.0.0.1"
 port = 9002
 
 # Address and port where the verifier and tenant can connect to reach the agent.
 # These keys are optional.
+#
+# To override contact_ip, set KEYLIME_AGENT_CONTACT_IP environment variable.
+# To override contact_port, set KEYLIME_AGENT_CONTACT_PORT environment variable.
 contact_ip = "127.0.0.1"
 contact_port = 9002
 
 # The address and port of registrar server which agent communicate with
+#
+# To override registrar_ip, set KEYLIME_AGENT_REGISTRAR_IP environment variable.
+# To override registrar_port, set KEYLIME_AGENT_REGISTRAR_PORT environment
+# variable.
 registrar_ip = "127.0.0.1"
 registrar_port = 8890
 
 # Enable mTLS communication between agent, verifier and tenant.
 # Details on why setting it to "false" is generally considered insecure can be found
 # on https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
+#
+# To override enable_agent_mtls, set KEYLIME_AGENT_ENABLE_AGENT_MTLS environment
+# variable.
 enable_agent_mtls = true
 
-# The keylime working directory.  Can be overriden by setting the KEYLIME_DIR
-# environment variable. The default value is /var/lib/keylime
+# The keylime working directory. The default value is /var/lib/keylime
+#
+# To override keylime_dir, set KEYLIME_AGENT_KEYLIME_DIR or KEYLIME_DIR
+# environment variable.
 keylime_dir = "/var/lib/keylime"
 
 # The name of the file containing the Keylime agent TLS server private key.
@@ -39,12 +64,17 @@ keylime_dir = "/var/lib/keylime"
 # If set as "default", the "server-private.pem" value is used.
 # If a relative path is set, it will be considered relative from the keylime_dir.
 # If an absolute path is set, it is used without change
+#
+# To override server_key, set KEYLIME_AGENT_SERVER_KEY environment variable.
 server_key = "default"
 
 # Set the password used to encrypt the private key file.
 # This password will also be used to protect the generated private key used for
 # mTLS authentication
 # If left empty, the private key will not be encrypted.
+#
+# To override server_key_password, set KEYLIME_AGENT_SERVER_KEY_PASSWORD
+# environment variable.
 server_key_password = ""
 
 # The name of the file containing the X509 certificate used as the Keylime agent
@@ -53,6 +83,8 @@ server_key_password = ""
 # If set as "default", the "server-cert.crt" value is used
 # If a relative path is set, it will be considered relative from the keylime_dir.
 # If an absolute path is set, it is used without change.
+#
+# To override server_cert, set KEYLIME_AGENT_SERVER_CERT environment variable.
 server_cert = "default"
 
 # The CA that signs the client certificates of the tenant and verifier.
@@ -60,19 +92,29 @@ server_cert = "default"
 # keylime_dir is used.
 # If a relative path is set, it will be considered relative from the keylime_dir.
 # If an absolute path is set, it is used without change.
+#
+# To override trusted_client_ca, set KEYLIME_AGENT_TRUSTED_CLIENT_CA environment
+# variable.
 trusted_client_ca = "default"
 
 # The name that should be used for the encryption key, placed in the
 # $keylime_dir/secure/ directory.
+#
+# To override enc_keyname, set KEYLIME_AGENT_ENC_KEYNAME environment variable.
 enc_keyname = "derived_tci_key"
 
 # The name that should be used for the optional decrypted payload, placed in
 # the $keylime_dir/secure directory.
+#
+# To override dec_payload_file, set KEYLIME_AGENT_DEC_PAYLOAD_FILE environment
+# variable.
 dec_payload_file = "decrypted_payload"
 
 # The size of the memory-backed tmpfs partition where Keylime stores crypto keys.
 # Use syntax that the 'mount' command would accept as a size parameter for tmpfs.
 # The default below sets it to 1 megabyte.
+#
+# To override secure_size, set KEYLIME_AGENT_SECURE_SIZE environment variable.
 secure_size = "1m"
 
 # Whether to allow the agent to automatically extract a zip file in the
@@ -80,21 +122,35 @@ secure_size = "1m"
 # After decryption, the archive will be unzipped to a directory in $keylime_dir/secure.
 # Note: the limits on the size of the tmpfs partition set above with the 'secure_size'
 # option will affect this.
+#
+# To override extract_payload_zip, set KEYLIME_AGENT_EXTRACT_PAYLOAD_ZIP
+# environment variable.
 extract_payload_zip = true
 
 # Whether to listen for revocation notifications from the verifier via zeromq.
 # Note: The agent supports receiving revocation notifications via REST API
 # regardless of the value set here.
+#
+# To override enable_revocation_notifications, set
+# KEYLIME_AGENT_ENABLE_REVOCATION_NOTIFICATIONS environment variable.
 enable_revocation_notifications = true
 
 # The path to the directory containing the pre-installed revocation action
 # scripts.  Ideally should point to an fixed/immutable location subject to
 # attestation.  The default is /usr/libexec/keylime.
+#
+# To override revocation_actions_dir, set KEYLIME_AGENT_REVOCATION_ACTIONS_DIR
+# environment variable.
 revocation_actions_dir = "/usr/libexec/keylime"
 
 # Revocation IP & Port used by the agent to receive revocation
 # notifications from the verifier via zeromq.
 # This is optional and used only when 'enable_revocation_notifications' is 'true'.
+#
+# To override revocation_notification_ip, set
+# KEYLIME_AGENT_REVOCATION_NOTIFICATION_IP environment variable.
+# To override revocation_notification_port, set
+# KEYLIME_AGENT_REVOCATION_NOTIFICATION_PORT environment variable.
 revocation_notification_ip = "127.0.0.1"
 revocation_notification_port = 8992
 
@@ -103,20 +159,29 @@ revocation_notification_port = 8992
 # provided (i.e. starts with '/').
 # If set to "default", Keylime will use the file RevocationNotifier-cert.crt
 # from the unzipped payload contents provided by the tenant.
+#
+# To override revocation_cert, set KEYLIME_AGENT_REVOCATION_CERT environment
+# variable.
 revocation_cert = "default"
 
 # A comma-separated list of executables to run upon receiving a revocation
 # message. Keylime will verify the signature first, then call these executables
 # passing the json revocation message.
-# The executables must be located in the 'revocation_actions' directory.
+# The executables must be located in the 'revocation_actions_dir' directory.
 #
 # Keylime will also get the list of revocation actions from the file
 # action_list in the unzipped payload contents provided by the verifier.
+#
+# To override revocation_actions, set KEYLIME_AGENT_REVOCATION_ACTIONS
+# environment variable.
 revocation_actions = ""
 
 # A script to execute after unzipping the tenant payload.
 # Keylime will run it with a /bin/sh environment and with a working directory of
 # $keylime_dir/secure/unzipped.
+#
+# To override payload_script, set KEYLIME_AGENT_PAYLOAD_SCRIPT environment
+# variable.
 payload_script = "autorun.sh"
 
 # In case mTLS for the agent is disabled and the use of payloads is still
@@ -124,11 +189,17 @@ payload_script = "autorun.sh"
 # to start. Details on why this configuration (mTLS disabled and payload enabled)
 # is generally considered insecure can be found on
 # https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
+#
+# To override enable_insecure_payload, set KEYLIME_AGENT_ENABLE_INSECURE_PAYLOAD
+# environment variable.
 enable_insecure_payload = false
 
 # Whether to allow running revocation actions sent as part of the payload.  The
 # default is true and setting as false will limit the revocation actions to the
 # pre-installed ones.
+#
+# To override allow_payload_revocation_actions, set
+# KEYLIME_AGENT_ALLOW_PAYLOAD_REVOCATION_ACTIONS environment variable.
 allow_payload_revocation_actions = true
 
 # TPM2-specific options, allows customizing default algorithms to use.
@@ -138,6 +209,12 @@ allow_payload_revocation_actions = true
 # - hashing:    sha512, sha384, sha256 or sha1
 # - encryption: ecc or rsa
 # - signing:    rsassa, rsapss, ecdsa, ecdaa or ecschnorr
+#
+# To override tpm_hash_alg, set KEYLIME_AGENT_TPM_HASH_ALG environment variable.
+# To override tpm_encryption_alg, set KEYLIME_AGENT_TPM_ENCRYPTION_ALG
+# environment variable.
+# To override tpm_signing_alg, set KEYLIME_AGENT_TPM_SIGNING_ALG environment
+# variable.
 tpm_hash_alg = "sha256"
 tpm_encryption_alg = "rsa"
 tpm_signing_alg = "rsassa"
@@ -146,12 +223,17 @@ tpm_signing_alg = "rsassa"
 # you require Keylime to use this EK, change "generate" to the actual EK
 # handle (e.g. "0x81000000"). The Keylime agent will then not attempt to
 # create a new EK upon startup, and neither will it flush the EK upon exit.
+#
+# To override ek_handle, set KEYLIME_AGENT_EK_HANDLE environment variable.
 ek_handle = "generate"
 
 # Use this option to state the existing TPM ownerpassword.
 # This option should be set only when a password is set for the Endorsement
 # Hierarchy (e.g. via "tpm2_changeauth -c e").
 # If no password was set, keep the empty string "".
+#
+# To override tpm_ownerpassword, set KEYLIME_AGENT_TPM_OWNERPASSWORD environment
+# variable.
 tpm_ownerpassword = ""
 
 # The user account to switch to to drop privileges when started as root
@@ -170,6 +252,7 @@ tpm_ownerpassword = ""
 # chown keylime /var/lib/keylime/cv_ca
 # chown keylime /var/lib/keylime/cv_ca/cacert.crt
 #
+# To override run_as, set KEYLIME_AGENT_RUN_AS environment variable.
 run_as = "keylime:tss"
 
 # Path where to store the agent tpm data which can be loaded later
@@ -177,5 +260,8 @@ run_as = "keylime:tss"
 # directory set by the keylime_dir option above
 # If set as "default" Keylime will use "agent_data.json", located at
 # keylime_dir.
+#
+# To override agent_data_path, set KEYLIME_AGENT_AGENT_DATA_PATH environment
+# variable.
 agent_data_path = "default"
 

--- a/keylime-agent/src/common.rs
+++ b/keylime-agent/src/common.rs
@@ -307,6 +307,7 @@ mod tests {
         Context,
     };
 
+    #[cfg(feature = "testing")]
     #[test]
     fn test_agent_data() -> Result<()> {
         let mut config = KeylimeConfig::default();
@@ -318,17 +319,19 @@ mod tests {
         )?;
 
         let tpm_hash_alg =
-            HashAlgorithm::try_from(config.agent.tpm_hash_alg.as_str())?;
+            HashAlgorithm::try_from(config.agent.tpm_hash_alg.as_str())
+                .expect("Failed to get hash algorithm");
 
         let tpm_signing_alg =
-            SignAlgorithm::try_from(config.agent.tpm_signing_alg.as_str())?;
+            SignAlgorithm::try_from(config.agent.tpm_signing_alg.as_str())
+                .expect("Failed to get signing algorithm");
 
-        let ek_result = ctx.create_ek(
-            tpm_encryption_alg,
-            config.agent.ek_handle.as_deref(),
-        )?;
+        let ek_result = ctx
+            .create_ek(tpm_encryption_alg, None)
+            .expect("Failed to create EK");
 
-        let ek_hash = hash_ek_pubkey(ek_result.public)?;
+        let ek_hash =
+            hash_ek_pubkey(ek_result.public).expect("Failed to get pubkey");
 
         let ak = ctx.create_ak(
             ek_result.key_handle,
@@ -352,6 +355,8 @@ mod tests {
         assert!(valid);
         Ok(())
     }
+
+    #[cfg(feature = "testing")]
     #[test]
     fn test_hash() -> Result<()> {
         let mut config = KeylimeConfig::default();
@@ -360,12 +365,12 @@ mod tests {
 
         let tpm_encryption_alg = EncryptionAlgorithm::try_from(
             config.agent.tpm_encryption_alg.as_str(),
-        )?;
+        )
+        .expect("Failed to get encryption algorithm");
 
-        let ek_result = ctx.create_ek(
-            tpm_encryption_alg,
-            config.agent.ek_handle.as_deref(),
-        )?;
+        let ek_result = ctx
+            .create_ek(tpm_encryption_alg, None)
+            .expect("Failed to create EK");
 
         let result = hash_ek_pubkey(ek_result.public);
 

--- a/keylime-agent/src/config.rs
+++ b/keylime-agent/src/config.rs
@@ -59,196 +59,251 @@ pub static DEFAULT_AGENT_DATA_PATH: &str = "agent_data.json";
 pub static DEFAULT_CONFIG: &str = "/etc/keylime/agent.conf";
 pub static DEFAULT_CONFIG_SYS: &str = "/usr/etc/keylime/agent.conf";
 
-impl Source for KeylimeConfig {
-    fn collect(&self) -> Result<Map<String, Value>, ConfigError> {
-        let agent: Map<String, Value> = Map::from([
-            ("version".to_string(), self.agent.version.to_string().into()),
-            ("uuid".to_string(), self.agent.uuid.to_string().into()),
-            ("ip".to_string(), self.agent.ip.to_string().into()),
-            ("port".to_string(), Value::from(self.agent.port)),
-            (
-                "contact_ip".to_string(),
-                if let Some(ref s) = self.agent.contact_ip {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "contact_port".to_string(),
-                if let Some(ref s) = self.agent.contact_port {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "registrar_ip".to_string(),
-                self.agent.registrar_ip.to_string().into(),
-            ),
-            (
-                "registrar_port".to_string(),
-                self.agent.registrar_port.into(),
-            ),
-            (
-                "enable_agent_mtls".to_string(),
-                self.agent.enable_agent_mtls.into(),
-            ),
-            (
-                "keylime_dir".to_string(),
-                self.agent.keylime_dir.to_string().into(),
-            ),
-            (
-                "server_key".to_string(),
-                if let Some(ref s) = self.agent.server_key {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "server_key_password".to_string(),
-                if let Some(ref s) = self.agent.server_key_password {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "server_cert".to_string(),
-                if let Some(ref s) = self.agent.server_cert {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "trusted_client_ca".to_string(),
-                if let Some(ref s) = self.agent.trusted_client_ca {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "enc_keyname".to_string(),
-                self.agent.enc_keyname.to_string().into(),
-            ),
-            (
-                "dec_payload_file".to_string(),
-                self.agent.dec_payload_file.to_string().into(),
-            ),
-            (
-                "secure_size".to_string(),
-                self.agent.secure_size.to_string().into(),
-            ),
-            (
-                "tpm_ownerpassword".to_string(),
-                if let Some(ref s) = self.agent.tpm_ownerpassword {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "extract_payload_zip".to_string(),
-                self.agent.extract_payload_zip.into(),
-            ),
-            (
-                "enable_revocation_notifications".to_string(),
-                self.agent.enable_revocation_notifications.into(),
-            ),
-            (
-                "revocation_actions_dir".to_string(),
-                if let Some(ref s) = self.agent.revocation_actions_dir {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "revocation_notification_ip".to_string(),
-                if let Some(ref s) = self.agent.revocation_notification_ip {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "revocation_notification_port".to_string(),
-                if let Some(ref s) = self.agent.revocation_notification_port {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "revocation_cert".to_string(),
-                if let Some(ref s) = self.agent.revocation_cert {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "revocation_actions".to_string(),
-                if let Some(ref s) = self.agent.revocation_actions {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "payload_script".to_string(),
-                self.agent.payload_script.to_string().into(),
-            ),
-            (
-                "enable_insecure_payload".to_string(),
-                self.agent.enable_insecure_payload.to_string().into(),
-            ),
-            (
-                "allow_payload_revocation_actions".to_string(),
-                self.agent.allow_payload_revocation_actions.into(),
-            ),
-            (
-                "tpm_hash_alg".to_string(),
-                self.agent.tpm_hash_alg.to_string().into(),
-            ),
-            (
-                "tpm_encryption_alg".to_string(),
-                self.agent.tpm_encryption_alg.to_string().into(),
-            ),
-            (
-                "tpm_signing_alg".to_string(),
-                self.agent.tpm_signing_alg.to_string().into(),
-            ),
-            (
-                "ek_handle".to_string(),
-                if let Some(ref s) = self.agent.ek_handle {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "run_as".to_string(),
-                if let Some(ref s) = self.agent.run_as {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-            (
-                "agent_data_path".to_string(),
-                if let Some(ref s) = self.agent.agent_data_path {
-                    s.to_string().into()
-                } else {
-                    "".into()
-                },
-            ),
-        ]);
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct EnvConfig {
+    pub version: Option<String>,
+    pub uuid: Option<String>,
+    pub ip: Option<String>,
+    pub port: Option<u32>,
+    pub contact_ip: Option<String>,
+    pub contact_port: Option<u32>,
+    pub registrar_ip: Option<String>,
+    pub registrar_port: Option<u32>,
+    pub enable_agent_mtls: Option<bool>,
+    pub keylime_dir: Option<String>,
+    pub server_key: Option<String>,
+    pub server_cert: Option<String>,
+    pub server_key_password: Option<String>,
+    pub trusted_client_ca: Option<String>,
+    pub enc_keyname: Option<String>,
+    pub dec_payload_file: Option<String>,
+    pub secure_size: Option<String>,
+    pub tpm_ownerpassword: Option<String>,
+    pub extract_payload_zip: Option<bool>,
+    pub enable_revocation_notifications: Option<bool>,
+    pub revocation_actions_dir: Option<String>,
+    pub revocation_notification_ip: Option<String>,
+    pub revocation_notification_port: Option<u32>,
+    pub revocation_cert: Option<String>,
+    pub revocation_actions: Option<String>,
+    pub payload_script: Option<String>,
+    pub enable_insecure_payload: Option<bool>,
+    pub allow_payload_revocation_actions: Option<bool>,
+    pub tpm_hash_alg: Option<String>,
+    pub tpm_encryption_alg: Option<String>,
+    pub tpm_signing_alg: Option<String>,
+    pub ek_handle: Option<String>,
+    pub run_as: Option<String>,
+    pub agent_data_path: Option<String>,
+}
 
-        Ok(Map::from([("agent".to_string(), agent.into())]))
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub(crate) struct AgentConfig {
+    pub version: String,
+    pub uuid: String,
+    pub ip: String,
+    pub port: u32,
+    pub contact_ip: String,
+    pub contact_port: u32,
+    pub registrar_ip: String,
+    pub registrar_port: u32,
+    pub enable_agent_mtls: bool,
+    pub keylime_dir: String,
+    pub server_key: String,
+    pub server_cert: String,
+    pub server_key_password: String,
+    pub trusted_client_ca: String,
+    pub enc_keyname: String,
+    pub dec_payload_file: String,
+    pub secure_size: String,
+    pub tpm_ownerpassword: String,
+    pub extract_payload_zip: bool,
+    pub enable_revocation_notifications: bool,
+    pub revocation_actions_dir: String,
+    pub revocation_notification_ip: String,
+    pub revocation_notification_port: u32,
+    pub revocation_cert: String,
+    pub revocation_actions: String,
+    pub payload_script: String,
+    pub enable_insecure_payload: bool,
+    pub allow_payload_revocation_actions: bool,
+    pub tpm_hash_alg: String,
+    pub tpm_encryption_alg: String,
+    pub tpm_signing_alg: String,
+    pub ek_handle: String,
+    pub run_as: String,
+    pub agent_data_path: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub(crate) struct KeylimeConfig {
+    pub agent: AgentConfig,
+}
+
+impl EnvConfig {
+    pub fn get_map(&self) -> Map<String, Value> {
+        let mut agent: Map<String, Value> = Map::new();
+        if let Some(ref v) = self.version {
+            _ = agent.insert("version".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.uuid {
+            _ = agent.insert("uuid".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.ip {
+            _ = agent.insert("ip".to_string(), v.to_string().into());
+        }
+        if let Some(v) = self.port {
+            _ = agent.insert("port".to_string(), v.into());
+        }
+        if let Some(ref v) = self.contact_ip {
+            _ = agent.insert("contact_ip".to_string(), v.to_string().into());
+        }
+        if let Some(v) = self.contact_port {
+            _ = agent.insert("contact_port".to_string(), v.into());
+        }
+        if let Some(ref v) = self.registrar_ip {
+            _ = agent
+                .insert("registrar_ip".to_string(), v.to_string().into());
+        }
+        if let Some(v) = self.registrar_port {
+            _ = agent.insert("registrar_port".to_string(), v.into());
+        }
+        if let Some(v) = self.enable_agent_mtls {
+            _ = agent.insert("enable_agent_mtls".to_string(), v.into());
+        }
+        if let Some(ref v) = self.keylime_dir {
+            _ = agent.insert("keylime_dir".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.server_key {
+            _ = agent.insert("server_key".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.server_key_password {
+            _ = agent.insert(
+                "server_key_password".to_string(),
+                v.to_string().into(),
+            );
+        }
+        if let Some(ref v) = self.server_cert {
+            _ = agent.insert("server_cert".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.trusted_client_ca {
+            _ = agent.insert(
+                "trusted_client_ca".to_string(),
+                v.to_string().into(),
+            );
+        }
+        if let Some(ref v) = self.enc_keyname {
+            _ = agent.insert("enc_keyname".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.dec_payload_file {
+            _ = agent
+                .insert("dec_payload_file".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.secure_size {
+            _ = agent.insert("secure_size".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.tpm_ownerpassword {
+            _ = agent.insert(
+                "tpm_ownerpassword".to_string(),
+                v.to_string().into(),
+            );
+        }
+        if let Some(v) = self.extract_payload_zip {
+            _ = agent.insert("extract_payload_zip".to_string(), v.into());
+        }
+        if let Some(v) = self.enable_revocation_notifications {
+            _ = agent.insert(
+                "enable_revocation_notifications".to_string(),
+                v.into(),
+            );
+        }
+        if let Some(ref v) = self.revocation_actions_dir {
+            _ = agent.insert(
+                "revocation_actions_dir".to_string(),
+                v.to_string().into(),
+            );
+        }
+        if let Some(ref v) = self.revocation_notification_ip {
+            _ = agent.insert(
+                "revocation_notification_ip".to_string(),
+                v.to_string().into(),
+            );
+        }
+        if let Some(v) = self.revocation_notification_port {
+            _ = agent
+                .insert("revocation_notification_port".to_string(), v.into());
+        }
+        if let Some(ref v) = self.revocation_cert {
+            _ = agent
+                .insert("revocation_cert".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.revocation_actions {
+            _ = agent.insert(
+                "revocation_actions".to_string(),
+                v.to_string().into(),
+            );
+        }
+        if let Some(ref v) = self.payload_script {
+            _ = agent
+                .insert("payload_script".to_string(), v.to_string().into());
+        }
+        if let Some(v) = self.enable_insecure_payload {
+            _ = agent.insert("enable_insecure_payload".to_string(), v.into());
+        }
+        if let Some(v) = self.allow_payload_revocation_actions {
+            _ = agent.insert(
+                "allow_payload_revocation_actions".to_string(),
+                v.into(),
+            );
+        }
+        if let Some(ref v) = self.tpm_hash_alg {
+            _ = agent
+                .insert("tpm_hash_alg".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.tpm_encryption_alg {
+            _ = agent.insert(
+                "tpm_encryption_alg".to_string(),
+                v.to_string().into(),
+            );
+        }
+        if let Some(ref v) = self.tpm_signing_alg {
+            _ = agent
+                .insert("tpm_signing_alg".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.ek_handle {
+            _ = agent.insert("ek_handle".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.run_as {
+            _ = agent.insert("run_as".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.agent_data_path {
+            _ = agent
+                .insert("agent_data_path".to_string(), v.to_string().into());
+        }
+        agent
+    }
+
+    pub fn iter(&self) -> impl Iterator {
+        self.get_map().into_iter()
+    }
+}
+
+impl KeylimeConfig {
+    pub fn new() -> Result<Self, Error> {
+        // Get the base configuration file from the environment variable or the default locations
+        let setting = config_get_setting()?.build()?;
+        let config: KeylimeConfig = setting.try_deserialize()?;
+
+        // Replace keywords with actual values
+        config_translate_keywords(&config)
+    }
+}
+
+impl Source for EnvConfig {
+    fn collect(&self) -> Result<Map<String, Value>, ConfigError> {
+        // Note: the returned mapping matches the KeylimeConfig
+        // This is to allow overriding the values using environment variables
+        Ok(Map::from([("agent".to_string(), self.get_map().into())]))
     }
 
     fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
@@ -256,56 +311,156 @@ impl Source for KeylimeConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) struct KeylimeConfig {
-    pub agent: AgentConfig,
-}
+impl Source for KeylimeConfig {
+    fn collect(&self) -> Result<Map<String, Value>, ConfigError> {
+        let mut m: Map<String, Value> = Map::new();
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) struct AgentConfig {
-    pub version: String,
-    pub uuid: String,
-    pub ip: String,
-    pub port: u32,
-    pub contact_ip: Option<String>,
-    pub contact_port: Option<u32>,
-    pub registrar_ip: String,
-    pub registrar_port: u32,
-    pub enable_agent_mtls: bool,
-    pub keylime_dir: String,
-    pub server_key: Option<String>,
-    pub server_cert: Option<String>,
-    pub server_key_password: Option<String>,
-    pub trusted_client_ca: Option<String>,
-    pub enc_keyname: String,
-    pub dec_payload_file: String,
-    pub secure_size: String,
-    pub tpm_ownerpassword: Option<String>,
-    pub extract_payload_zip: bool,
-    pub enable_revocation_notifications: bool,
-    pub revocation_actions_dir: Option<String>,
-    pub revocation_notification_ip: Option<String>,
-    pub revocation_notification_port: Option<u32>,
-    pub revocation_cert: Option<String>,
-    pub revocation_actions: Option<String>,
-    pub payload_script: String,
-    pub enable_insecure_payload: bool,
-    pub allow_payload_revocation_actions: bool,
-    pub tpm_hash_alg: String,
-    pub tpm_encryption_alg: String,
-    pub tpm_signing_alg: String,
-    pub ek_handle: Option<String>,
-    pub run_as: Option<String>,
-    pub agent_data_path: Option<String>,
+        _ = m.insert(
+            "version".to_string(),
+            self.agent.version.to_string().into(),
+        );
+        _ = m.insert("uuid".to_string(), self.agent.uuid.to_string().into());
+        _ = m.insert("ip".to_string(), self.agent.ip.to_string().into());
+        _ = m.insert("port".to_string(), self.agent.port.into());
+        _ = m.insert(
+            "contact_ip".to_string(),
+            self.agent.contact_ip.to_string().into(),
+        );
+        _ = m.insert(
+            "contact_port".to_string(),
+            self.agent.contact_port.into(),
+        );
+        _ = m.insert(
+            "registrar_ip".to_string(),
+            self.agent.registrar_ip.to_string().into(),
+        );
+        _ = m.insert(
+            "registrar_port".to_string(),
+            self.agent.registrar_port.into(),
+        );
+        _ = m.insert(
+            "enable_agent_mtls".to_string(),
+            self.agent.enable_agent_mtls.into(),
+        );
+        _ = m.insert(
+            "keylime_dir".to_string(),
+            self.agent.keylime_dir.to_string().into(),
+        );
+        _ = m.insert(
+            "server_key".to_string(),
+            self.agent.server_key.to_string().into(),
+        );
+        _ = m.insert(
+            "server_key_password".to_string(),
+            self.agent.server_key_password.to_string().into(),
+        );
+        _ = m.insert(
+            "server_cert".to_string(),
+            self.agent.server_cert.to_string().into(),
+        );
+        _ = m.insert(
+            "trusted_client_ca".to_string(),
+            self.agent.trusted_client_ca.to_string().into(),
+        );
+        _ = m.insert(
+            "enc_keyname".to_string(),
+            self.agent.enc_keyname.to_string().into(),
+        );
+        _ = m.insert(
+            "dec_payload_file".to_string(),
+            self.agent.dec_payload_file.to_string().into(),
+        );
+        _ = m.insert(
+            "secure_size".to_string(),
+            self.agent.secure_size.to_string().into(),
+        );
+        _ = m.insert(
+            "tpm_ownerpassword".to_string(),
+            self.agent.tpm_ownerpassword.to_string().into(),
+        );
+        _ = m.insert(
+            "extract_payload_zip".to_string(),
+            self.agent.extract_payload_zip.to_string().into(),
+        );
+        _ = m.insert(
+            "enable_revocation_notifications".to_string(),
+            self.agent
+                .enable_revocation_notifications
+                .to_string()
+                .into(),
+        );
+        _ = m.insert(
+            "revocation_actions_dir".to_string(),
+            self.agent.revocation_actions_dir.to_string().into(),
+        );
+        _ = m.insert(
+            "revocation_notification_ip".to_string(),
+            self.agent.revocation_notification_ip.to_string().into(),
+        );
+        _ = m.insert(
+            "revocation_notification_port".to_string(),
+            self.agent.revocation_notification_port.into(),
+        );
+        _ = m.insert(
+            "revocation_cert".to_string(),
+            self.agent.revocation_cert.to_string().into(),
+        );
+        _ = m.insert(
+            "revocation_actions".to_string(),
+            self.agent.revocation_actions.to_string().into(),
+        );
+        _ = m.insert(
+            "payload_script".to_string(),
+            self.agent.payload_script.to_string().into(),
+        );
+        _ = m.insert(
+            "enable_insecure_payload".to_string(),
+            self.agent.enable_insecure_payload.into(),
+        );
+        _ = m.insert(
+            "allow_payload_revocation_actions".to_string(),
+            self.agent.allow_payload_revocation_actions.into(),
+        );
+        _ = m.insert(
+            "tpm_hash_alg".to_string(),
+            self.agent.tpm_hash_alg.to_string().into(),
+        );
+        _ = m.insert(
+            "tpm_encryption_alg".to_string(),
+            self.agent.tpm_encryption_alg.to_string().into(),
+        );
+        _ = m.insert(
+            "tpm_signing_alg".to_string(),
+            self.agent.tpm_signing_alg.to_string().into(),
+        );
+        _ = m.insert(
+            "ek_handle".to_string(),
+            self.agent.ek_handle.to_string().into(),
+        );
+        _ = m.insert(
+            "run_as".to_string(),
+            self.agent.run_as.to_string().into(),
+        );
+        _ = m.insert(
+            "agent_data_path".to_string(),
+            self.agent.agent_data_path.to_string().into(),
+        );
+
+        Ok(Map::from([("agent".to_string(), m.into())]))
+    }
+
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
+        Box::new(self.clone())
+    }
 }
 
 impl Default for AgentConfig {
     fn default() -> Self {
         // In case the process is executed by privileged user
         let run_as = if permissions::get_euid() == 0 {
-            Some(DEFAULT_RUN_AS.to_string())
+            DEFAULT_RUN_AS.to_string()
         } else {
-            None
+            "".to_string()
         };
 
         AgentConfig {
@@ -315,44 +470,39 @@ impl Default for AgentConfig {
             registrar_ip: DEFAULT_REGISTRAR_IP.to_string(),
             registrar_port: DEFAULT_REGISTRAR_PORT,
             uuid: DEFAULT_UUID.to_string(),
-            contact_ip: Some(DEFAULT_CONTACT_IP.to_string()),
-            contact_port: Some(DEFAULT_CONTACT_PORT),
+            contact_ip: DEFAULT_CONTACT_IP.to_string(),
+            contact_port: DEFAULT_CONTACT_PORT,
             tpm_hash_alg: DEFAULT_TPM_HASH_ALG.to_string(),
             tpm_encryption_alg: DEFAULT_TPM_ENCRYPTION_ALG.to_string(),
             tpm_signing_alg: DEFAULT_TPM_SIGNING_ALG.to_string(),
-            agent_data_path: Some("default".to_string()),
+            agent_data_path: "default".to_string(),
             enable_revocation_notifications:
                 DEFAULT_ENABLE_REVOCATION_NOTIFICATIONS,
-            revocation_cert: Some("default".to_string()),
-            revocation_notification_ip: Some(
-                DEFAULT_REVOCATION_NOTIFICATION_IP.to_string(),
-            ),
-            revocation_notification_port: Some(
+            revocation_cert: "default".to_string(),
+            revocation_notification_ip: DEFAULT_REVOCATION_NOTIFICATION_IP
+                .to_string(),
+            revocation_notification_port:
                 DEFAULT_REVOCATION_NOTIFICATION_PORT,
-            ),
             secure_size: DEFAULT_SECURE_SIZE.to_string(),
             payload_script: DEFAULT_PAYLOAD_SCRIPT.to_string(),
             dec_payload_file: DEFAULT_DEC_PAYLOAD_FILE.to_string(),
             enc_keyname: DEFAULT_ENC_KEYNAME.to_string(),
             extract_payload_zip: DEFAULT_EXTRACT_PAYLOAD_ZIP,
-            server_key: Some("default".to_string()),
-            server_key_password: Some(
-                DEFAULT_SERVER_KEY_PASSWORD.to_string(),
-            ),
-            server_cert: Some("default".to_string()),
-            trusted_client_ca: Some("default".to_string()),
-            revocation_actions: Some(DEFAULT_REVOCATION_ACTIONS.to_string()),
-            revocation_actions_dir: Some(
-                DEFAULT_REVOCATION_ACTIONS_DIR.to_string(),
-            ),
+            server_key: "default".to_string(),
+            server_key_password: DEFAULT_SERVER_KEY_PASSWORD.to_string(),
+            server_cert: "default".to_string(),
+            trusted_client_ca: "default".to_string(),
+            revocation_actions: DEFAULT_REVOCATION_ACTIONS.to_string(),
+            revocation_actions_dir: DEFAULT_REVOCATION_ACTIONS_DIR
+                .to_string(),
             allow_payload_revocation_actions:
                 DEFAULT_ALLOW_PAYLOAD_REVOCATION_ACTIONS,
             keylime_dir: DEFAULT_KEYLIME_DIR.to_string(),
             enable_agent_mtls: DEFAULT_ENABLE_AGENT_MTLS,
             enable_insecure_payload: DEFAULT_ENABLE_INSECURE_PAYLOAD,
             run_as,
-            tpm_ownerpassword: Some(DEFAULT_TPM_OWNERPASSWORD.to_string()),
-            ek_handle: Some(DEFAULT_EK_HANDLE.to_string()),
+            tpm_ownerpassword: DEFAULT_TPM_OWNERPASSWORD.to_string(),
+            ek_handle: DEFAULT_EK_HANDLE.to_string(),
         }
     }
 }
@@ -366,6 +516,26 @@ impl Default for KeylimeConfig {
         // The default config should never fail to translate keywords
         config_translate_keywords(&c).unwrap() //#[allow_ci]
     }
+}
+
+fn config_get_env_setting() -> Result<impl Source, Error> {
+    let env_config: EnvConfig = Config::builder()
+        // Add environment variables overrides
+        .add_source(
+            Environment::with_prefix("KEYLIME_AGENT")
+                .separator(".")
+                .prefix_separator("_"),
+        )
+        .build()?
+        .try_deserialize()?;
+
+    // Log debug message for configuration obtained from environment
+    env_config
+        .get_map()
+        .iter()
+        .for_each(|(c, v)| debug!("Environment configuration {c}={v}"));
+
+    Ok(env_config)
 }
 
 fn config_get_file_setting() -> Result<ConfigBuilder<DefaultState>, Error> {
@@ -404,11 +574,7 @@ fn config_get_file_setting() -> Result<ConfigBuilder<DefaultState>, Error> {
                 .collect::<Vec<_>>(),
         )
         // Add environment variables overrides
-        .add_source(
-            Environment::with_prefix("KEYLIME")
-                .separator("_")
-                .prefix_separator("_"),
-        ))
+        .add_source(config_get_env_setting()?))
 }
 
 fn config_get_setting() -> Result<ConfigBuilder<DefaultState>, Error> {
@@ -421,11 +587,7 @@ fn config_get_setting() -> Result<ConfigBuilder<DefaultState>, Error> {
                         File::new(&env_cfg, FileFormat::Toml).required(true),
                     )
                     // Add environment variables overrides
-                    .add_source(
-                        Environment::with_prefix("KEYLIME")
-                            .prefix_separator("_")
-                            .separator("_"),
-                    ));
+                    .add_source(config_get_env_setting()?));
             } else {
                 warn!("Configuration set in KEYLIME_AGENT_CONFIG environment variable not found");
                 return Err(Error::Configuration("Configuration set in KEYLIME_AGENT_CONFIG environment variable not found".to_string()));
@@ -444,109 +606,97 @@ fn config_translate_keywords(
     let env_keylime_dir = env::var("KEYLIME_DIR").ok();
     let keylime_dir = match env_keylime_dir {
         Some(ref dir) => {
-            if !dir.is_empty() {
-                dir.to_string()
+            if dir.is_empty() {
+                match &config.agent.keylime_dir {
+                    s => s.clone(),
+                    _ => DEFAULT_KEYLIME_DIR.to_string(),
+                }
             } else {
-                config.agent.keylime_dir.to_string()
+                dir.to_string()
             }
         }
-        None => config.agent.keylime_dir.to_string(),
+        None => match &config.agent.keylime_dir {
+            s => s.clone(),
+            _ => DEFAULT_KEYLIME_DIR.to_string(),
+        },
     };
 
+    // Validate that keylime_dir exists
+    let keylime_dir = Path::new(&keylime_dir).canonicalize().map_err(|e| {
+        Error::Configuration(format!(
+            "Path {keylime_dir} set in keylime_dir configuration option not found: {e}"
+        ))
+    })?;
+
     let mut agent_data_path = config_get_file_path(
+        "agent_data_path",
         &config.agent.agent_data_path,
         &keylime_dir,
         DEFAULT_AGENT_DATA_PATH,
     );
 
     let mut server_key = config_get_file_path(
+        "server_key",
         &config.agent.server_key,
         &keylime_dir,
         DEFAULT_SERVER_KEY,
     );
 
     let mut server_cert = config_get_file_path(
+        "server_cert",
         &config.agent.server_cert,
         &keylime_dir,
         DEFAULT_SERVER_CERT,
     );
 
     let mut trusted_client_ca = config_get_file_path(
+        "trusted_client_ca",
         &config.agent.trusted_client_ca,
         &keylime_dir,
         DEFAULT_TRUSTED_CLIENT_CA,
     );
 
+    let ek_handle = match config.agent.ek_handle.as_ref() {
+        "generate" => "".to_string(),
+        "" => "".to_string(),
+        s => s.to_string(),
+    };
+
+    // Validate the configuration
+
+    // If revocation notifications is enabled, verify all the required options for revocation
+    if config.agent.enable_revocation_notifications {
+        if config.agent.revocation_notification_ip.is_empty() {
+            error!("The option 'enable_revocation_notifications' is set as 'true' but 'revocation_notification_ip' was set as empty");
+            return Err(Error::Configuration("The option 'enable_revocation_notifications' is set as 'true' but 'revocation_notification_ip' was set as empty".to_string()));
+        }
+        if config.agent.revocation_cert.is_empty() {
+            error!("The option 'enable_revocation_notifications' is set as 'true' 'revocation_cert' was set as empty");
+            return Err(Error::Configuration("The option 'enable_revocation_notifications' is set as 'true' but 'revocation_notification_cert' was set as empty".to_string()));
+        }
+        let actions_dir = match config.agent.revocation_actions_dir.as_ref() {
+            "" => {
+                error!("The option 'enable_revocation_notifications' is set as 'true' but the revocation actions directory was set as empty in 'revocation_actions_dir'");
+                return Err(Error::Configuration("The option 'enable_revocation_notifications' is set as 'true' but 'revocation_actions_dir' was set as empty".to_string()));
+            }
+            dir => dir.to_string(),
+        };
+    }
+
     let mut revocation_cert = config_get_file_path(
+        "revocation_cert",
         &config.agent.revocation_cert,
         &keylime_dir,
         &format!("secure/unzipped/{DEFAULT_REVOCATION_CERT}"),
     );
 
-    let tpm_ownerpassword = match config.agent.tpm_ownerpassword {
-        Some(ref s) => {
-            if s.as_str() != "generate" {
-                Some(s.to_string())
-            } else {
-                None
-            }
-        }
-        None => None,
-    };
-
-    let ek_handle = match config.agent.ek_handle {
-        Some(ref s) => {
-            if s.as_str() != "generate" {
-                Some(s.to_string())
-            } else {
-                None
-            }
-        }
-        None => None,
-    };
-
-    // Validate the configuration
-
-    // If mTLS is enabled, the trusted client CA certificate is required
-    if config.agent.enable_agent_mtls
-        && config.agent.trusted_client_ca.is_none()
-    {
-        error!("The option 'enable_agent_mtls' is set as 'true' but no certificate was set in 'trusted_client_ca' option");
-        return Err(Error::Configuration(
-                "The option 'enable_agent_mtls' is set as 'true' but no certificate was set in 'trusted_client_ca' option".to_string()));
-    }
-
-    // If revocation notifications is enabled, verify all the required options for revocation
-    if config.agent.enable_revocation_notifications {
-        if config.agent.revocation_notification_ip.is_none() {
-            error!("The option 'enable_revocation_notifications' is set as 'true' but no IP was set in 'revocation_notification_ip'");
-            return Err(Error::Configuration("The option 'enable_revocation_notifications' is set as 'true' but no IP was set in 'revocation_notification_ip'".to_string()));
-        }
-        if config.agent.revocation_notification_port.is_none() {
-            error!("The option 'enable_revocation_notifications' is set as 'true' but no port was set in 'revocation_notification_port'");
-            return Err(Error::Configuration("The option 'enable_revocation_notifications' is set as 'true' but no port was set in 'revocation_notification_port'".to_string()));
-        }
-        if config.agent.revocation_cert.is_none() {
-            error!("The option 'enable_revocation_notifications' is set as 'true' but no certificate was set in 'revocation_cert'");
-            return Err(Error::Configuration("The option 'enable_revocation_notifications' is set as 'true' but no certificate was set in 'revocation_notification_cert'".to_string()));
-        }
-        let actions_dir = match config.agent.revocation_actions_dir {
-            Some(ref dir) => dir.to_string(),
-            None => {
-                error!("The option 'enable_revocation_notifications' is set as 'true' but the revocation actions directory was not set in 'revocation_actions_dir'");
-                return Err(Error::Configuration("The option 'enable_revocation_notifications' is set as 'true' but the revocation actions directory was not set in 'revocation_actions_dir'".to_string()));
-            }
-        };
-    }
-
     Ok(KeylimeConfig {
         agent: AgentConfig {
-            keylime_dir,
+            keylime_dir: keylime_dir.display().to_string(),
             uuid,
             server_key,
             server_cert,
             trusted_client_ca,
-            tpm_ownerpassword,
             ek_handle,
             agent_data_path,
             revocation_cert,
@@ -555,48 +705,33 @@ fn config_translate_keywords(
     })
 }
 
-impl KeylimeConfig {
-    pub fn new() -> Result<Self, Error> {
-        // Get the base configuration file from the environment variable or the default locations
-        let setting = config_get_setting()?.build()?;
-        let config: KeylimeConfig = setting.try_deserialize()?;
-
-        // Replace keywords with actual values
-        config_translate_keywords(&config)
-    }
-}
-
 /// Expand a file path from the configuration file.
 ///
-/// If the option is None, return None
-/// If the option string is empty, return None
-/// If the option string is set as "default", return the provided default path relative from the provided work_dir.
-/// If the option string is a relative path, return the path relative from the provided work_dir
-/// If the option string is an absolute path, return the path without change.
+/// If the string is set as "default", return the provided default path relative from the provided work_dir.
+/// If the string is empty, use again the default value
+/// If the string is a relative path, return the path relative from the provided work_dir
+/// If the string is an absolute path, return the path without change.
 fn config_get_file_path(
-    path: &Option<String>,
-    work_dir: &str,
+    option: &str,
+    path: &str,
+    work_dir: &Path,
     default: &str,
-) -> Option<String> {
-    if let Some(ref value) = path {
-        if value == "default" {
-            return Some(
-                Path::new(work_dir).join(default).display().to_string(),
-            );
-        } else if value.is_empty() {
-            return None;
-        } else {
-            let value = Path::new(&value);
-            if value.is_relative() {
-                return Some(
-                    Path::new(work_dir).join(value).display().to_string(),
-                );
+) -> String {
+    match path {
+        "default" => work_dir.join(default).display().to_string(),
+        "" => {
+            warn!("Empty string provided in configuration option {option}, using default {default}");
+            work_dir.join(default).display().to_string()
+        }
+        v => {
+            let p = Path::new(v);
+            if p.is_relative() {
+                work_dir.join(p).display().to_string()
             } else {
-                return Some(value.display().to_string());
+                p.display().to_string()
             }
         }
     }
-    None
 }
 
 fn get_uuid(agent_uuid_config: &str) -> String {
@@ -614,8 +749,9 @@ fn get_uuid(agent_uuid_config: &str) -> String {
         uuid_config => match Uuid::parse_str(uuid_config) {
             Ok(uuid_config) => uuid_config.to_string(),
             Err(_) => {
-                info!("Misformatted UUID: {}", &uuid_config);
+                warn!("Misformatted UUID: {}", &uuid_config);
                 let agent_uuid = Uuid::new_v4();
+                info!("Using generated UUID: {}", &uuid_config);
                 agent_uuid.to_string()
             }
         },
@@ -630,13 +766,21 @@ mod tests {
     #[test]
     fn test_default() {
         let default = KeylimeConfig::default();
+
+        let c = KeylimeConfig {
+            agent: AgentConfig::default(),
+        };
+
+        let result = config_translate_keywords(&c);
+        assert!(result.is_ok());
+        let expected = result.unwrap(); //#[allow_ci]
+        assert_eq!(expected, default);
     }
 
     #[test]
     fn get_revocation_cert_path_default() {
         let test_config = KeylimeConfig::default();
-        let revocation_cert_path =
-            (test_config.agent.revocation_cert.clone()).unwrap(); //#[allow_ci]
+        let revocation_cert_path = test_config.agent.revocation_cert.clone();
         let mut expected = Path::new(&test_config.agent.keylime_dir)
             .join("secure/unzipped")
             .join(DEFAULT_REVOCATION_CERT)
@@ -649,15 +793,14 @@ mod tests {
     fn get_revocation_cert_path_absolute() {
         let mut test_config = KeylimeConfig {
             agent: AgentConfig {
-                revocation_cert: Some(String::from("/test/cert.crt")),
+                revocation_cert: "/test/cert.crt".to_string(),
                 ..Default::default()
             },
         };
         let result = config_translate_keywords(&test_config);
         assert!(result.is_ok());
         let test_config = result.unwrap(); //#[allow_ci]
-        let revocation_cert_path =
-            (test_config.agent.revocation_cert).unwrap(); //#[allow_ci]
+        let revocation_cert_path = test_config.agent.revocation_cert;
         let mut expected = Path::new("/test/cert.crt").display().to_string();
         assert_eq!(revocation_cert_path, expected);
     }
@@ -666,15 +809,14 @@ mod tests {
     fn get_revocation_cert_path_relative() {
         let mut test_config = KeylimeConfig {
             agent: AgentConfig {
-                revocation_cert: Some(String::from("cert.crt")),
+                revocation_cert: "cert.crt".to_string(),
                 ..Default::default()
             },
         };
         let result = config_translate_keywords(&test_config);
         assert!(result.is_ok());
         let test_config = result.unwrap(); //#[allow_ci]
-        let revocation_cert_path =
-            (test_config.agent.revocation_cert.clone()).unwrap(); //#[allow_ci]
+        let revocation_cert_path = test_config.agent.revocation_cert.clone();
         let mut expected = Path::new(&test_config.agent.keylime_dir)
             .join("cert.crt")
             .display()
@@ -683,24 +825,10 @@ mod tests {
     }
 
     #[test]
-    fn get_revocation_cert_path_empty() {
+    fn get_revocation_notification_ip_empty() {
         let mut test_config = KeylimeConfig {
             agent: AgentConfig {
-                revocation_cert: Some(String::from("")),
-                ..Default::default()
-            },
-        };
-        let result = config_translate_keywords(&test_config);
-        assert!(result.is_ok());
-        let test_config = result.unwrap(); //#[allow_ci]
-        assert_eq!(test_config.agent.revocation_cert, None);
-    }
-
-    #[test]
-    fn get_revocation_cert_path_none() {
-        let mut test_config = KeylimeConfig {
-            agent: AgentConfig {
-                revocation_cert: None,
+                revocation_notification_ip: "".to_string(),
                 ..Default::default()
             },
         };
@@ -710,7 +838,7 @@ mod tests {
         let mut test_config = KeylimeConfig {
             agent: AgentConfig {
                 enable_revocation_notifications: false,
-                revocation_cert: None,
+                revocation_notification_ip: "".to_string(),
                 ..Default::default()
             },
         };
@@ -719,7 +847,58 @@ mod tests {
         let result = config_translate_keywords(&test_config);
         assert!(result.is_ok());
         let test_config = result.unwrap(); //#[allow_ci]
-        assert_eq!(test_config.agent.revocation_cert, None);
+        assert_eq!(
+            test_config.agent.revocation_notification_ip,
+            "".to_string()
+        );
+    }
+
+    #[test]
+    fn get_revocation_cert_empty() {
+        let mut test_config = KeylimeConfig {
+            agent: AgentConfig {
+                revocation_cert: "".to_string(),
+                ..Default::default()
+            },
+        };
+        let result = config_translate_keywords(&test_config);
+        // Due to enable_revocation_notifications being set
+        assert!(result.is_err());
+        let mut test_config = KeylimeConfig {
+            agent: AgentConfig {
+                enable_revocation_notifications: false,
+                revocation_cert: "".to_string(),
+                ..Default::default()
+            },
+        };
+
+        // Now unset enable_revocation_notifications and check that is allowed
+        let result = config_translate_keywords(&test_config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn get_revocation_actions_dir_empty() {
+        let mut test_config = KeylimeConfig {
+            agent: AgentConfig {
+                revocation_actions_dir: "".to_string(),
+                ..Default::default()
+            },
+        };
+        let result = config_translate_keywords(&test_config);
+        // Due to enable_revocation_notifications being set
+        assert!(result.is_err());
+        let mut test_config = KeylimeConfig {
+            agent: AgentConfig {
+                enable_revocation_notifications: false,
+                revocation_actions_dir: "".to_string(),
+                ..Default::default()
+            },
+        };
+
+        // Now unset enable_revocation_notifications and check that is allowed
+        let result = config_translate_keywords(&test_config);
+        assert!(result.is_ok());
     }
 
     #[test]
@@ -738,5 +917,90 @@ mod tests {
             "D432FBB3-D2F1-4A97-9EF7-75BD81C0000X",
         ))
         .unwrap(); //#[allow_ci]
+    }
+
+    #[test]
+    fn test_env_var() {
+        let override_map: Map<&str, &str> = Map::from([
+            ("VERSION", "override_version"),
+            ("UUID", "override_uuid"),
+            ("IP", "override_ip"),
+            ("PORT", "9999"),
+            ("CONTACT_IP", "override_contact_ip"),
+            ("CONTACT_PORT", "9999"),
+            ("REGISTRAR_IP", "override_registrar_ip"),
+            ("REGISTRAR_PORT", "9999"),
+            ("ENABLE_AGENT_MTLS", "false"),
+            ("KEYLIME_DIR", "override_keylime_dir"),
+            ("SERVER_KEY", "override_server_key"),
+            ("SERVER_CERT", "override_server_cert"),
+            ("SERVER_KEY_PASSWORD", "override_server_key_password"),
+            ("TRUSTED_CLIENT_CA", "override_trusted_client_ca"),
+            ("ENC_KEYNAME", "override_enc_keyname"),
+            ("DEC_PAYLOAD_FILE", "override_dec_payload_file"),
+            ("SECURE_SIZE", "override_secure_size"),
+            ("TPM_OWNERPASSWORD", "override_tpm_ownerpassword"),
+            ("EXTRACT_PAYLOAD_ZIP", "false"),
+            ("ENABLE_REVOCATION_NOTIFICATIONS", "false"),
+            ("REVOCATION_ACTIONS_DIR", "override_revocation_actions_dir"),
+            (
+                "REVOCATION_NOTIFICATION_IP",
+                "override_revocation_notification_ip",
+            ),
+            ("REVOCATION_NOTIFICATION_PORT", "9999"),
+            ("REVOCATION_CERT", "override_revocation_cert"),
+            ("REVOCATION_ACTIONS", "override_revocation_actions"),
+            ("PAYLOAD_SCRIPT", "override_payload_script"),
+            ("ENABLE_INSECURE_PAYLOAD", "true"),
+            ("ALLOW_PAYLOAD_REVOCATION_ACTIONS", "false"),
+            ("TPM_HASH_ALG", "override_tpm_hash_alg"),
+            ("TPM_ENCRYPTION_ALG", "override_tpm_encryption_alg"),
+            ("TPM_SIGNING_ALG", "override_tpm_signing_alg"),
+            ("EK_HANDLE", "override_ek_handle"),
+            ("RUN_AS", "override_run_as"),
+            ("AGENT_DATA_PATH", "override_agent_data_path"),
+        ]);
+
+        for (c, v) in override_map.into_iter() {
+            let default = KeylimeConfig::default();
+
+            let env_conf: EnvConfig = Config::builder()
+                .add_source(
+                    Environment::default()
+                        .separator(".")
+                        .prefix_separator("_")
+                        .source(Some({
+                            let mut env = Map::new();
+                            _ = env.insert(c.into(), v.into());
+                            env
+                        })),
+                )
+                .build()
+                .unwrap() //#[allow_ci]
+                .try_deserialize()
+                .unwrap(); //#[allow_ci]
+
+            let new_conf: KeylimeConfig = Config::builder()
+                .add_source(default)
+                .add_source(env_conf)
+                .build()
+                .unwrap() //#[allow_ci]
+                .try_deserialize()
+                .unwrap(); //#[allow_ci]
+
+            let m = new_conf.collect().unwrap(); //#[allow_ci]
+            let internal = m.get("agent").unwrap(); //#[allow_ci]
+            let obtained = internal.to_owned().into_table().unwrap(); //#[allow_ci]
+
+            let d = KeylimeConfig::default().collect().unwrap(); //#[allow_ci]
+            let i = d.get("agent").unwrap(); //#[allow_ci]
+            let mut expected = i.to_owned().into_table().unwrap(); //#[allow_ci]
+            _ = expected.insert(c.to_lowercase(), v.into());
+
+            for (i, j) in obtained.iter() {
+                let e = expected.get(i).unwrap(); //#[allow_ci]
+                assert!(e.to_string() == j.to_string());
+            }
+        }
     }
 }

--- a/keylime-agent/src/keys_handler.rs
+++ b/keylime-agent/src/keys_handler.rs
@@ -817,19 +817,15 @@ mod tests {
             encrypt_aead(k.as_ref(), &iv[..], payload).unwrap() //#[allow_ci]
         });
 
-        let auth_tag =
-            compute_hmac(k.as_ref(), test_config.agent.uuid.as_bytes())
-                .unwrap(); //#[allow_ci]
+        let uuid = test_config.agent.uuid;
+        let auth_tag = compute_hmac(k.as_ref(), uuid.as_bytes()).unwrap(); //#[allow_ci]
 
         let arbiter = Arbiter::new();
-
         let p_tx = payload_tx.clone();
-        let uuid = test_config.agent.uuid.clone();
+        let uuid_clone = uuid.clone();
         // Run keys worker
         assert!(arbiter.spawn(Box::pin(async move {
-            let result =
-                worker(true, test_config.agent.uuid.clone(), keys_rx, p_tx)
-                    .await;
+            let result = worker(true, uuid_clone, keys_rx, p_tx).await;
 
             if result.is_err() {
                 debug!("keys worker failed: {:?}", result);

--- a/keylime/src/tpm.rs
+++ b/keylime/src/tpm.rs
@@ -151,13 +151,21 @@ impl Context {
         // Retrieve EK handle, EK pub cert, and TPM pub object
         let key_handle = match handle {
             Some(v) => {
-                let handle =
-                    u32::from_str_radix(v.trim_start_matches("0x"), 16)?;
-                self.inner
-                    .tr_from_tpm_public(TpmHandle::Persistent(
-                        PersistentTpmHandle::new(handle)?,
-                    ))?
-                    .into()
+                if v.is_empty() {
+                    ek::create_ek_object(
+                        &mut self.inner,
+                        alg.into(),
+                        DefaultKey,
+                    )?
+                } else {
+                    let handle =
+                        u32::from_str_radix(v.trim_start_matches("0x"), 16)?;
+                    self.inner
+                        .tr_from_tpm_public(TpmHandle::Persistent(
+                            PersistentTpmHandle::new(handle)?,
+                        ))?
+                        .into()
+                }
             }
             None => {
                 ek::create_ek_object(&mut self.inner, alg.into(), DefaultKey)?


### PR DESCRIPTION
Read the configuration options set via environment variables separately
to initialize an EnvConfig structure and use this structure as a
Source to override the values of the KeylimeConfig obtained from the
configuration files.

For this, change the prefix for the environment variables to
KEYLIME_AGENT with the 'prefix_separator' as '_', and 'separator' as
'.'.

Then the configuration options obtained from the environment variables
are used to initialize an EnvConfig structure, which does not contain
sub-structures.

The EnvConfig structure is a duplicate of AgentConfig structure, but
contains Option<T> for all configuration options, allowing values to not
be set via environment variables.

The remaining optional fields in AgentConfig were replaced to be
required (not Option<T>).

Note that the verification of required/non-required options
was not used since all values are set with the default values and then
successively overriden by values from the configuration files and
environment variables.

The Source trait was implemented for the EnvConfig structure in a way
that it is possible to use it as the source for KeylimeConfig structure.

Fixes: #510

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>