### PR TITLE
packit: Re-enable tests on Fedora Rawhide

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,6 +4,6 @@ jobs:
   metadata:
     targets:
     - fedora-stable
-#    - fedora-rawhide
+    - fedora-rawhide
     - centos-stream-9-x86_64
     skip_build: true


### PR DESCRIPTION
With the updated tpm2-tss and rust-tss-esapi, it is possible to build the agent on Fedora Rawhide again.