### PR TITLE
cargo: Bump proc-macro2 crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "363a6f739a0c0addeaf6ed75150b95743aa18643a3c6f40409ed7b6db3a6911f"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
This fixes the compilation issue with the nightly compiler.

See:

* https://github.com/rust-lang/rust/issues/113152
* https://github.com/dtolnay/proc-macro2/pull/391
* https://github.com/rust-lang/rust/pull/111571