### PR TITLE
Initial PR to add support for IDevID and IAK

### DIFF
--- a/keylime-agent.conf
+++ b/keylime-agent.conf
@@ -227,6 +227,21 @@ tpm_signing_alg = "rsassa"
 # To override ek_handle, set KEYLIME_AGENT_EK_HANDLE environment variable.
 ek_handle = "generate"
 
+# Enable IDevID and IAK usage and set their algorithms.
+# Choosing a template will override the name and asymmetric algorithm choices.
+# Templates are specified in the TCG document found here, section 7.3.4: 
+# https://trustedcomputinggroup.org/wp-content/uploads/TPM-2p0-Keys-for-Device-Identity-and-Attestation_v1_r12_pub10082021.pdf
+#
+# Accepted values:
+# iak_idevid_asymmetric_alg:   rsa, ecc
+# iak_idevid_name_alg:        sha256, sm3_256, sha384, sha512
+# iak_idevid_template:        H-1, H-2, H-3, H-4, H-5
+# Leave template as "" in order to use asymmetric and name algorithm options
+enable_iak_idevid = false
+iak_idevid_asymmetric_alg = "rsa"
+iak_idevid_name_alg = "sha256"
+iak_idevid_template = ""
+
 # Use this option to state the existing TPM ownerpassword.
 # This option should be set only when a password is set for the Endorsement
 # Hierarchy (e.g. via "tpm2_changeauth -c e").

--- a/keylime-agent/src/config.rs
+++ b/keylime-agent/src/config.rs
@@ -55,6 +55,10 @@ pub static DEFAULT_TPM_HASH_ALG: &str = "sha256";
 pub static DEFAULT_TPM_ENCRYPTION_ALG: &str = "rsa";
 pub static DEFAULT_TPM_SIGNING_ALG: &str = "rsassa";
 pub static DEFAULT_EK_HANDLE: &str = "generate";
+pub static DEFAULT_ENABLE_IAK_IDEVID: bool = true;
+pub static DEFAULT_IAK_IDEVID_ASYMMETRIC_ALG: &str = "rsa";
+pub static DEFAULT_IAK_IDEVID_NAME_ALG: &str = "sha256";
+pub static DEFAULT_IAK_IDEVID_TEMPLATE: &str = "";
 pub static DEFAULT_RUN_AS: &str = "keylime:tss";
 pub static DEFAULT_AGENT_DATA_PATH: &str = "agent_data.json";
 pub static DEFAULT_CONFIG: &str = "/etc/keylime/agent.conf";
@@ -94,6 +98,10 @@ pub(crate) struct EnvConfig {
     pub tpm_encryption_alg: Option<String>,
     pub tpm_signing_alg: Option<String>,
     pub ek_handle: Option<String>,
+    pub enable_iak_idevid: Option<bool>,
+    pub iak_idevid_asymmetric_alg: Option<String>,
+    pub iak_idevid_name_alg: Option<String>,
+    pub iak_idevid_template: Option<String>,
     pub run_as: Option<String>,
     pub agent_data_path: Option<String>,
 }
@@ -132,6 +140,10 @@ pub(crate) struct AgentConfig {
     pub tpm_encryption_alg: String,
     pub tpm_signing_alg: String,
     pub ek_handle: String,
+    pub enable_iak_idevid: bool,
+    pub iak_idevid_asymmetric_alg: String,
+    pub iak_idevid_name_alg: String,
+    pub iak_idevid_template: String,
     pub run_as: String,
     pub agent_data_path: String,
 }
@@ -273,6 +285,30 @@ impl EnvConfig {
         }
         if let Some(ref v) = self.ek_handle {
             _ = agent.insert("ek_handle".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.enable_iak_idevid {
+            _ = agent.insert(
+                "enable_iak_idevid".to_string(),
+                v.to_string().into(),
+            );
+        }
+        if let Some(ref v) = self.iak_idevid_asymmetric_alg {
+            _ = agent.insert(
+                "iak_idevid_asymmetric_alg".to_string(),
+                v.to_string().into(),
+            );
+        }
+        if let Some(ref v) = self.iak_idevid_name_alg {
+            _ = agent.insert(
+                "iak_idevid_name_alg".to_string(),
+                v.to_string().into(),
+            );
+        }
+        if let Some(ref v) = self.iak_idevid_template {
+            _ = agent.insert(
+                "iak_idevid_template".to_string(),
+                v.to_string().into(),
+            );
         }
         if let Some(ref v) = self.run_as {
             _ = agent.insert("run_as".to_string(), v.to_string().into());
@@ -439,6 +475,22 @@ impl Source for KeylimeConfig {
             self.agent.ek_handle.to_string().into(),
         );
         _ = m.insert(
+            "enable_iak_idevid".to_string(),
+            self.agent.enable_iak_idevid.into(),
+        );
+        _ = m.insert(
+            "iak_idevid_asymmetric_alg".to_string(),
+            self.agent.iak_idevid_asymmetric_alg.to_string().into(),
+        );
+        _ = m.insert(
+            "iak_idevid_name_alg".to_string(),
+            self.agent.iak_idevid_name_alg.to_string().into(),
+        );
+        _ = m.insert(
+            "iak_idevid_template".to_string(),
+            self.agent.iak_idevid_template.to_string().into(),
+        );
+        _ = m.insert(
             "run_as".to_string(),
             self.agent.run_as.to_string().into(),
         );
@@ -504,6 +556,11 @@ impl Default for AgentConfig {
             run_as,
             tpm_ownerpassword: DEFAULT_TPM_OWNERPASSWORD.to_string(),
             ek_handle: DEFAULT_EK_HANDLE.to_string(),
+            enable_iak_idevid: DEFAULT_ENABLE_IAK_IDEVID,
+            iak_idevid_asymmetric_alg: DEFAULT_IAK_IDEVID_ASYMMETRIC_ALG
+                .to_string(),
+            iak_idevid_name_alg: DEFAULT_IAK_IDEVID_NAME_ALG.to_string(),
+            iak_idevid_template: DEFAULT_IAK_IDEVID_TEMPLATE.to_string(),
         }
     }
 }
@@ -971,6 +1028,13 @@ mod tests {
             ("TPM_ENCRYPTION_ALG", "override_tpm_encryption_alg"),
             ("TPM_SIGNING_ALG", "override_tpm_signing_alg"),
             ("EK_HANDLE", "override_ek_handle"),
+            ("ENABLE_IAK_IDEVID", "true"),
+            (
+                "IAK_IDEVID_ASYMMETRIC_ALG",
+                "override_iak_idevid_asymmetric_alg",
+            ),
+            ("IAK_IDEVID_NAME_ALG", "override_iak_idevid_name_alg"),
+            ("IAK_IDEVID_TEMPLATE", "override_iak_idevid_template"),
             ("RUN_AS", "override_run_as"),
             ("AGENT_DATA_PATH", "override_agent_data_path"),
         ]);

--- a/keylime-agent/src/registrar_agent.rs
+++ b/keylime-agent/src/registrar_agent.rs
@@ -22,6 +22,26 @@ struct Register<'a> {
     ek_tpm: &'a [u8],
     #[serde(serialize_with = "serialize_as_base64")]
     aik_tpm: &'a [u8],
+    #[serde(
+        serialize_with = "serialize_option_base64",
+        skip_serializing_if = "Option::is_none"
+    )]
+    iak_tpm: Option<&'a [u8]>,
+    #[serde(
+        serialize_with = "serialize_option_base64",
+        skip_serializing_if = "Option::is_none"
+    )]
+    idevid_tpm: Option<&'a [u8]>,
+    #[serde(
+        serialize_with = "serialize_maybe_base64",
+        skip_serializing_if = "Option::is_none"
+    )]
+    iak_attest: Option<Vec<u8>>,
+    #[serde(
+        serialize_with = "serialize_maybe_base64",
+        skip_serializing_if = "Option::is_none"
+    )]
+    iak_sign: Option<Vec<u8>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     mtls_cert: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -94,6 +114,10 @@ pub(crate) async fn do_register_agent(
     ek_tpm: &[u8],
     ekcert: Option<Vec<u8>>,
     aik_tpm: &[u8],
+    iak_tpm: Option<&[u8]>,
+    idevid_tpm: Option<&[u8]>,
+    iak_attest: Option<Vec<u8>>,
+    iak_sign: Option<Vec<u8>>,
     mtls_cert_x509: Option<&X509>,
     ip: &str,
     port: u32,
@@ -113,6 +137,10 @@ pub(crate) async fn do_register_agent(
         ekcert,
         ek_tpm,
         aik_tpm,
+        iak_tpm,
+        idevid_tpm,
+        iak_attest,
+        iak_sign,
         mtls_cert,
         ip,
         port: Some(port),
@@ -195,6 +223,10 @@ mod tests {
             &mock_data,
             Some(mock_data.to_vec()),
             &mock_data,
+            None,
+            None,
+            None,
+            None,
             Some(&cert),
             "",
             0,
@@ -237,6 +269,10 @@ mod tests {
             &mock_data,
             None,
             &mock_data,
+            None,
+            None,
+            None,
+            None,
             Some(&cert),
             "",
             0,
@@ -275,6 +311,10 @@ mod tests {
             &mock_data,
             Some(mock_data.to_vec()),
             &mock_data,
+            None,
+            None,
+            None,
+            None,
             Some(&cert),
             "",
             0,

--- a/keylime-agent/src/serialization.rs
+++ b/keylime-agent/src/serialization.rs
@@ -48,6 +48,21 @@ where
     }
 }
 
+pub(crate) fn serialize_option_base64<S>(
+    value: &Option<&[u8]>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match *value {
+        Some(value) => {
+            serializer.serialize_str(&general_purpose::STANDARD.encode(value))
+        }
+        None => serializer.serialize_none(),
+    }
+}
+
 pub(crate) fn deserialize_maybe_base64<'de, D>(
     deserializer: D,
 ) -> Result<Option<Vec<u8>>, D::Error>


### PR DESCRIPTION
This is the first of a series of PRs that will enable the use of IDevIDs and IAKs as proposed in enhancement 81.
The modifications to the Keylime repositories are:

**Keylime**
Columns for the IDevID and IAK are added to the database
The IAK and IDevID sent by the agent are processed
The AK is verified by the IAK

**Rust-Keylime**
Config options to enable IDevID and IAK generation and use are added, with choices on how to generate the IDevID and IAK
The IAK and IDevID are generated according to config options
The IAK is used to certify the AK in the registration process

The purpose of this PR is to begin enabling the use of IAK and IDevID in keylime, starting with their generation. Options for the server config are not yet added so the inclusion of IAK and IDevID are left as optional for the agent.
The changes are all backwards compatible. The use of the IAK to certify and verify the AK is to act as a simple early use case in the process. Down the road this will be changed to encompass all the options listed in the enhancement, and those options will be included in the Keylime config.

N.B.
The certify in Rust-keylime currently just uses the UUID as qualifying data. This should perhaps be changed to include some temporal data at some point.