### PR TITLE
Enable hex values to be used for tpm_ownerpassword

### DIFF
--- a/keylime-agent.conf
+++ b/keylime-agent.conf
@@ -263,6 +263,9 @@ idevid_cert = "default"
 # Use this option to state the existing TPM ownerpassword.
 # This option should be set only when a password is set for the Endorsement
 # Hierarchy (e.g. via "tpm2_changeauth -c e").
+# In order to use a hex value for the password, use the prefix "hex:"
+# For example if tpm2_changeauth -c e "hex:00a1b2c3e4" has run, the config option
+# would be 'tpm_ownerpassword = "hex:00a1b2c3e4"'
 # If no password was set, keep the empty string "".
 #
 # To override tpm_ownerpassword, set KEYLIME_AGENT_TPM_OWNERPASSWORD environment


### PR DESCRIPTION
This fixes [#760](https://github.com/keylime/rust-keylime/issues/760).

If a TPM has been set up with a non-string auth value, for example by running:
```tpm2_changeauth -c E "hex:0000DF0237BE41C0E0124CAAD0A619B29B8E3EE4173521656729C6F339DBC449"```
the keylime agent is not currently compatible with the TPM as there is no way provide this value.

This fixes the issue, by checking for "hex:" at the start of the tpm password and using a hex password if it is found.