### PR TITLE
packit: Bump Fedora version used for code coverage

### DIFF
--- a/.github/workflows/submit-HEAD-coverage.yaml
+++ b/.github/workflows/submit-HEAD-coverage.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Install testing-farm script
       run: pip3 -v install tft-cli
     - name: Run tests on Testing Farm
-      run: testing-farm request --context distro=fedora-37 --arch x86_64 --compose Fedora-37 --plan '/e2e' -e UPLOAD_COVERAGE=1 2>&1 | tee tt_output
+      run: testing-farm request --context distro=fedora-39 --arch x86_64 --compose Fedora-39 --plan '/e2e' -e UPLOAD_COVERAGE=1 2>&1 | tee tt_output
       env:
         TESTING_FARM_API_TOKEN: ${{ secrets.TESTING_FARM_API_TOKEN }}
     - name: Find PR Packit tests to finish and download e2e_coverage.txt and upstream_coverage.xml coverage files.

--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -75,8 +75,8 @@
       - how: shell
         script:
          - yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-     # disable code coverage measurement everywhere except F37 and CS9
-   - when: distro != fedora-37
+     # disable code coverage measurement everywhere except F39 and CS9
+   - when: distro != fedora-39
      environment+:
         KEYLIME_RUST_CODE_COVERAGE: 0
      discover+:

--- a/scripts/download_packit_coverage.sh
+++ b/scripts/download_packit_coverage.sh
@@ -34,8 +34,8 @@ PROJECT="keylime/rust-keylime"
 
 # TF_JOB_DESC points to a Testing farm job that does code coverage measurement and 
 # uploads coverage XML files to a web drive
-# currently we are doing that in a job running tests on Fedora-37
-TF_JOB_DESC="testing-farm:fedora-37-x86_64"
+# currently we are doing that in a job running tests on Fedora-39
+TF_JOB_DESC="testing-farm:fedora-39-x86_64"
 TF_TEST_OUTPUT="/setup/generate_upstream_rust_keylime_code_coverage.*/output.txt"
 TF_ARTIFACTS_URL_PREFIX="https://artifacts.dev.testing-farm.io"
 


### PR DESCRIPTION
Fedora 37 is EOL, use Fedora 39 instead