### PR TITLE
Bump configuration version and fix enable_iak_idevid

### DIFF
--- a/keylime-agent.conf
+++ b/keylime-agent.conf
@@ -11,7 +11,7 @@
 # The configuration file version
 #
 # To override, set KEYLIME_AGENT_VERSION environment variable.
-version = "2.0"
+version = "2.1"
 
 # The agent's UUID.
 # If you set this to "generate", Keylime will create a random UUID.

--- a/keylime-agent/src/config.rs
+++ b/keylime-agent/src/config.rs
@@ -298,11 +298,8 @@ impl EnvConfig {
         if let Some(ref v) = self.ek_handle {
             _ = agent.insert("ek_handle".to_string(), v.to_string().into());
         }
-        if let Some(ref v) = self.enable_iak_idevid {
-            _ = agent.insert(
-                "enable_iak_idevid".to_string(),
-                v.to_string().into(),
-            );
+        if let Some(v) = self.enable_iak_idevid {
+            _ = agent.insert("enable_iak_idevid".to_string(), v.into());
         }
         if let Some(ref v) = self.iak_idevid_asymmetric_alg {
             _ = agent.insert(


### PR DESCRIPTION
The configuration version should've been bumped with the addition of the IDevID/IAK options, following the templates added for the configuration.

This also fixes the enable_iak_idevid processing as the option is a boolean which can be copied.