### PR TITLE
packit: Build RPM packages on Copr for fedora-all

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -44,8 +44,7 @@ jobs:
             --exclude-crate-path "libloading#tests" &&
         tar jcf rpm/fedora/rust-keylime-vendor.tar.xz vendor'
   targets:
-    - fedora-stable
-#    - fedora-rawhide
+    - fedora-all
 
 - job: copr_build
   trigger: commit

--- a/rpm/fedora/keylime-agent-rust.spec
+++ b/rpm/fedora/keylime-agent-rust.spec
@@ -4,13 +4,12 @@
 
 %global crate keylime_agent
 
-%if 0%{?fedora} < 38
-# For older Fedora versions, use vendored dependencies due to broken packages
+# On Fedora-38 and current Rawhide, it is not possible to build due to missing
+# dependency base64 version 0.13 (required by rust-tss-esapi)
+# Also due to https://github.com/tpm2-software/tpm2-tools/issues/3210,
+# tpm2-tools is currently broken.
+# Use vendored dependencies for all Fedora versions.
 %global bundled_rust_deps 1
-%else
-# Otherwise, use only system Rust libraries
-%global bundled_rust_deps 0
-%endif
 
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/debug/.*$
 


### PR DESCRIPTION
Enable building RPM packages on Copr for all active Fedora versions

On Fedora-38 and current Rawhide, it is not possible to build the keylime agent due to the issues:
-  https://github.com/tpm2-software/tpm2-tools/issues/3210
   - `tpm2-tools` is currently broken when build with `-lto -DFORTIFY_SOURCE=3`
- The `rust-base64` package version `0.13`, required to build `rust-tss-esapi` is not available.

This makes the RPM build to use vendored dependencies for all Fedora versions.