### PR TITLE
Make use of workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,46 @@
 [workspace]
+members = [
+    "keylime",
+    "keylime-agent",
+    "keylime-ima-emulator",
+]
+resolver = "2"
 
-members = ["keylime", "keylime-agent", "keylime-ima-emulator"]
+[workspace.package]
+authors = ["Keylime Authors"]
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/keylime/rust-keylime"
+version = "0.2.3"
+
+[workspace.dependencies]
+actix-rt = "2"
+actix-web =  { version = "4", default-features = false, features = ["macros", "openssl"] }
+base64 = "0.21"
+cfg-if = "1"
+clap = { version = "4.3", features = ["derive"] }
+compress-tools = "0.12"
+config = { version = "0.13", default-features = false, features = ["toml"] }
+futures = "0.3.6"
+glob = "0.3"
+hex = "0.4"
+keylime = { version = "=0.2.3", path = "keylime" }
+libc = "0.2.43"
+log = "0.4"
+openssl = "0.10.15"
+pest = "2.6"
+pest_derive = "2.6"
+picky-asn1-der = "0.3.1"
+picky-asn1-x509 = "0.6.1"
+pretty_env_logger = "0.4"
+reqwest = {version = "0.11", default-features = false, features = ["json"]}
+serde = "1.0.80"
+serde_derive = "1.0.80"
+serde_json = { version = "1.0", features = ["raw_value"] }
+signal-hook = "0.3"
+static_assertions = "1"
+tempfile = "3.4.0"
+thiserror = "1.0"
+tokio = {version = "1.24", features = ["rt", "sync", "macros"]}
+tss-esapi = {version = "7.2.0", features = ["generate-bindings"]}
+uuid = {version = "1.3", features = ["v4"]}

--- a/keylime-agent/Cargo.toml
+++ b/keylime-agent/Cargo.toml
@@ -1,39 +1,39 @@
 [package]
-authors = ["Keylime Authors"]
-edition = "2021"
 name = "keylime_agent"
-version = "0.2.3"
-license = "Apache-2.0"
 description = "Rust agent for Keylime"
-repository = "https://github.com/keylime/rust-keylime"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
-actix-web =  { version = "4", default-features = false, features = ["macros", "openssl"] }
-base64 = "0.21"
-cfg-if = "1"
-clap = { version = "4.3", features = ["derive"] }
-compress-tools = "0.12"
-config = { version = "0.13", default-features = false, features = ["toml"] }
-futures = "0.3.6"
-glob = "0.3"
-hex = "0.4"
-keylime = { path = "../keylime" }
-libc = "0.2.43"
-log = "0.4"
-openssl = "0.10.15"
-picky-asn1-der = "0.3.1"
-picky-asn1-x509 = "0.6.1"
-pretty_env_logger = "0.4"
-reqwest = {version = "0.11", default-features = false, features = ["json"]}
-serde = "1.0.80"
-serde_derive = "1.0.80"
-serde_json = { version = "1.0", features = ["raw_value"] }
-static_assertions = "1"
-tempfile = "3.4.0"
-tokio = {version = "1.24", features = ["rt", "sync", "macros"]}
-tss-esapi = {version = "7.2.0", features = ["generate-bindings"]}
-thiserror = "1.0"
-uuid = {version = "1.3", features = ["v4"]}
+actix-web.workspace = true
+base64.workspace = true
+cfg-if.workspace = true
+clap.workspace = true
+compress-tools.workspace = true
+config.workspace = true
+futures.workspace = true
+glob.workspace = true
+hex.workspace = true
+keylime.workspace = true
+libc.workspace = true
+log.workspace = true
+openssl.workspace = true
+picky-asn1-der.workspace = true
+picky-asn1-x509.workspace = true
+pretty_env_logger.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+static_assertions.workspace = true
+tempfile.workspace = true
+tokio.workspace = true
+tss-esapi.workspace = true
+thiserror.workspace = true
+uuid.workspace = true
 zmq = {version = "0.9.2", optional = true}
 # wiremock was moved to be a regular dependency because optional
 # dev-dependencies are not supported
@@ -41,7 +41,7 @@ zmq = {version = "0.9.2", optional = true}
 wiremock = {version = "0.5", optional = true}
 
 [dev-dependencies]
-actix-rt = "2"
+actix-rt.workspace = true
 
 [features]
 # The features enabled by default

--- a/keylime-ima-emulator/Cargo.toml
+++ b/keylime-ima-emulator/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
 name = "keylime_ima_emulator"
-version = "0.2.3"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "IMA emulator for Keylime"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
-clap = { version = "4.3", features = ["derive"] }
-hex = "0.4"
-keylime = { path = "../keylime" }
-log = "0.4"
-openssl = "0.10.15"
-signal-hook = "0.3"
-thiserror = "1.0"
-tss-esapi = {version = "7.2.0", features = ["generate-bindings"]}
+clap.workspace = true
+hex.workspace = true
+keylime.workspace = true
+log.workspace = true
+openssl.workspace = true
+signal-hook.workspace = true
+thiserror.workspace = true
+tss-esapi.workspace = true

--- a/keylime/Cargo.toml
+++ b/keylime/Cargo.toml
@@ -1,22 +1,24 @@
 [package]
 name = "keylime"
-version = "0.2.3"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "Shared utilities for Keylime crates"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
-base64 = "0.21"
-hex = "0.4"
-log = "0.4"
-openssl = "0.10.15"
-pest = "2.6"
-pest_derive = "2.6"
-serde = "1.0.80"
-serde_derive = "1.0.80"
-static_assertions = "1"
-thiserror = "1.0"
-tss-esapi = {version = "7.2.0", features = ["generate-bindings"]}
+base64.workspace = true
+hex.workspace = true
+log.workspace = true
+openssl.workspace = true
+pest.workspace = true
+pest_derive.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+static_assertions.workspace = true
+thiserror.workspace = true
+tss-esapi.workspace = true
 
 [dev-dependencies]
-tempfile = "3.0.4"
+tempfile.workspace = true


### PR DESCRIPTION
This allows us to define several crate dependencies in a single place: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table