### PR TITLE
tests: Fix tarpaulin issues with dropped -v option

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -40,10 +40,11 @@ cargo test --features testing -- --nocapture
 echo "-------- Testing with coverage"
 TCTI=tabrmd:bus_type=session RUST_BACKTRACE=1 RUST_LOG=info \
 KEYLIME_CONFIG=$PWD/keylime-agent.conf \
-cargo tarpaulin -v \
+cargo tarpaulin --verbose \
       --target-dir target/tarpaulin \
       --workspace \
       --exclude-files 'target/*' \
       --ignore-panics --ignore-tests \
       --out Html --out Json \
-      --all-features
+      --all-features \
+      --engine llvm


### PR DESCRIPTION
This is a workaround for https://github.com/xd009642/tarpaulin/issues/1388

The issue was fixed upstream but not released yet, which makes our pipelines to fail.

This also adds the --engine llvm to try to solve the eventual timeout that happens on our tests.