### PR TITLE
Change number of required uploaded files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 3
+    after_n_builds: 2
 
 coverage:
   status:
@@ -16,7 +16,7 @@ comment:
   behavior: default
   require_changes: false
   require_base: no
-  after_n_builds: 3
+  after_n_builds: 2
 
 flags:
   e2e-testsuite:


### PR DESCRIPTION
This is misconfiguration from keylime project,
in codecov yaml where are uploaded 3 coverage
files, but for rust keylime is uploading only
2 coverage files.

Signed-off-by: Patrik Koncity <pkoncity@redhat.com>