### PR TITLE
rpm: Remove unused directory and add dependency for mount

### DIFF
--- a/rpm/centos/keylime-agent-rust.spec
+++ b/rpm/centos/keylime-agent-rust.spec
@@ -49,6 +49,7 @@ Source1:        rust-keylime-vendor.tar.xz
 ExclusiveArch:  %{rust_arches}
 
 Requires: tpm2-tss
+Requires: util-linux-core
 
 # The keylime-base package provides the keylime user creation. It is available
 # from Fedora 36
@@ -83,7 +84,6 @@ Rust agent for Keylime
 
 mkdir -p %{buildroot}/%{_sharedstatedir}/keylime
 mkdir -p --mode=0700 %{buildroot}/%{_rundir}/keylime
-mkdir -p --mode=0700 %{buildroot}/%{_localstatedir}/log/keylime
 mkdir -p --mode=0700 %{buildroot}/%{_libexecdir}/keylime
 mkdir -p --mode=0700  %{buildroot}/%{_sysconfdir}/keylime
 mkdir -p --mode=0700  %{buildroot}/%{_sysconfdir}/keylime/agent.conf.d
@@ -134,7 +134,6 @@ chown -R keylime:keylime %{_sysconfdir}/keylime
 %{_unitdir}/keylime_agent.service
 %{_unitdir}/var-lib-keylime-secure.mount
 %attr(700,keylime,keylime) %dir %{_rundir}/keylime
-%attr(700,keylime,keylime) %dir %{_localstatedir}/log/keylime
 %attr(700,keylime,keylime) %{_sharedstatedir}/keylime
 %attr(700,keylime,keylime) %{_libexecdir}/keylime
 %{_bindir}/keylime_agent

--- a/rpm/fedora/keylime-agent-rust.spec
+++ b/rpm/fedora/keylime-agent-rust.spec
@@ -58,6 +58,7 @@ Patch1:         rust-keylime-metadata.patch
 ExclusiveArch:  %{rust_arches}
 
 Requires: tpm2-tss
+Requires: util-linux-core
 
 # The keylime-base package provides the keylime user creation. It is available
 # from Fedora 36
@@ -107,7 +108,6 @@ EOF
 
 mkdir -p %{buildroot}/%{_sharedstatedir}/keylime
 mkdir -p --mode=0700 %{buildroot}/%{_rundir}/keylime
-mkdir -p --mode=0700 %{buildroot}/%{_localstatedir}/log/keylime
 mkdir -p --mode=0700 %{buildroot}/%{_libexecdir}/keylime
 mkdir -p --mode=0700  %{buildroot}/%{_sysconfdir}/keylime
 mkdir -p --mode=0700  %{buildroot}/%{_sysconfdir}/keylime/agent.conf.d
@@ -158,7 +158,6 @@ chown -R keylime:keylime %{_sysconfdir}/keylime
 %{_unitdir}/keylime_agent.service
 %{_unitdir}/var-lib-keylime-secure.mount
 %attr(700,keylime,keylime) %dir %{_rundir}/keylime
-%attr(700,keylime,keylime) %dir %{_localstatedir}/log/keylime
 %attr(700,keylime,keylime) %{_sharedstatedir}/keylime
 %attr(700,keylime,keylime) %{_libexecdir}/keylime
 %{_bindir}/keylime_agent


### PR DESCRIPTION
Remove ownership of /var/log/keylime which is unused.

Add Requires on util-linux-core for the mount command.