### PR TITLE
typo fix for default path to measured boot log file

### DIFF
--- a/keylime-agent.conf
+++ b/keylime-agent.conf
@@ -309,7 +309,7 @@ ima_ml_path = "default"
 # Path from where the agent will read the measured boot event log.
 #
 # If set as "default", Keylime will use the default path:
-# The default path is /sys/kernel/security/tpm0/binary_boot_measurements
+# The default path is /sys/kernel/security/tpm0/binary_bios_measurements
 # If set as a relative path, it will be considered from the root path "/".
 # If set as an absolute path, it will use it without changes
 measuredboot_ml_path = "default"

--- a/keylime-agent/src/config.rs
+++ b/keylime-agent/src/config.rs
@@ -66,7 +66,7 @@ pub static DEFAULT_AGENT_DATA_PATH: &str = "agent_data.json";
 pub static DEFAULT_IMA_ML_PATH: &str =
     "/sys/kernel/security/ima/ascii_runtime_measurements";
 pub static DEFAULT_MEASUREDBOOT_ML_PATH: &str =
-    "/sys/kernel/security/tpm0/binary_boot_measurements";
+    "/sys/kernel/security/tpm0/binary_bios_measurements";
 pub static DEFAULT_CONFIG: &str = "/etc/keylime/agent.conf";
 pub static DEFAULT_CONFIG_SYS: &str = "/usr/etc/keylime/agent.conf";
 


### PR DESCRIPTION
This bug found during testing (of non-kubernetized keylime) by @niteeshkd. It was introduced by me in #665.
