### PR TITLE
Add workflow to run cargo-audit security audit

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,26 @@
+name: Security audit
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*"
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  workflow_dispatch:
+    branches:
+      - master
+
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/audit-check@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,8 +20,6 @@ jobs:
       run: cargo fmt --all -- --check
     - name: Check for panics
       run: ./tests/nopanic.ci
-    - name: Run cargo audit
-      run: cargo audit
 
   tests:
     name: Fedora tests


### PR DESCRIPTION
Move the cargo-audit run from the static analysis job to a dedicated workflow using the github action instead of running the tool manually.

This improves the visibility of detected issues as the github action can use the checks interface and also create issues automatically.

The workflow runs cargo audit on pushes to master branch, when tags are created, or when a PR modifies dependencies (`Cargo.toml` or `Cargo.lock`)