### PR TITLE
Cargo: Update base64 to version 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,7 +1027,7 @@ dependencies = [
 name = "keylime"
 version = "0.2.0"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "hex",
  "log",
  "openssl",
@@ -1045,7 +1045,7 @@ version = "0.2.0"
 dependencies = [
  "actix-rt",
  "actix-web",
- "base64 0.13.1",
+ "base64 0.21.0",
  "cfg-if",
  "clap",
  "compress-tools",

--- a/keylime-agent/Cargo.toml
+++ b/keylime-agent/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/keylime/rust-keylime"
 
 [dependencies]
 actix-web =  { version = "4", default-features = false, features = ["macros", "openssl"] }
-base64 = "0.13"
+base64 = "0.21"
 cfg-if = "1"
 clap = { version = "3.2", features = ["derive"] }
 compress-tools = "0.12"

--- a/keylime-agent/src/crypto.rs
+++ b/keylime-agent/src/crypto.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2021 Keylime Authors
 
+use base64::{engine::general_purpose, Engine as _};
 use openssl::{
     asn1::Asn1Time,
     encrypt::Decrypter,
@@ -244,7 +245,8 @@ pub(crate) fn asym_verify(
     verifier
         .set_rsa_pss_saltlen(openssl::sign::RsaPssSaltlen::MAXIMUM_LENGTH)?;
     verifier.update(message.as_bytes())?;
-    Ok(verifier.verify(&base64::decode(signature.as_bytes())?)?)
+    Ok(verifier
+        .verify(&general_purpose::STANDARD.decode(signature.as_bytes())?)?)
 }
 
 /*

--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -49,6 +49,7 @@ mod serialization;
 mod version_handler;
 
 use actix_web::{dev::Service, http, middleware, rt, web, App, HttpServer};
+use base64::{engine::general_purpose, Engine as _};
 use clap::{Arg, Command as ClapApp};
 use common::*;
 use error::{Error, Result};
@@ -520,7 +521,7 @@ async fn main() -> Result<()> {
         if config.agent.ek_handle.is_empty() {
             ctx.as_mut().flush_context(ek_result.key_handle.into())?;
         }
-        let mackey = base64::encode(key.value());
+        let mackey = general_purpose::STANDARD.encode(key.value());
         let auth_tag =
             crypto::compute_hmac(mackey.as_bytes(), agent_uuid.as_bytes())?;
         let auth_tag = hex::encode(&auth_tag);

--- a/keylime-agent/src/quotes_handler.rs
+++ b/keylime-agent/src/quotes_handler.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2021 Keylime Authors
 
-use crate::{tpm, Error as KeylimeError, QuoteData};
-
 use crate::common::JsonWrapper;
 use crate::crypto;
 use crate::serialization::serialize_maybe_base64;
+use crate::{tpm, Error as KeylimeError, QuoteData};
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
+use base64::{engine::general_purpose, Engine as _};
 use log::*;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -277,7 +277,7 @@ pub async fn integrity(
                     );
                 }
                 mb_measurement_list = match f.read_to_end(&mut ml) {
-                    Ok(_) => Some(base64::encode(ml)),
+                    Ok(_) => Some(general_purpose::STANDARD.encode(ml)),
                     Err(e) => {
                         warn!("Could not read TPM2 event log: {}", e);
                         None

--- a/keylime-agent/src/serialization.rs
+++ b/keylime-agent/src/serialization.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2021 Keylime Authors
 
+use base64::{engine::general_purpose, Engine as _};
 use serde::{Deserialize, Serialize};
 use serde_json::Number;
 
@@ -16,7 +17,7 @@ pub(crate) fn serialize_as_base64<S>(
 where
     S: serde::Serializer,
 {
-    serializer.serialize_str(&base64::encode(bytes))
+    serializer.serialize_str(&general_purpose::STANDARD.encode(bytes))
 }
 
 pub(crate) fn deserialize_as_base64<'de, D>(
@@ -26,7 +27,9 @@ where
     D: serde::Deserializer<'de>,
 {
     String::deserialize(deserializer).and_then(|string| {
-        base64::decode(string).map_err(serde::de::Error::custom)
+        general_purpose::STANDARD
+            .decode(string)
+            .map_err(serde::de::Error::custom)
     })
 }
 
@@ -38,7 +41,9 @@ where
     S: serde::Serializer,
 {
     match *value {
-        Some(ref value) => serializer.serialize_str(&base64::encode(value)),
+        Some(ref value) => {
+            serializer.serialize_str(&general_purpose::STANDARD.encode(value))
+        }
         None => serializer.serialize_none(),
     }
 }

--- a/keylime/Cargo.toml
+++ b/keylime/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = "0.13"
+base64 = "0.21"
 hex = "0.4"
 log = "0.4"
 openssl = "0.10.15"

--- a/keylime/src/tpm.rs
+++ b/keylime/src/tpm.rs
@@ -2,6 +2,7 @@
 // Copyright 2021 Keylime Authors
 
 use crate::algorithms::{EncryptionAlgorithm, HashAlgorithm, SignAlgorithm};
+use base64::{engine::general_purpose, Engine as _};
 use log::*;
 use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
@@ -560,9 +561,9 @@ fn encode_quote_string(
     let pcr_vec = pcrdata_to_vec(pcrs_read, pcr_data);
 
     // base64 encoding
-    let att_str = base64::encode(att_vec);
-    let sig_str = base64::encode(sig_vec);
-    let pcr_str = base64::encode(pcr_vec);
+    let att_str = general_purpose::STANDARD.encode(att_vec);
+    let sig_str = general_purpose::STANDARD.encode(sig_vec);
+    let pcr_str = general_purpose::STANDARD.encode(pcr_vec);
 
     // create concatenated string
     let mut quote = String::new();
@@ -833,9 +834,9 @@ pub mod testing {
         let pcr_str = split.next().ok_or(TpmError::InvalidRequest)?;
 
         // base64 decoding
-        let att_comp_finished = base64::decode(att_str)?;
-        let sig_comp_finished = base64::decode(sig_str)?;
-        let pcr_comp_finished = base64::decode(pcr_str)?;
+        let att_comp_finished = general_purpose::STANDARD.decode(att_str)?;
+        let sig_comp_finished = general_purpose::STANDARD.decode(sig_str)?;
+        let pcr_comp_finished = general_purpose::STANDARD.decode(pcr_str)?;
 
         let sig: Signature = vec_to_sig(&sig_comp_finished)?.try_into()?;
         let (pcrsel, pcrdata) = vec_to_pcrdata(&pcr_comp_finished)?;


### PR DESCRIPTION
There were incompatible changes between version `0.13` and `0.21`, which requires some changes in the code.

Supersedes #570 