### PR TITLE
cargo: Replace compress-tools with zip crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +403,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,18 +509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "compress-tools"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2022acb201ed5fd3dca0a33a5a5d101305ce18239b97e7ddc1995e1caab77e"
-dependencies = [
- "derive_more",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +561,21 @@ checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crypto-common"
@@ -704,6 +719,16 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1141,7 +1166,6 @@ dependencies = [
  "base64 0.21.7",
  "cfg-if",
  "clap",
- "compress-tools",
  "config",
  "futures",
  "glob",
@@ -1164,6 +1188,7 @@ dependencies = [
  "tss-esapi",
  "uuid",
  "wiremock",
+ "zip",
  "zmq",
 ]
 
@@ -1300,6 +1325,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -2814,6 +2848,18 @@ dependencies = [
  "quote",
  "syn 1.0.100",
  "synstructure",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ actix-web =  { version = "4", default-features = false, features = ["macros", "o
 base64 = "0.21"
 cfg-if = "1"
 clap = { version = "4.3", features = ["derive"] }
-compress-tools = "0.12"
 config = { version = "0.13", default-features = false, features = ["toml"] }
 futures = "0.3.6"
 glob = "0.3"
@@ -44,3 +43,4 @@ thiserror = "1.0"
 tokio = {version = "1.24", features = ["rt", "sync", "macros"]}
 tss-esapi = {version = "7.4.0", features = ["generate-bindings"]}
 uuid = {version = "1.3", features = ["v4"]}
+zip = {version = "0.6", default-features = false, features= ["deflate"]}

--- a/README.md
+++ b/README.md
@@ -33,19 +33,17 @@ replaces the Python implementation.
 The following packages are required for building:
 
 * `clang`
-* `libarchive-devel`
 * `openssl-devel`
 * `tpm2-tss-devel`
 * (optional for the `with-zmq` feature): `zeromq-devel`
 
 To install, use the following command:
 ```
-$ dnf install clang libarchive-devel openssl-devel tpm2-tss-devel zeromq-devel
+$ dnf install clang openssl-devel tpm2-tss-devel zeromq-devel
 ```
 
 For runtime, the following packages are required:
 
-* `libarchive`
 * `openssl`
 * `tpm2-tss`
 * `systemd` (to run as systemd service)
@@ -56,7 +54,6 @@ For runtime, the following packages are required:
 
 For Debian and Ubuntu, use the following packages are required:
 
-* `libarchive-dev`
 * `libclang-dev`
 * `libssl-dev`
 * `libtss2-dev`
@@ -66,13 +63,12 @@ For Debian and Ubuntu, use the following packages are required:
 To install, use the following command:
 
 ```
-$ apt-get install libarchive-dev libclang-dev libssl-dev libtss2-dev libzmq3-dev pkg-config
+$ apt-get install libclang-dev libssl-dev libtss2-dev libzmq3-dev pkg-config
 ```
 
 For runtime, the following packages are required:
 
 * `coreutils` (for the `mount` command)
-* `libarchive`
 * `libssl`
 * `libtss2-esys-3.0.2-0`
 * (optional for the `with-zmq` feature): `libzmq3`

--- a/docker/fedora/keylime_rust.Dockerfile
+++ b/docker/fedora/keylime_rust.Dockerfile
@@ -35,7 +35,6 @@ glib2-static \
 gnulib \
 kmod \
 llvm llvm-devel \
-libarchive-devel \
 libselinux-python3 \
 libtool \
 libtpms \

--- a/docker/release/Dockerfile.distroless
+++ b/docker/release/Dockerfile.distroless
@@ -20,24 +20,6 @@ RUN ./configure \
 RUN make
 RUN make install
 
-# Install libarchive (dependency for the compress-tools crate) - we need only a minimum feature set here
-WORKDIR /src
-RUN wget https://github.com/libarchive/libarchive/releases/download/v3.6.2/libarchive-3.6.2.tar.gz
-RUN tar xf libarchive-3.6.2.tar.gz
-WORKDIR /src/libarchive-3.6.2
-RUN ./configure \
-    --prefix=/usr \
-    --with-openssl \
-    --without-mbedtls \
-    --without-nettle \
-    --without-xml2 \
-    --without-expat \
-    --disable-static
-RUN make
-RUN make install
-# there is a bug in the libarchive.pc file which wrongly adds iconv
-RUN sed -i "s/iconv //" /usr/lib/pkgconfig/libarchive.pc
-
 # build rust-keylime
 COPY . /src/rust-keylime/
 WORKDIR /src/rust-keylime
@@ -65,11 +47,8 @@ LABEL org.opencontainers.image.vendor="The Keylime Authors"
 # NOTE: the cc base image comes with all C runtime dependencies (libc, libm, libgcc, etc.), so no need to copy those
 # TODO: Unfortunately the COPY directive is following links and not preserving the link file. This slightly bloats the image.
 
-# libarchive is a direct dependency for the compress-tools crate, so we must copy itself and all its dependencies
+# libz is a direct dependency for the zip crate
 COPY --from=builder \
-    /usr/lib/libarchive.so* \
-    /lib/x86_64-linux-gnu/liblzma.so* \
-    /lib/x86_64-linux-gnu/libbz2.so* \
     /lib/x86_64-linux-gnu/libz.so* \
     /usr/lib/x86_64-linux-gnu/
 # tpm2-tss libraries are a dependency (probably not all of them, but we just copy all)
@@ -94,9 +73,6 @@ EXPOSE 9002/tcp
 LABEL install="podman volume create keylime-agent"
 LABEL uninstall="podman volume rm keylime-agent"
 LABEL run="podman run --read-only --name keylime-agent --rm --device /dev/tpm0 --device /dev/tpmrm0 -v keylime-agent:/var/lib/keylime -v /etc/keylime:/etc/keylime:ro --tmpfs /var/lib/keylime/secure:rw,size=1m,mode=0700 -dt IMAGE"
-
-# Create a system user 'keylime' to allow dropping privileges
-RUN useradd -s /sbin/nologin -r -G tss keylime
 
 # run as root by default
 USER 0:0

--- a/docker/release/Dockerfile.fedora
+++ b/docker/release/Dockerfile.fedora
@@ -9,7 +9,6 @@ RUN microdnf install -y \
     clang-devel \
     dnf-plugins-core \
     git \
-    libarchive-devel \
     make \
     openssl-devel \
     rust \
@@ -43,7 +42,7 @@ LABEL vendor="The Keylime Authors"
 # Install all agent runtime dependencies from the builder image
 # NOTE: the fedora base image is "fat" and comes with basically all dependencies that we need out of the box with a few exceptions
 RUN microdnf makecache && \
-    microdnf -y install tpm2-tss libarchive openssl util-linux-core && \
+    microdnf -y install tpm2-tss openssl util-linux-core && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/*
 

--- a/docker/release/Dockerfile.wolfi
+++ b/docker/release/Dockerfile.wolfi
@@ -13,7 +13,7 @@ RUN apk update
 RUN apk add --no-cache --update-cache \
     rust \
     make pkgconf gcc glibc glibc-dev openssl openssl-dev posix-libc-utils \
-    clang-15 llvm15 wget
+    clang-17 clang-17-dev wget
 
 # Install tpm2-tss (dependency for the tss-esapi crate)
 WORKDIR /src

--- a/docker/release/Dockerfile.wolfi
+++ b/docker/release/Dockerfile.wolfi
@@ -10,15 +10,10 @@ RUN apk update
 # - install rust
 # - install gcc and others to compile tpm2-tss
 # - we are using the "generate-bindings" feature for the tss-esapi crate which requires clang/llvm
-# - Install libarchive (dependency for the compress-tools crate)
 RUN apk add --no-cache --update-cache \
     rust \
     make pkgconf gcc glibc glibc-dev openssl openssl-dev posix-libc-utils \
-    clang-15 llvm15 \
-    libarchive libarchive-dev
-
-# there is a bug in the libarchive.pc file which wrongly adds iconv
-RUN sed -i "s/iconv //" /usr/lib/pkgconfig/libarchive.pc
+    clang-15 llvm15 wget
 
 # Install tpm2-tss (dependency for the tss-esapi crate)
 WORKDIR /src
@@ -69,19 +64,10 @@ COPY --from=builder \
     /usr/lib/libssl.so* \
     /usr/lib/
 
-# libarchive is a direct dependency for the compress-tools crate, so we must copy itself and all its dependencies
+# libz is a direct dependency for the zip crate
 COPY --from=builder \
-    /lib/libacl.so* \
-    /lib/libattr.so* \
     /lib/libz.so* \
     /lib/
-COPY --from=builder \
-    /usr/lib/libarchive.so* \
-    /usr/lib/libexpat.so* \
-    /usr/lib/liblzma.so* \
-    /usr/lib/libzstd.so* \
-    /usr/lib/libbz2.so* \
-    /usr/lib/
 
 # tpm2-tss libraries are a dependency (probably not all of them, but we just copy all)
 # because we are using the tss-esapi crate which is essentially just a wrapper around those (unfortunately)
@@ -105,9 +91,6 @@ EXPOSE 9002/tcp
 LABEL install="podman volume create keylime-agent"
 LABEL uninstall="podman volume rm keylime-agent"
 LABEL run="podman run --read-only --name keylime-agent --rm --device /dev/tpm0 --device /dev/tpmrm0 -v keylime-agent:/var/lib/keylime -v /etc/keylime:/etc/keylime:ro --tmpfs /var/lib/keylime/secure:rw,size=1m,mode=0700 -dt IMAGE"
-
-# Create a system user 'keylime' to allow dropping privileges
-RUN useradd -s /sbin/nologin -r -G tss keylime
 
 # run as root by default
 USER 0:0

--- a/keylime-agent/Cargo.toml
+++ b/keylime-agent/Cargo.toml
@@ -12,7 +12,6 @@ actix-web.workspace = true
 base64.workspace = true
 cfg-if.workspace = true
 clap.workspace = true
-compress-tools.workspace = true
 config.workspace = true
 futures.workspace = true
 glob.workspace = true
@@ -34,6 +33,7 @@ tokio.workspace = true
 tss-esapi.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
+zip.workspace = true
 zmq = {version = "0.9.2", optional = true}
 # wiremock was moved to be a regular dependency because optional
 # dev-dependencies are not supported

--- a/keylime-agent/src/error.rs
+++ b/keylime-agent/src/error.rs
@@ -25,8 +25,6 @@ pub(crate) enum Error {
     Config(#[from] config::ConfigError),
     #[error("Infallible: {0}")]
     Infallible(#[from] std::convert::Infallible),
-    #[error("Compress tools error: {0}")]
-    CompressTools(#[from] compress_tools::Error),
     #[error("Conversion error: {0}")]
     Conversion(String),
     #[error("Configuration error: {0}")]
@@ -91,6 +89,8 @@ pub(crate) enum Error {
     Receiver(String),
     #[error("List parser error: {0}")]
     ListParser(#[from] keylime::list_parser::Error),
+    #[error("Zip error: {0}")]
+    Zip(#[from] zip::result::ZipError),
     #[error("{0}")]
     Other(String),
 }

--- a/keylime-agent/src/payloads.rs
+++ b/keylime-agent/src/payloads.rs
@@ -11,7 +11,6 @@ use crate::{
 #[cfg(feature = "with-zmq")]
 use crate::revocation::ZmqMessage;
 
-use compress_tools::*;
 use log::*;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -25,6 +24,7 @@ use std::{
     sync::{Arc, Condvar, Mutex},
 };
 use tokio::sync::mpsc::{Receiver, Sender};
+use zip::ZipArchive;
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub(crate) struct Payload {
@@ -177,7 +177,8 @@ fn optional_unzip_payload(
                 info!("Unzipping payload {} to {:?}", dec_file, unzipped);
 
                 let mut source = fs::File::open(zipped_payload_path)?;
-                uncompress_archive(&mut source, unzipped, Ownership::Ignore)?;
+                let mut zip = ZipArchive::new(source)?;
+                zip.extract(unzipped)?;
             }
         }
     }

--- a/rpm/centos/keylime-agent-rust.spec
+++ b/rpm/centos/keylime-agent-rust.spec
@@ -59,7 +59,6 @@ Requires: keylime-base
 
 BuildRequires:  systemd
 BuildRequires:  openssl-devel
-BuildRequires:  libarchive-devel
 BuildRequires:  tpm2-tss-devel
 BuildRequires:  clang
 BuildRequires:  rust-toolset

--- a/rpm/fedora/keylime-agent-rust.spec
+++ b/rpm/fedora/keylime-agent-rust.spec
@@ -68,7 +68,6 @@ Requires: keylime-base
 
 BuildRequires:  systemd
 BuildRequires:  openssl-devel
-BuildRequires:  libarchive-devel
 BuildRequires:  tpm2-tss-devel
 BuildRequires:  clang
 BuildRequires:  rust-packaging >= 21-2

--- a/rpm/fedora/rust-keylime-metadata.patch
+++ b/rpm/fedora/rust-keylime-metadata.patch
@@ -1,28 +1,6 @@
-diff --git a/keylime-agent/Cargo.toml b/keylime-agent/Cargo.toml
-index 0cc1385..286e807 100644
---- a/keylime-agent/Cargo.toml
-+++ b/keylime-agent/Cargo.toml
-@@ -21,8 +21,8 @@ keylime = { path = "../keylime" }
- libc = "0.2.43"
- log = "0.4"
- openssl = "0.10.15"
--picky-asn1-der = "0.3.1"
--picky-asn1-x509 = "0.6.1"
-+picky-asn1-der = "0.3"
-+picky-asn1-x509 = "0.7"
- pretty_env_logger = "0.4"
- reqwest = {version = "0.11", default-features = false, features = ["json"]}
- serde = "1.0.80"
-@@ -31,7 +31,7 @@ serde_json = { version = "1.0", features = ["raw_value"] }
- static_assertions = "1"
- tempfile = "3.4.0"
- tokio = {version = "1.24", features = ["rt", "sync"]}
--tss-esapi = {version = "7.2.0", features = ["generate-bindings"]}
-+tss-esapi = {version = "7", features = ["generate-bindings"]}
- thiserror = "1.0"
- uuid = {version = "1.3", features = ["v4"]}
- zmq = {version = "0.9.2", optional = true}
-@@ -48,18 +48,6 @@ actix-rt = "2"
+--- a/keylime-agent/Cargo.toml	2024-01-31 10:25:42.291841679 +0100
++++ b/keylime-agent/Cargo.toml	2024-01-31 10:28:02.795282892 +0100
+@@ -48,18 +48,6 @@
  default = []
  # this should change to dev-dependencies when we have integration testing
  testing = ["wiremock"]


### PR DESCRIPTION
Replace `compress-tools` with `zip` crate
Remove mentions of `libarchive` dependency from `README`, as well as from rpm spec files and dockerfiles
Remove keylime user creation from non-fedora based dockerfiles.
Add wget installation to `wolfi` based image.

Fixes #733 
Fixes #671