### PR TITLE
rpm/fedora: Fix metadata patch

### DIFF
--- a/rpm/fedora/rust-keylime-metadata.patch
+++ b/rpm/fedora/rust-keylime-metadata.patch
@@ -1,16 +1,7 @@
 diff --git a/keylime-agent/Cargo.toml b/keylime-agent/Cargo.toml
-index 2d9cd9a..e4a7852 100644
+index 0cc1385..286e807 100644
 --- a/keylime-agent/Cargo.toml
 +++ b/keylime-agent/Cargo.toml
-@@ -13,7 +13,7 @@ base64 = "0.13"
- cfg-if = "1"
- clap = { version = "3.2", features = ["derive"] }
- compress-tools = "0.12"
--config = { version = "0.13", features = ["toml"] }
-+config = { version = "0.12", features = ["toml"] }
- futures = "0.3.6"
- glob = "0.3"
- hex = "0.4"
 @@ -21,8 +21,8 @@ keylime = { path = "../keylime" }
  libc = "0.2.43"
  log = "0.4"
@@ -20,7 +11,7 @@ index 2d9cd9a..e4a7852 100644
 +picky-asn1-der = "0.3"
 +picky-asn1-x509 = "0.7"
  pretty_env_logger = "0.4"
- reqwest = {version = "0.11", features = ["json"]}
+ reqwest = {version = "0.11", default-features = false, features = ["json"]}
  serde = "1.0.80"
 @@ -31,7 +31,7 @@ serde_json = { version = "1.0", features = ["raw_value"] }
  static_assertions = "1"
@@ -31,11 +22,9 @@ index 2d9cd9a..e4a7852 100644
  thiserror = "1.0"
  uuid = {version = "1.3", features = ["v4"]}
  zmq = {version = "0.9.2", optional = true}
-@@ -46,20 +46,7 @@ actix-rt = "2"
- [features]
- # The features enabled by default
+@@ -48,18 +48,6 @@ actix-rt = "2"
  default = []
--# this should change to dev-dependencies when we have integration testing
+ # this should change to dev-dependencies when we have integration testing
  testing = ["wiremock"]
 -# Whether the agent should be compiled with support to listen for notification
 -# messages on ZeroMQ


### PR DESCRIPTION
With the changes in the Cargo.toml, the patch for the rpm also needs to
be fixed

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>
