### PR TITLE
tpm: Overhaul errors

### DIFF
--- a/keylime/src/tpm.rs
+++ b/keylime/src/tpm.rs
@@ -114,10 +114,7 @@ pub fn get_idevid_template(
     template_str: &str,
     asym_alg_str: &str,
     name_alg_str: &str,
-) -> std::result::Result<
-    (AsymmetricAlgorithm, HashingAlgorithm),
-    AlgorithmError,
-> {
+) -> Result<(AsymmetricAlgorithm, HashingAlgorithm)> {
     let template_str = if ["", "detect", "default"].contains(&template_str) {
         detect_str
     } else {
@@ -147,6 +144,8 @@ pub enum TpmError {
         kind: Option<Tss2ResponseCodeKind>,
         message: String,
     },
+    #[error("AlgorithmError: {0}")]
+    AlgorithmError(#[from] AlgorithmError),
     #[error("Infallible: {0}")]
     Infallible(#[from] std::convert::Infallible),
     #[error("IO error: {0}")]


### PR DESCRIPTION
Add granular error types for every possible error raised by the `tpm` module. This improves diagnosing the cause of the errors without showing complex errors coming from underlying libraries.
    
This also drops all `expect()` and `unwrap()` uses to avoid panicking.

Fixes: #330, #639  
