### PR TITLE
Deprecate `with-zmq` and `legacy-python-actions` features

### DIFF
--- a/keylime-agent.conf
+++ b/keylime-agent.conf
@@ -133,7 +133,7 @@ extract_payload_zip = true
 #
 # To override enable_revocation_notifications, set
 # KEYLIME_AGENT_ENABLE_REVOCATION_NOTIFICATIONS environment variable.
-enable_revocation_notifications = true
+enable_revocation_notifications = false
 
 # The path to the directory containing the pre-installed revocation action
 # scripts.  Ideally should point to an fixed/immutable location subject to

--- a/keylime-agent/Cargo.toml
+++ b/keylime-agent/Cargo.toml
@@ -45,16 +45,20 @@ actix-rt = "2"
 
 [features]
 # The features enabled by default
-default = ["with-zmq", "legacy-python-actions"]
+default = []
 # this should change to dev-dependencies when we have integration testing
 testing = ["wiremock"]
 # Whether the agent should be compiled with support to listen for notification
 # messages on ZeroMQ
+#
+# This feature is deprecated and will be removed on next major release
 with-zmq = ["zmq"]
 # Whether the agent should be compiled with support for python revocation
 # actions loaded as modules, which is the only kind supported by the python
 # agent (unless the enhancement-55 is implemented). See:
 # https://github.com/keylime/enhancements/blob/master/55_revocation_actions_without_python.md
+#
+# This feature is deprecated and will be removed on next major release
 legacy-python-actions = []
 
 [package.metadata.deb]

--- a/keylime-agent/src/config.rs
+++ b/keylime-agent/src/config.rs
@@ -38,7 +38,7 @@ pub static DEFAULT_DEC_PAYLOAD_FILE: &str = "decrypted_payload";
 pub static DEFAULT_SECURE_SIZE: &str = "1m";
 pub static DEFAULT_TPM_OWNERPASSWORD: &str = "";
 pub static DEFAULT_EXTRACT_PAYLOAD_ZIP: bool = true;
-pub static DEFAULT_ENABLE_REVOCATION_NOTIFICATIONS: bool = true;
+pub static DEFAULT_ENABLE_REVOCATION_NOTIFICATIONS: bool = false;
 pub static DEFAULT_REVOCATION_ACTIONS_DIR: &str = "/usr/libexec/keylime";
 pub static DEFAULT_REVOCATION_NOTIFICATION_IP: &str = "127.0.0.1";
 pub static DEFAULT_REVOCATION_NOTIFICATION_PORT: u32 = 8992;
@@ -828,6 +828,7 @@ mod tests {
     fn get_revocation_notification_ip_empty() {
         let mut test_config = KeylimeConfig {
             agent: AgentConfig {
+                enable_revocation_notifications: true,
                 revocation_notification_ip: "".to_string(),
                 ..Default::default()
             },
@@ -857,6 +858,7 @@ mod tests {
     fn get_revocation_cert_empty() {
         let mut test_config = KeylimeConfig {
             agent: AgentConfig {
+                enable_revocation_notifications: true,
                 revocation_cert: "".to_string(),
                 ..Default::default()
             },
@@ -881,6 +883,7 @@ mod tests {
     fn get_revocation_actions_dir_empty() {
         let mut test_config = KeylimeConfig {
             agent: AgentConfig {
+                enable_revocation_notifications: true,
                 revocation_actions_dir: "".to_string(),
                 ..Default::default()
             },

--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -226,6 +226,8 @@ async fn main() -> Result<()> {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "legacy-python-actions")] {
+            warn!("The support for legacy python revocation actions is deprecated and will be removed on next major release");
+
             let actions_dir = &config.agent.revocation_actions_dir;
             // Verify if the python shim is installed in the expected location
             let python_shim = Path::new(&actions_dir).join("shim.py");
@@ -729,6 +731,8 @@ async fn main() -> Result<()> {
     // If with-zmq feature is enabled, run the service listening for ZeroMQ messages
     #[cfg(feature = "with-zmq")]
     let zmq_task = if config.agent.enable_revocation_notifications {
+        warn!("The support for ZeroMQ revocation notifications is deprecated and will be removed on next major release");
+
         let zmq_ip = config.agent.revocation_notification_ip;
         let zmq_port = config.agent.revocation_notification_port;
 


### PR DESCRIPTION
The features are disabled by default and will be removed on next major
release.

This changes the default value of the 'enable_revocation_notifications'
to false. 

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>

Note:  The default value used by the python configuration upgrade script needs to be updated accordingly.