### PR TITLE
Allow setting binary measured boot log path on RPM binaries

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,5 +1,9 @@
 downstream_package_name: keylime-agent-rust
 upstream_project_url: https://github.com/keylime/rust-keylime
+specfile_path: rpm/fedora/keylime-agent-rust.spec
+actions:
+  get-current-version:
+  - bash -c "git describe --tags --abbrev=0 | sed 's/v\(.*\)/\1/g'"
 
 srpm_build_deps:
   - cargo
@@ -24,6 +28,8 @@ jobs:
   files_to_sync:
     - rpm/fedora/*
   actions:
+    get-current-version:
+      bash -c "git describe --tags --abbrev=0 | sed 's/v\(.*\)/\1/g'"
     post-upstream-clone:
       bash -c 'if [[ ! -d /var/tmp/cargo-vendor-filterer ]]; then git clone https://github.com/cgwalters/cargo-vendor-filterer.git /var/tmp/cargo-vendor-filterer; fi &&
         cd /var/tmp/cargo-vendor-filterer &&
@@ -48,6 +54,8 @@ jobs:
   files_to_sync:
     - rpm/centos/*
   actions:
+    get-current-version:
+      bash -c "git describe --tags --abbrev=0 | sed 's/v\(.*\)/\1/g'"
     post-upstream-clone:
       bash -c 'if [[ ! -d /var/tmp/cargo-vendor-filterer ]]; then git clone https://github.com/cgwalters/cargo-vendor-filterer.git /var/tmp/cargo-vendor-filterer; fi &&
         cd /var/tmp/cargo-vendor-filterer &&

--- a/keylime-agent/src/common.rs
+++ b/keylime-agent/src/common.rs
@@ -53,7 +53,7 @@ pub const AES_256_KEY_LEN: usize = 32;
 pub const AES_BLOCK_SIZE: usize = 16;
 
 cfg_if::cfg_if! {
-    if #[cfg(any(test, feature = "testing"))] {
+    if #[cfg(test)] {
         // Secure mount of tpmfs (False is generally used for development environments)
         pub static MOUNT_SECURE: bool = false;
 

--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -147,7 +147,16 @@ async fn main() -> Result<()> {
         None
     };
 
-    let measuredboot_ml_path = Path::new(MEASUREDBOOT_ML);
+    let mut measuredboot_ml_path = Path::new(MEASUREDBOOT_ML);
+
+    // Allow setting the binary bios measurements log path when testing
+    let env_mb_path: String;
+    #[cfg(feature = "testing")]
+    if let Ok(v) = std::env::var("TPM_BINARY_MEASUREMENTS") {
+        env_mb_path = v;
+        measuredboot_ml_path = Path::new(&env_mb_path);
+    }
+
     let measuredboot_ml_file = if measuredboot_ml_path.exists() {
         match fs::File::open(measuredboot_ml_path) {
             Ok(file) => Some(Mutex::new(file)),
@@ -871,9 +880,15 @@ mod testing {
                 Err(err) => None,
             };
 
-            let measuredboot_ml_path = Path::new(
-                "/sys/kernel/security/tpm0/binary_bios_measurements",
-            );
+            // Allow setting the binary bios measurements log path when testing
+            let mut measuredboot_ml_path = Path::new(MEASUREDBOOT_ML);
+            let env_mb_path;
+            #[cfg(feature = "testing")]
+            if let Ok(v) = std::env::var("TPM_BINARY_MEASUREMENTS") {
+                env_mb_path = v;
+                measuredboot_ml_path = Path::new(&env_mb_path);
+            }
+
             let measuredboot_ml_file =
                 match fs::File::open(measuredboot_ml_path) {
                     Ok(file) => Some(Mutex::new(file)),

--- a/rpm/README.md
+++ b/rpm/README.md
@@ -1,0 +1,9 @@
+# Keylime testing RPM
+
+The specfiles in this directory are used to build RPM packages on Copr using
+packit for testing purposes.  Do not use the RPM built using these files in a
+production environment.
+
+The goal is to avoid recompiling the project multiple times during testing.
+
+The binaries in the test RPM are build with the `testing` feature enabled.

--- a/rpm/centos/keylime-agent-rust.spec
+++ b/rpm/centos/keylime-agent-rust.spec
@@ -9,7 +9,7 @@
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/debug/.*$
 
 Name:           keylime-agent-rust
-Version:        v0.2.0
+Version:        0.2.0
 Release:        %{?autorelease}%{!?autorelease:1%{?dist}}
 Summary:        Rust agent for Keylime
 
@@ -32,7 +32,7 @@ Summary:        Rust agent for Keylime
 #
 License:        ASL 2.0 and BSD and MIT
 URL:            https://github.com/keylime/rust-keylime/
-Source0:        rust-keylime-v0.2.0.tar.gz
+Source0:        rust-keylime-v%{version}.tar.gz
 # The vendor tarball is created using cargo-vendor-filterer to remove Windows
 # related files (https://github.com/cgwalters/cargo-vendor-filterer)
 #   tar xf rust-keylime-%%{version}.tar.gz
@@ -71,13 +71,13 @@ Conflicts:      keylime-agent
 Rust agent for Keylime
 
 %prep
-%autosetup -n rust-keylime-v0.2.0 -N
+%autosetup -n rust-keylime-%{version} -N
 %autopatch -m 100 -p1
 # Source1 is vendored dependencies
 %cargo_prep -V 1
 
 %build
-%cargo_build
+%cargo_build --features=testing
 
 %install
 

--- a/rpm/fedora/keylime-agent-rust.spec
+++ b/rpm/fedora/keylime-agent-rust.spec
@@ -15,7 +15,7 @@
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/debug/.*$
 
 Name:           keylime-agent-rust
-Version:        v0.2.0
+Version:        0.2.0
 Release:        %{?autorelease}%{!?autorelease:1%{?dist}}
 Summary:        Rust agent for Keylime
 
@@ -38,7 +38,7 @@ Summary:        Rust agent for Keylime
 #
 License:        ASL 2.0 and BSD and MIT
 URL:            https://github.com/keylime/rust-keylime/
-Source0:        rust-keylime-v0.2.0.tar.gz
+Source0:        rust-keylime-v%{version}.tar.gz
 # The vendor tarball is created using cargo-vendor-filterer to remove Windows
 # related files (https://github.com/cgwalters/cargo-vendor-filterer)
 #   tar xf rust-keylime-%%{version}.tar.gz
@@ -102,7 +102,7 @@ EOF
 %endif
 
 %build
-%cargo_build
+%cargo_build -ftesting
 
 %install
 

--- a/rpm/fedora/rust-keylime-metadata.patch
+++ b/rpm/fedora/rust-keylime-metadata.patch
@@ -1,6 +1,8 @@
---- a/keylime-agent/Cargo.toml	2023-03-28 18:22:10.988506154 +0200
-+++ b/keylime-agent/Cargo.toml	2023-03-28 19:30:54.836096045 +0200
-@@ -13,7 +13,7 @@
+diff --git a/keylime-agent/Cargo.toml b/keylime-agent/Cargo.toml
+index 2d9cd9a..e4a7852 100644
+--- a/keylime-agent/Cargo.toml
++++ b/keylime-agent/Cargo.toml
+@@ -13,7 +13,7 @@ base64 = "0.13"
  cfg-if = "1"
  clap = { version = "3.2", features = ["derive"] }
  compress-tools = "0.12"
@@ -9,7 +11,7 @@
  futures = "0.3.6"
  glob = "0.3"
  hex = "0.4"
-@@ -21,8 +21,8 @@
+@@ -21,8 +21,8 @@ keylime = { path = "../keylime" }
  libc = "0.2.43"
  log = "0.4"
  openssl = "0.10.15"
@@ -20,7 +22,7 @@
  pretty_env_logger = "0.4"
  reqwest = {version = "0.11", features = ["json"]}
  serde = "1.0.80"
-@@ -31,7 +31,7 @@
+@@ -31,7 +31,7 @@ serde_json = { version = "1.0", features = ["raw_value"] }
  static_assertions = "1"
  tempfile = "3.4.0"
  tokio = {version = "1.24", features = ["rt", "sync"]}
@@ -29,11 +31,12 @@
  thiserror = "1.0"
  uuid = {version = "1.3", features = ["v4"]}
  zmq = {version = "0.9.2", optional = true}
-@@ -47,19 +47,6 @@
+@@ -46,20 +46,7 @@ actix-rt = "2"
+ [features]
  # The features enabled by default
  default = []
- # this should change to dev-dependencies when we have integration testing
--testing = ["wiremock"]
+-# this should change to dev-dependencies when we have integration testing
+ testing = ["wiremock"]
 -# Whether the agent should be compiled with support to listen for notification
 -# messages on ZeroMQ
 -#


### PR DESCRIPTION
Allow setting the path to the binary bios measurements log file via the `TPM_BINARY_MEASUREMENTS` environment variable when build with the `testing` feature enabled.

The binaries in the RPM are build with the `testing` feature enabled.

Fixes #490 