### PR TITLE
Adding release Dockerfiles

### DIFF
--- a/docker/release/Dockerfile.distroless
+++ b/docker/release/Dockerfile.distroless
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# the builder stage which uses the official rust base image (based on Debian 11) to build the keylime agent
+FROM rust:1.70-bullseye AS builder
+
+# we are using the "generate-bindings" feature for the tss-esapi crate which requires clang/llvm
+RUN apt-get update && apt-get install -y --no-install-recommends clang llvm
+
+# Install tpm2-tss (dependency for the tss-esapi crate)
+WORKDIR /src
+RUN wget https://github.com/tpm2-software/tpm2-tss/releases/download/4.0.1/tpm2-tss-4.0.1.tar.gz
+RUN tar xf tpm2-tss-4.0.1.tar.gz
+WORKDIR /src/tpm2-tss-4.0.1
+RUN ./configure \
+    --prefix=/usr \
+    --disable-static \
+    --disable-fapi \
+    --disable-policy \
+    --disable-doxygen-doc \
+    --disable-defaultflags
+RUN make
+RUN make install
+
+# Install libarchive (dependency for the compress-tools crate) - we need only a minimum feature set here
+WORKDIR /src
+RUN wget https://github.com/libarchive/libarchive/releases/download/v3.6.2/libarchive-3.6.2.tar.gz
+RUN tar xf libarchive-3.6.2.tar.gz
+WORKDIR /src/libarchive-3.6.2
+RUN ./configure \
+    --prefix=/usr \
+    --with-openssl \
+    --without-mbedtls \
+    --without-nettle \
+    --without-xml2 \
+    --without-expat \
+    --disable-static
+RUN make
+RUN make install
+# there is a bug in the libarchive.pc file which wrongly adds iconv
+RUN sed -i "s/iconv //" /usr/lib/pkgconfig/libarchive.pc
+
+# build rust-keylime
+COPY . /src/rust-keylime/
+WORKDIR /src/rust-keylime
+RUN make RELEASE=1 TARGETDIR=target target/release/keylime_agent
+
+# truly just for debugging purposes for the assembly stage
+RUN readelf -W \
+    --file-header --program-headers --sections --dynamic --notes --version-info --arch-specific --unwind --section-groups --histogram \
+    /src/rust-keylime/target/release/keylime_agent
+RUN ldd /src/rust-keylime/target/release/keylime_agent
+
+# now assemble a release docker image using a minimal docker image
+FROM gcr.io/distroless/cc-debian11:latest
+ARG VERSION=latest
+LABEL org.opencontainers.image.authors="Keylime Team <main@keylime.groups.io>"
+LABEL org.opencontainers.image.version="$VERSION"
+LABEL org.opencontainers.image.title="Keylime Agent"
+LABEL org.opencontainers.image.description="Keylime Agent - Bootstrapping and Maintaining Trust in the Cloud"
+LABEL org.opencontainers.image.url="https://keylime.dev/"
+LABEL org.opencontainers.image.source="https://github.com/keylime/rust-keylime/"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.vendor="The Keylime Authors"
+
+# Copy all agent dependencies from the builder image
+# NOTE: the cc base image comes with all C runtime dependencies (libc, libm, libgcc, etc.), so no need to copy those
+# TODO: Unfortunately the COPY directive is following links and not preserving the link file. This slightly bloats the image.
+
+# libarchive is a direct dependency for the compress-tools crate, so we must copy itself and all its dependencies
+COPY --from=builder \
+    /usr/lib/libarchive.so* \
+    /lib/x86_64-linux-gnu/liblzma.so* \
+    /lib/x86_64-linux-gnu/libbz2.so* \
+    /lib/x86_64-linux-gnu/libz.so* \
+    /usr/lib/x86_64-linux-gnu/
+# tpm2-tss libraries are a dependency (probably not all of them, but we just copy all)
+# because we are using the tss-esapi crate which is essentially just a wrapper around those (unfortunately)
+COPY --from=builder \
+    /usr/lib/libtss2*.so* \
+    /usr/lib/x86_64-linux-gnu/
+
+# now copy the agent from the builder
+COPY --from=builder /src/rust-keylime/target/release/keylime_agent /bin/keylime_agent
+COPY --from=builder /src/rust-keylime/keylime-agent.conf /etc/keylime/keylime-agent.conf
+ENTRYPOINT ["/bin/keylime_agent"]
+
+# we default the log level to info if not overwritten
+ENV RUST_LOG=keylime_agent=info
+
+# the agent currently listens on this port by default
+# it's good practice to declare this in the Dockerfile
+EXPOSE 9002/tcp
+
+# define the stopsignal to be SIGINT like the systemd service file does
+STOPSIGNAL SIGINT
+
+# these are all podman labels that work with the 'podman container runlabel' command, and are standardized at least in RHEL (install, uninstall, run)
+LABEL install="podman volume create keylime-agent"
+LABEL uninstall="podman volume rm keylime-agent"
+LABEL run="podman run --read-only --name keylime-agent --rm --device /dev/tpm0 --device /dev/tpmrm0 -v keylime-agent:/var/lib/keylime -v /etc/keylime:/etc/keylime:ro --tmpfs /var/lib/keylime/secure:rw,size=1m,mode=0700 -dt IMAGE"
+
+# run as root by default
+USER 0:0

--- a/docker/release/Dockerfile.fedora
+++ b/docker/release/Dockerfile.fedora
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# the builder stage which uses the latest Fedora minimal image to build the keylime agent - we know this works well
+FROM registry.fedoraproject.org/fedora-minimal AS builder
+
+# Packaged dependencies
+RUN microdnf install -y \
+    cargo \
+    clang \
+    clang-devel \
+    dnf-plugins-core \
+    git \
+    libarchive-devel \
+    make \
+    openssl-devel \
+    rust \
+    systemd \
+    tpm2-tss \
+    tpm2-tss-devel
+
+# build rust-keylime
+COPY . /src/rust-keylime/
+WORKDIR /src/rust-keylime
+RUN make RELEASE=1 TARGETDIR=target target/release/keylime_agent
+
+# now assemble a release docker image using a fedora minimal base image
+FROM registry.fedoraproject.org/fedora-minimal
+ARG VERSION=latest
+LABEL org.opencontainers.image.authors="Keylime Team <main@keylime.groups.io>"
+LABEL org.opencontainers.image.version="$VERSION"
+LABEL org.opencontainers.image.title="Keylime Agent"
+LABEL org.opencontainers.image.description="Keylime Agent - Bootstrapping and Maintaining Trust in the Cloud"
+LABEL org.opencontainers.image.url="https://keylime.dev/"
+LABEL org.opencontainers.image.source="https://github.com/keylime/rust-keylime/"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.vendor="The Keylime Authors"
+
+# these labels are set in the fedora base image and should be overwritten
+LABEL name="Keylime Agent"
+LABEL version="$VERSION"
+LABEL license="Apache-2.0"
+LABEL vendor="The Keylime Authors"
+
+# Install all agent runtime dependencies from the builder image
+# NOTE: the fedora base image is "fat" and comes with basically all dependencies that we need out of the box with a few exceptions
+RUN microdnf makecache && \
+    microdnf -y install tpm2-tss libarchive openssl util-linux-core && \
+    microdnf clean all && \
+    rm -rf /var/cache/dnf/*
+
+# now copy the agent from the builder
+COPY --from=builder /src/rust-keylime/target/release/keylime_agent /bin/keylime_agent
+COPY --from=builder /src/rust-keylime/keylime-agent.conf /etc/keylime/keylime-agent.conf
+ENTRYPOINT ["/bin/keylime_agent"]
+
+# we default the log level to info if not overwritten
+ENV RUST_LOG=keylime_agent=info
+
+# the agent currently listens on this port by default
+# it's good practice to declare this in the Dockerfile
+EXPOSE 9002
+
+# define the stopsignal to be SIGINT like the systemd service file does
+STOPSIGNAL SIGINT
+
+# these are all podman labels that work with the 'podman container runlabel' command, and are standardized at least in RHEL (install, uninstall, run)
+LABEL install="podman volume create keylime-agent"
+LABEL uninstall="podman volume rm keylime-agent"
+LABEL run="podman run --read-only --name keylime-agent --rm --device /dev/tpm0 --device /dev/tpmrm0 -v keylime-agent:/var/lib/keylime -v /etc/keylime:/etc/keylime:ro --tmpfs /var/lib/keylime/secure:rw,size=1m,mode=0700 -dt IMAGE"
+
+# run as root by default
+USER 0:0

--- a/docker/release/Dockerfile.wolfi
+++ b/docker/release/Dockerfile.wolfi
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# the builder stage which uses the wolfi-base image to build the keylime agent
+# NOTE: even though there is a rust wolfi base image, it does not ship apk which we need to add some dependencies
+FROM cgr.dev/chainguard/wolfi-base AS builder
+
+# update apk
+RUN apk update
+
+# we are installing build dependencies, describe them per line as they are added:
+# - install rust
+# - install gcc and others to compile tpm2-tss
+# - we are using the "generate-bindings" feature for the tss-esapi crate which requires clang/llvm
+# - Install libarchive (dependency for the compress-tools crate)
+RUN apk add --no-cache --update-cache \
+    rust \
+    make pkgconf gcc glibc glibc-dev openssl openssl-dev posix-libc-utils \
+    clang-15 llvm15 \
+    libarchive libarchive-dev
+
+# there is a bug in the libarchive.pc file which wrongly adds iconv
+RUN sed -i "s/iconv //" /usr/lib/pkgconfig/libarchive.pc
+
+# Install tpm2-tss (dependency for the tss-esapi crate)
+WORKDIR /src
+RUN wget https://github.com/tpm2-software/tpm2-tss/releases/download/4.0.1/tpm2-tss-4.0.1.tar.gz
+RUN tar xf tpm2-tss-4.0.1.tar.gz
+WORKDIR /src/tpm2-tss-4.0.1
+RUN ./configure \
+    --prefix=/usr \
+    --disable-static \
+    --disable-fapi \
+    --disable-policy \
+    --disable-doxygen-doc \
+    --disable-defaultflags \
+    --disable-dependency-tracking
+RUN make
+RUN make install
+
+# build rust-keylime
+COPY . /src/rust-keylime/
+WORKDIR /src/rust-keylime
+RUN make RELEASE=1 TARGETDIR=target target/release/keylime_agent
+
+# truly just for debugging purposes for the assembly stage
+RUN readelf -W \
+    --file-header --program-headers --sections --dynamic --notes --version-info --arch-specific --unwind --section-groups --histogram \
+    /src/rust-keylime/target/release/keylime_agent
+RUN ldd /src/rust-keylime/target/release/keylime_agent
+
+# now assemble a release docker image using a minimal docker image
+FROM cgr.dev/chainguard/cc-dynamic:latest
+ARG VERSION=latest
+LABEL org.opencontainers.image.authors="Keylime Team <main@keylime.groups.io>"
+LABEL org.opencontainers.image.version="$VERSION"
+LABEL org.opencontainers.image.title="Keylime Agent"
+LABEL org.opencontainers.image.description="Keylime Agent - Bootstrapping and Maintaining Trust in the Cloud"
+LABEL org.opencontainers.image.url="https://keylime.dev/"
+LABEL org.opencontainers.image.source="https://github.com/keylime/rust-keylime/"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.vendor="The Keylime Authors"
+
+# Copy all agent dependencies from the builder image
+# NOTE: the cc base image comes with all C runtime dependencies (libc, libm, libgcc_s, etc.), so no need to copy those
+# TODO: Unfortunately the COPY directive is following links and not preserving the link file. This slightly bloats the image.
+
+# openssl (both crypto and ssl libraries) are direct dependencies
+COPY --from=builder \
+    /usr/lib/libcrypto.so* \
+    /usr/lib/libssl.so* \
+    /usr/lib/
+
+# libarchive is a direct dependency for the compress-tools crate, so we must copy itself and all its dependencies
+COPY --from=builder \
+    /lib/libacl.so* \
+    /lib/libattr.so* \
+    /lib/libz.so* \
+    /lib/
+COPY --from=builder \
+    /usr/lib/libarchive.so* \
+    /usr/lib/libexpat.so* \
+    /usr/lib/liblzma.so* \
+    /usr/lib/libzstd.so* \
+    /usr/lib/libbz2.so* \
+    /usr/lib/
+
+# tpm2-tss libraries are a dependency (probably not all of them, but we just copy all)
+# because we are using the tss-esapi crate which is essentially just a wrapper around those (unfortunately)
+COPY --from=builder \
+    /usr/lib/libtss2*.so* \
+    /usr/lib/
+
+# now copy the agent from the builder
+COPY --from=builder /src/rust-keylime/target/release/keylime_agent /bin/keylime_agent
+COPY --from=builder /src/rust-keylime/keylime-agent.conf /etc/keylime/keylime-agent.conf
+ENTRYPOINT ["/bin/keylime_agent"]
+
+# we default the log level to info if not overwritten
+ENV RUST_LOG=keylime_agent=info
+
+# the agent currently listens on this port by default
+# it's good practice to declare this in the Dockerfile
+EXPOSE 9002/tcp
+
+# define the stopsignal to be SIGINT like the systemd service file does
+STOPSIGNAL SIGINT
+
+# these are all podman labels that work with the 'podman container runlabel' command, and are standardized at least in RHEL (install, uninstall, run)
+LABEL install="podman volume create keylime-agent"
+LABEL uninstall="podman volume rm keylime-agent"
+LABEL run="podman run --read-only --name keylime-agent --rm --device /dev/tpm0 --device /dev/tpmrm0 -v keylime-agent:/var/lib/keylime -v /etc/keylime:/etc/keylime:ro --tmpfs /var/lib/keylime/secure:rw,size=1m,mode=0700 -dt IMAGE"
+
+# run as root by default
+USER 0:0

--- a/docker/release/build_locally.sh
+++ b/docker/release/build_locally.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 Keylime Authors
+
+# Build Docker container locally
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+if [ "$1" = "--help" -o "$1" = "-h" ] ; then
+    echo "USAGE: $0 [VERSION] [KEYLIME_DIR] [DOCKER_BUILDX_FLAGS...]" 1>&2
+    echo 1>&2
+    echo "Examples:" 1>&2
+    echo "$0" 1>&2
+    echo "$0 15.1.2" 1>&2
+    echo "$0 15.1.2 /different/source/folder" 1>&2
+    echo "$0 15.1.2 /source/folder --pull --push" 1>&2
+    echo "DOCKERFILE_TYPE=fedora $0" 1>&2 
+    echo "DOCKERFILE_TYPE=wolfi $0" 1>&2
+    echo 1>&2 
+    exit 0
+fi
+
+VERSION=${1:-latest}
+$( cd -- "${SCRIPT_DIR}/../dev/images" &> /dev/null && pwd )
+KEYLIME_DIR=${2:-$( cd -- "${SCRIPT_DIR}/../../" &>/dev/null && pwd )}
+# TODO: why is shift N not working?
+shift
+shift
+DOCKER_BUILDX_FLAGS=${@:-"--load"}
+
+# overwrite this with one of the following:
+# - distroless (default)
+# - fedora
+# - wolfi
+DOCKERFILE_TYPE="${DOCKERFILE_TYPE:-distroless}"
+
+LOG_DIR=${LOG_DIR:-/tmp}
+DOCKERFILE="${SCRIPT_DIR}/Dockerfile.${DOCKERFILE_TYPE}"
+
+docker buildx build \
+    -f $DOCKERFILE \
+    -t keylime_agent:${VERSION}-${DOCKERFILE_TYPE} \
+    --progress=plain \
+    --platform=linux/amd64 \
+    --build-arg VERSION="$VERSION" \
+    $DOCKER_BUILDX_FLAGS $KEYLIME_DIR 2>&1 | tee $LOG_DIR/docker-keylime-agent-build.log
+docker tag keylime_agent:${VERSION}-${DOCKERFILE_TYPE} keylime_agent:${VERSION}


### PR DESCRIPTION
This PR aims to add a Dockerfile for a release version of the rust keylime agent.

**This is a work-in-progress at this point.** It is being discussed in the keylime-operator slack channel.

It currently contains a local build script like in the main keylime repository. Also, it contains different versions which have their advantages/disadvantages that we should discuss:
- `Dockerfile.distroless`:  an absolute bare minimum container which does not even have a shell. It is based on the "distroless" container effort from Google (which for example forms the base images for a couple of bigger projects like Kubernetes)
- `Dockerfile.wolfi`: also a bare minimum container which does not even have a shell. It is based on the wolfi container distribution from Chainguard which in turn was inspired by Google's distroless and ko projects. Its focus is a dedicated container distribution which heavily focuses on security, frequent updates and updates faster/more often than distroless
- `Dockerfile.fedora`: is based on Fedora 38. This is a "fat" image, but both the build stage as well as the assembly stage are based upon Fedora 38. This is probably closer to what we know works.

Here a comparison of the two versions:

## Dockerfile.distroless

- builder stage based on official Rust Docker images
- official Rust image (which is chosen here) is based on Debian 11
- has an additional custom compilation/installation stage for libarchive in the builder stage with minimal options for libarchive (which are enough for our purposes)
- has an additional compilation/installation stage for tpm2-tss with minimal options which _should_ be enough for our purposes (fapi and fapi policy libs are disabled)
- the assembly stage uses `gcr.io/distroless/cc` as a base image which is a minimal no-shell base image including C runtime dependencies (libc, libgcc, etc.) as well as OpenSSL and root CA certificates. This image is intended for use by languages like Rust or D according to its [documentation](https://github.com/GoogleContainerTools/distroless/blob/main/cc/README.md)
- the distroless images are all based on Debian 11 at this point in time, so this makes the build and assembly compatible
- dependencies and compiled agent are copied from the builder stage

Pros of this approach are IMHO:
- maximized for security as it truly does not contain what is not needed
- image size is quite good (still bigger than I expected though)
- good control over used versions of dependencies and rust version etc.

Cons of this approach are IMHO:
- based on Debian 11 which uses oldish versions of things - probably not an issue at all though, and it does have all security patches after all
- OpenSSL version is 1.1 here - again, not sure if this is an issue for us
- harder to debug (because there is no shell)

image size:

```
REPOSITORY                                                         TAG       IMAGE ID       CREATED          SIZE
keylime_agent                                                      latest    3ce6c74b8a73   22 minutes ago   57.6MB
```

## Dockerfile.wolfi

- builder stage based on wolfi-base docker images
- rust is being installed through wolfi which is the latest version - unfortunately Chainguard's rust image does not work because it does not allow to add dependencies
- has an additional compilation/installation stage for tpm2-tss with minimal options which _should_ be enough for our purposes (fapi and fapi policy libs are disabled)
- the assembly stage uses `cgr.dev/chainguard/cc-dynamic` as a base image which is a minimal no-shell base image including C runtime dependencies (libc, libgcc, etc.). This image is intended for use by languages like Rust even according to Chainguard's rust image [documentation](https://edu.chainguard.dev/chainguard/chainguard-images/reference/rust/overview/#application-setup-for-end-users)
- both builder and assembly stage images use the same base, so there is no potential incompatibilities between binaries/libraries
- dependencies and compiled agent are copied from the builder stage

Pros of this approach are IMHO:
- maximized for security as it truly does not contain what is not needed
- even better than distroless in regards to security IMHO
- image size is quite good (still bigger than I expected though)
- good control over used versions of dependencies and rust version etc.

Cons of this approach are IMHO:
- Chainguard is a relatively new player in this game (not sure that matters, just potentially for long-term maintainability)
- harder to debug (because there is no shell)

image size:

```
REPOSITORY                                                         TAG                        IMAGE ID       CREATED          SIZE
keylime_agent                                                      latest                     367bada26999   6 minutes ago    42.4MB
```

## Dockerfile.fedora

- builder stage uses Fedora 38 like the existing docker image for testing
- all build dependencies are installed through Fedora packages
- runtime dependencies are installed in the assembly stage (as compared to copied)

Pros of this approach are IMHO:
- probably the closest to what we know works
- easier to debug (has shell and tools, etc.)

Cons of this approach are IMHO:
- image size is "fat" for an agent which should be very small
- still contains a lot of tools and things (including package manager) which aren't necessary and are just an increase in attack surface
- even the keylime agent has a lot of library dependencies because of its C library dependencies that are for sure not required at all and are solely there to satisfy linker requirements

image size:

```
REPOSITORY                                                         TAG       IMAGE ID       CREATED             SIZE
keylime_agent                                                      latest    cbf68e330487   17 seconds ago      203MB
```