### PR TITLE
Removing SIGINT stop signals from Dockerfiles and systemd service

### DIFF
--- a/dist/systemd/system/keylime_agent.service
+++ b/dist/systemd/system/keylime_agent.service
@@ -14,7 +14,6 @@ After=tpm2-abrmd.service
 
 [Service]
 ExecStart=/usr/bin/keylime_agent
-KillSignal=SIGINT
 TimeoutSec=60s
 Restart=on-failure
 RestartSec=120s

--- a/docker/release/Dockerfile.distroless
+++ b/docker/release/Dockerfile.distroless
@@ -90,9 +90,6 @@ ENV RUST_LOG=keylime_agent=info
 # it's good practice to declare this in the Dockerfile
 EXPOSE 9002/tcp
 
-# define the stopsignal to be SIGINT like the systemd service file does
-STOPSIGNAL SIGINT
-
 # these are all podman labels that work with the 'podman container runlabel' command, and are standardized at least in RHEL (install, uninstall, run)
 LABEL install="podman volume create keylime-agent"
 LABEL uninstall="podman volume rm keylime-agent"

--- a/docker/release/Dockerfile.fedora
+++ b/docker/release/Dockerfile.fedora
@@ -59,9 +59,6 @@ ENV RUST_LOG=keylime_agent=info
 # it's good practice to declare this in the Dockerfile
 EXPOSE 9002
 
-# define the stopsignal to be SIGINT like the systemd service file does
-STOPSIGNAL SIGINT
-
 # these are all podman labels that work with the 'podman container runlabel' command, and are standardized at least in RHEL (install, uninstall, run)
 LABEL install="podman volume create keylime-agent"
 LABEL uninstall="podman volume rm keylime-agent"

--- a/docker/release/Dockerfile.wolfi
+++ b/docker/release/Dockerfile.wolfi
@@ -101,9 +101,6 @@ ENV RUST_LOG=keylime_agent=info
 # it's good practice to declare this in the Dockerfile
 EXPOSE 9002/tcp
 
-# define the stopsignal to be SIGINT like the systemd service file does
-STOPSIGNAL SIGINT
-
 # these are all podman labels that work with the 'podman container runlabel' command, and are standardized at least in RHEL (install, uninstall, run)
 LABEL install="podman volume create keylime-agent"
 LABEL uninstall="podman volume rm keylime-agent"

--- a/keylime-ima-emulator/src/main.rs
+++ b/keylime-ima-emulator/src/main.rs
@@ -9,6 +9,7 @@ use log::*;
 
 use clap::Parser;
 use signal_hook::consts::SIGINT;
+use signal_hook::consts::SIGTERM;
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::fs::File;
@@ -216,6 +217,7 @@ fn main() -> std::result::Result<(), ImaEmulatorError> {
 
     let shutdown_marker = Arc::new(AtomicBool::new(false));
     signal_hook::flag::register(SIGINT, Arc::clone(&shutdown_marker))?;
+    signal_hook::flag::register(SIGTERM, Arc::clone(&shutdown_marker))?;
     println!("Monitoring {}", args.ima_log.display());
     while !shutdown_marker.load(Ordering::SeqCst) {
         for (pcr_hash_alg, position) in positions.iter_mut() {


### PR DESCRIPTION
This PR does the following things and is a follow-up on #613 and #601 :

- removes the `KillSignal=SIGINT` from the systemd service file as it can now safely rely on the SIGTERM default
- removes the `STOPSIGNAL SIGINT` from the Dockerfiles as it can also here now safely rely on the default SIGTERM being sent by container runtimes
- adds SIGTERM handling to the IMA emulator