### PR TITLE
Set X509 SAN with local DNSname/IP/IPv6

### DIFF
--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -586,10 +586,16 @@ async fn main() -> Result<()> {
     let mtls_cert;
     let ssl_context;
     if config.agent.enable_agent_mtls {
+        let contact_ips = vec![config.agent.contact_ip.clone()];
         cert = match config.agent.server_cert.as_ref() {
             "" => {
                 debug!("The server_cert option was not set in the configuration file");
-                crypto::generate_x509(&nk_priv, &agent_uuid)?
+
+                crypto::generate_x509(
+                    &nk_priv,
+                    &agent_uuid,
+                    Some(contact_ips),
+                )?
             }
             path => {
                 let cert_path = Path::new(&path);
@@ -601,7 +607,11 @@ async fn main() -> Result<()> {
                     crypto::load_x509_pem(cert_path)?
                 } else {
                     debug!("Generating new mTLS certificate");
-                    let cert = crypto::generate_x509(&nk_priv, &agent_uuid)?;
+                    let cert = crypto::generate_x509(
+                        &nk_priv,
+                        &agent_uuid,
+                        Some(contact_ips),
+                    )?;
                     // Write the generated certificate
                     crypto::write_x509(&cert, cert_path)?;
                     cert

--- a/keylime-agent/src/registrar_agent.rs
+++ b/keylime-agent/src/registrar_agent.rs
@@ -233,7 +233,12 @@ mod tests {
 
         let mock_data = [0u8; 1];
         let priv_key = crypto::testing::rsa_generate(2048).unwrap(); //#[allow_ci]
-        let cert = crypto::generate_x509(&priv_key, "uuid").unwrap(); //#[allow_ci]
+        let cert = crypto::generate_x509(
+            &priv_key,
+            "uuid",
+            Some(vec!["1.2.3.4".to_string()]),
+        )
+        .unwrap(); //#[allow_ci]
         let response = do_register_agent(
             ip,
             port,
@@ -248,7 +253,7 @@ mod tests {
             None,
             None,
             Some(&cert),
-            "",
+            "1.2.3.4",
             0,
         )
         .await;
@@ -281,7 +286,12 @@ mod tests {
 
         let mock_data = [0u8; 1];
         let priv_key = crypto::testing::rsa_generate(2048).unwrap(); //#[allow_ci]
-        let cert = crypto::generate_x509(&priv_key, "uuid").unwrap(); //#[allow_ci]
+        let cert = crypto::generate_x509(
+            &priv_key,
+            "uuid",
+            Some(vec!["1.2.3.4".to_string(), "1.2.3.5".to_string()]),
+        )
+        .unwrap(); //#[allow_ci]
         let response = do_register_agent(
             ip,
             port,
@@ -325,7 +335,7 @@ mod tests {
 
         let mock_data = [0u8; 1];
         let priv_key = crypto::testing::rsa_generate(2048).unwrap(); //#[allow_ci]
-        let cert = crypto::generate_x509(&priv_key, "uuid").unwrap(); //#[allow_ci]
+        let cert = crypto::generate_x509(&priv_key, "uuid", None).unwrap(); //#[allow_ci]
         let response = do_register_agent(
             ip,
             port,


### PR DESCRIPTION
Set X509 Subject Alternative Name with local  DNS names (localhost, localhost.domain) and  local IPs (127.0.0.1, ::1). It will also include the contact IP stored in configuration

Resolves: #327