### PR TITLE
Update tokio, uuid, and clap minimum versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,16 +432,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2137,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom 0.2.7",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,24 +2205,11 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
- "tokio-macros",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/keylime-agent/Cargo.toml
+++ b/keylime-agent/Cargo.toml
@@ -30,7 +30,7 @@ serde_derive = "1.0.80"
 serde_json = { version = "1.0", features = ["raw_value"] }
 static_assertions = "1"
 tempfile = "3.0.4"
-tokio = {version = "1.13.1", features = ["full"]}
+tokio = {version = "1.24", features = ["rt", "sync"]}
 tss-esapi = {version = "7.1.0", features = ["generate-bindings"]}
 thiserror = "1.0"
 uuid = {version = "0.8", features = ["v4"]}

--- a/keylime-agent/Cargo.toml
+++ b/keylime-agent/Cargo.toml
@@ -33,7 +33,7 @@ tempfile = "3.0.4"
 tokio = {version = "1.24", features = ["rt", "sync"]}
 tss-esapi = {version = "7.1.0", features = ["generate-bindings"]}
 thiserror = "1.0"
-uuid = {version = "0.8", features = ["v4"]}
+uuid = {version = "1.3", features = ["v4"]}
 zmq = {version = "0.9.2", optional = true}
 # wiremock was moved to be a regular dependency because optional
 # dev-dependencies are not supported

--- a/keylime-agent/Cargo.toml
+++ b/keylime-agent/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/keylime/rust-keylime"
 actix-web =  { version = "4", features = ["openssl"] }
 base64 = "0.13"
 cfg-if = "1"
-clap = { version = "~3.1.18", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 compress-tools = "0.12"
 config = { version = "0.13", features = ["toml"] }
 futures = "0.3.6"

--- a/keylime-agent/src/payloads.rs
+++ b/keylime-agent/src/payloads.rs
@@ -361,7 +361,7 @@ mod tests {
         (k, payload.into())
     }
 
-    #[tokio::test]
+    #[actix_rt::test]
     async fn test_run() {
         let dir = tempfile::tempdir().unwrap(); //#[allow_ci]
         let script_path = dir.path().join("test-script.sh");
@@ -453,7 +453,7 @@ echo hello > test-output
     }
 
     #[cfg(feature = "testing")]
-    #[tokio::test]
+    #[actix_rt::test]
     async fn test_run_encrypted_payload() {
         let test_config = KeylimeConfig::default();
         let temp_workdir = tempfile::tempdir().unwrap(); //#[allow_ci]

--- a/keylime-agent/src/registrar_agent.rs
+++ b/keylime-agent/src/registrar_agent.rs
@@ -161,7 +161,7 @@ mod tests {
     use wiremock::matchers::{any, method};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    #[tokio::test]
+    #[actix_rt::test]
     async fn mock_register_agent_ok() {
         let response: Response<RegisterResponseResults> = Response {
             code: 200.into(),
@@ -203,7 +203,7 @@ mod tests {
         assert!(response.is_ok());
     }
 
-    #[tokio::test]
+    #[actix_rt::test]
     async fn mock_register_agent_ok_without_ekcert() {
         let response: Response<RegisterResponseResults> = Response {
             code: 200.into(),
@@ -245,7 +245,7 @@ mod tests {
         assert!(response.is_ok());
     }
 
-    #[tokio::test]
+    #[actix_rt::test]
     async fn mock_register_agent_err() {
         let response: Response<RegisterResponseResults> = Response {
             code: 200.into(),
@@ -284,7 +284,7 @@ mod tests {
         assert_eq!(response.err().unwrap().http_code().unwrap(), 404); //#[allow_ci]
     }
 
-    #[tokio::test]
+    #[actix_rt::test]
     async fn mock_activate_agent_ok() {
         let response: Response<ActivateResponseResults> = Response {
             code: 200.into(),
@@ -312,7 +312,7 @@ mod tests {
         assert!(response.is_ok());
     }
 
-    #[tokio::test]
+    #[actix_rt::test]
     async fn mock_activate_agent_err() {
         let response: Response<ActivateResponseResults> = Response {
             code: 200.into(),

--- a/keylime-ima-emulator/Cargo.toml
+++ b/keylime-ima-emulator/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "~3.1.18", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 hex = "0.4"
 keylime = { path = "../keylime" }
 log = "0.4"


### PR DESCRIPTION
Update dependencies minimum versions:

- `clap` to `3.2`
- `tokio` to `1.24`
- `uuid` to `1.3`

Also reduce `tokio` features from `full` to only `rt` and `sync`.