### PR TITLE
Remove private_in_public

### DIFF
--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -10,7 +10,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
     unconditional_recursion,
     unused,
     while_true,


### PR DESCRIPTION
Resolves: #652

According to The Rust RFC Book type privacy chapter: https://rust-lang.github.io/rfcs/2145-type-privacy.html "private_in_public" compatibility lint will be removed and its uses will be reported as warnings by
"renamed_and_removed_lints"