### PR TITLE
cargo: Add testing feature to keylime library

### DIFF
--- a/keylime/Cargo.toml
+++ b/keylime/Cargo.toml
@@ -24,3 +24,8 @@ picky-asn1-x509.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[features]
+# This feature enables tests that require a TPM and the TCTI environment
+# variable properly configured
+testing = []


### PR DESCRIPTION
This feature enables tests that require a TPM and TCTI environment variable properly configured to run.