### PR TITLE
workflows: Update checkout action to version 4

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     name: Static code checks
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check formatting
       run: cargo fmt --all -- --check
     - name: Check for panics
@@ -25,7 +25,7 @@ jobs:
     name: Fedora tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run tests
       run: docker run --security-opt seccomp=tests/seccomp-profile.json -v $(pwd):/tmp/code_under_test -w /tmp/code_under_test quay.io/keylime/keylime-ci:latest dbus-run-session -- /tmp/code_under_test/tests/run.sh
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/submit-HEAD-coverage.yaml
+++ b/.github/workflows/submit-HEAD-coverage.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: Submit code coverage from merged PR
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install testing-farm script
       run: pip3 -v install tft-cli
     - name: Run tests on Testing Farm

--- a/.github/workflows/submit-PR-coverage.yaml
+++ b/.github/workflows/submit-PR-coverage.yaml
@@ -11,7 +11,7 @@ jobs:
       run:
         working-directory: scripts
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Wait for Packit tests to finish and download e2e_coverage.txt and upstream_coverage.xml files.
       run: ./download_packit_coverage.sh
       env:


### PR DESCRIPTION
This avoids warnings about deprecated node version on check runs