### PR TITLE
cargo: Bump tss-esapi to version 7.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,31 +341,32 @@ checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bindgen"
-version = "0.63.0"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
  "lazycell",
  "log",
  "peeking_take_while",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.100",
+ "syn 2.0.48",
  "which",
 ]
 
 [[package]]
 name = "bitfield"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
 name = "bitflags"
@@ -1153,7 +1154,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "picky-asn1-der 0.3.1",
+ "picky-asn1-der",
  "picky-asn1-x509",
  "pretty_env_logger",
  "reqwest",
@@ -1328,13 +1329,13 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.100",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1517,20 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1"
-version = "0.3.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889bbb26c80acf919e89980dfc8e04eb19df272d8a9893ec9b748d3a1675abde"
-dependencies = [
- "oid",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "picky-asn1"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1088a7f82ee21e534da0f62b074b559d2a0717b0d5104ba7a47c1f5bc6c83f69"
+checksum = "295eea0f33c16be21e2a98b908fdd4d73c04dd48c8480991b76dbcf0cb58b212"
 dependencies = [
  "oid",
  "serde",
@@ -1539,36 +1529,25 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-der"
-version = "0.2.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbbd5390ab967396cc7473e6e0848684aec7166e657c6088604e07b54a73dbe"
+checksum = "5df7873a9e36d42dadb393bea5e211fe83d793c172afad5fb4ec846ec582793f"
 dependencies = [
- "picky-asn1 0.3.3",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "picky-asn1-der"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de76bf631e2f2064f78d7f1ea8a57cb0445d83138cd5fac67274d50b0f6053c2"
-dependencies = [
- "picky-asn1 0.5.0",
+ "picky-asn1",
  "serde",
  "serde_bytes",
 ]
 
 [[package]]
 name = "picky-asn1-x509"
-version = "0.6.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3033675030de806aba1d5470949701b7c9f1dbf77e3bb17bd12e5f945e560ba"
+checksum = "2c5f20f71a68499ff32310f418a6fad8816eac1a2859ed3f0c5c741389dd6208"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.4",
  "oid",
- "picky-asn1 0.3.3",
- "picky-asn1-der 0.2.5",
+ "picky-asn1",
+ "picky-asn1-der",
  "serde",
 ]
 
@@ -1604,6 +1583,16 @@ checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
  "env_logger",
  "log",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1922,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.7"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
 dependencies = [
  "serde",
 ]
@@ -2314,9 +2303,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tss-esapi"
-version = "7.2.0"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891582e26e83f2cbd608b18cbd7ffb921482740524187a2bca20cf44a286547b"
+checksum = "de234df360c349f78ecd33f0816ab3842db635732212b5cfad67f2638336864e"
 dependencies = [
  "bitfield",
  "enumflags2",
@@ -2326,7 +2315,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "oid",
- "picky-asn1 0.3.3",
+ "picky-asn1",
  "picky-asn1-x509",
  "regex",
  "serde",
@@ -2336,9 +2325,9 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi-sys"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b8be553262e0924410fe96404830252477f175f228081f21cb0bd87f2ccebe"
+checksum = "535cd192581c2ec4d5f82e670b1d3fbba6a23ccce8c85de387642051d7cad5b5"
 dependencies = [
  "bindgen",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ log = "0.4"
 openssl = "0.10.15"
 pest = "2.6"
 pest_derive = "2.6"
-picky-asn1-der = "0.3.1"
-picky-asn1-x509 = "0.6.1"
+picky-asn1-der = "0.4"
+picky-asn1-x509 = "0.12"
 pretty_env_logger = "0.4"
 reqwest = {version = "0.11", default-features = false, features = ["json"]}
 serde = "1.0.80"
@@ -42,5 +42,5 @@ static_assertions = "1"
 tempfile = "3.4.0"
 thiserror = "1.0"
 tokio = {version = "1.24", features = ["rt", "sync", "macros"]}
-tss-esapi = {version = "7.2.0", features = ["generate-bindings"]}
+tss-esapi = {version = "7.4.0", features = ["generate-bindings"]}
 uuid = {version = "1.3", features = ["v4"]}


### PR DESCRIPTION
This also bumps `picky-asn1-x509` to version `0.12.0` and `picky-asn1-der` to version `0.4.1`.

This update is important to allow the implementation of the support for ECC EK, which is currently not supported by the agent.