### PR TITLE
crypto: Enable TLS 1.3

### DIFF
--- a/keylime/src/crypto.rs
+++ b/keylime/src/crypto.rs
@@ -655,7 +655,7 @@ pub fn generate_tls_context(
     key: &PKey<Private>,
     ca_certs: Vec<X509>,
 ) -> Result<SslAcceptorBuilder, CryptoError> {
-    let mut ssl_context_builder = SslAcceptor::mozilla_intermediate(
+    let mut ssl_context_builder = SslAcceptor::mozilla_intermediate_v5(
         SslMethod::tls(),
     )
     .map_err(|source| CryptoError::SSLContextBuilderError {


### PR DESCRIPTION
The agent server used the `SslAcceptor::mozilla_intermediate()` which disables TLS 1.3 and restricts the TLS 1.2 ciphers to:

```
TLSv1.2:
 ciphers:
   TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519)
   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (ecdh_x25519)
   TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (ecdh_x25519)
   TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 (dh 2048)
   TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 (dh 2048)
   TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (ecdh_x25519)
   TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 (ecdh_x25519)
   TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (ecdh_x25519)
   TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (ecdh_x25519)
   TLS_DHE_RSA_WITH_AES_128_CBC_SHA256 (dh 2048)
   TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048)
   TLS_DHE_RSA_WITH_AES_256_CBC_SHA256 (dh 2048)
   TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048)
   TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 4096)
   TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 4096)
   TLS_RSA_WITH_AES_128_CBC_SHA256 (rsa 4096)
   TLS_RSA_WITH_AES_256_CBC_SHA256 (rsa 4096)
   TLS_RSA_WITH_AES_128_CBC_SHA (rsa 4096)
   TLS_RSA_WITH_AES_256_CBC_SHA (rsa 4096)
```

With this change TLS 1.3 is enabled. The following ciphers are accepted:
```
TLSv1.2:
 ciphers:
   TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 (dh 2048)
   TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 (dh 2048)
   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1)
   TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (secp256r1)
   TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1)
TLSv1.3:
 ciphers:
   TLS_AKE_WITH_AES_128_GCM_SHA256 (ecdh_x25519)
   TLS_AKE_WITH_AES_256_GCM_SHA384 (ecdh_x25519)
   TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519)
```