### PR TITLE
Add the ability to use persistent handles for IDevID and IAK rather than regenerating, and add auth values for them

### DIFF
--- a/keylime-agent.conf
+++ b/keylime-agent.conf
@@ -227,7 +227,10 @@ tpm_signing_alg = "rsassa"
 # To override ek_handle, set KEYLIME_AGENT_EK_HANDLE environment variable.
 ek_handle = "generate"
 
-# Enable IDevID and IAK usage and set their algorithms.
+# Enable IDevID and IAK usage 
+enable_iak_idevid = true
+
+# Select IDevID and IAK templates or algorithms for regenerating the keys.
 # By default the template will be detected automatically from the certificates. This will happen if iak_idevid_template is left empty or set as "default" or "detect".
 # Choosing a template will override the name and asymmetric algorithm choices. To use these choices, set iak_idevid_template to "manual"
 # Templates are specified in the TCG document found here, section 7.3.4: 
@@ -237,12 +240,19 @@ ek_handle = "generate"
 # iak_idevid_template:        default, detect, H-1, H-2, H-3, H-4, H-5, manual
 # iak_idevid_asymmetric_alg:   rsa, ecc
 # iak_idevid_name_alg:        sha256, sm3_256, sha384, sha512
-enable_iak_idevid = false
 iak_idevid_template = "detect"
 # In order for these values to be used, set the iak_idevid_template option to manual
 iak_idevid_asymmetric_alg = "rsa"
 iak_idevid_name_alg = "sha256"
 
+# Alternatively if the keys are persisted, provide the handles for their location below, and optionally their passwords.
+# If handles are provided, they will take priority over templates/algorithms selected above.
+# To use a hex password, use the prefix "hex:" at the start of the password.
+idevid_password = ""
+idevid_handle = ""
+
+iak_password = ""
+iak_handle = ""
 
 # The name of the file containing the X509 IAK certificate.
 # If set as "default", the "iak-cert.crt" value is used

--- a/keylime-agent.conf
+++ b/keylime-agent.conf
@@ -228,7 +228,7 @@ tpm_signing_alg = "rsassa"
 ek_handle = "generate"
 
 # Enable IDevID and IAK usage 
-enable_iak_idevid = true
+enable_iak_idevid = false
 
 # Select IDevID and IAK templates or algorithms for regenerating the keys.
 # By default the template will be detected automatically from the certificates. This will happen if iak_idevid_template is left empty or set as "default" or "detect".

--- a/keylime-agent/src/config.rs
+++ b/keylime-agent/src/config.rs
@@ -341,19 +341,16 @@ impl EnvConfig {
             );
         }
         if let Some(ref v) = self.idevid_password {
-            _ = agent.insert(
-                "idevid_password".to_string(),
-                v.to_string().into(),
-            );
+            _ = agent
+                .insert("idevid_password".to_string(), v.to_string().into());
         }
         if let Some(ref v) = self.iak_password {
-            _ = agent.insert(
-                "iak_password".to_string(),
-                v.to_string().into(),
-            );
+            _ = agent
+                .insert("iak_password".to_string(), v.to_string().into());
         }
         if let Some(ref v) = self.idevid_handle {
-            _ = agent.insert("idevid_handle".to_string(), v.to_string().into());
+            _ = agent
+                .insert("idevid_handle".to_string(), v.to_string().into());
         }
         if let Some(ref v) = self.iak_handle {
             _ = agent.insert("iak_handle".to_string(), v.to_string().into());

--- a/keylime-agent/src/config.rs
+++ b/keylime-agent/src/config.rs
@@ -62,6 +62,10 @@ pub static DEFAULT_ENABLE_IAK_IDEVID: bool = false;
 pub static DEFAULT_IAK_IDEVID_ASYMMETRIC_ALG: &str = "rsa";
 pub static DEFAULT_IAK_IDEVID_NAME_ALG: &str = "sha256";
 pub static DEFAULT_IAK_IDEVID_TEMPLATE: &str = "H-1";
+pub static DEFAULT_IDEVID_PASSWORD: &str = "";
+pub static DEFAULT_IAK_PASSWORD: &str = "";
+pub static DEFAULT_IDEVID_HANDLE: &str = "";
+pub static DEFAULT_IAK_HANDLE: &str = "";
 pub static DEFAULT_RUN_AS: &str = "keylime:tss";
 pub static DEFAULT_AGENT_DATA_PATH: &str = "agent_data.json";
 pub static DEFAULT_IMA_ML_PATH: &str =
@@ -111,6 +115,10 @@ pub(crate) struct EnvConfig {
     pub iak_idevid_asymmetric_alg: Option<String>,
     pub iak_idevid_name_alg: Option<String>,
     pub iak_idevid_template: Option<String>,
+    pub idevid_password: Option<String>,
+    pub iak_password: Option<String>,
+    pub idevid_handle: Option<String>,
+    pub iak_handle: Option<String>,
     pub run_as: Option<String>,
     pub agent_data_path: Option<String>,
     pub ima_ml_path: Option<String>,
@@ -157,6 +165,10 @@ pub(crate) struct AgentConfig {
     pub iak_idevid_asymmetric_alg: String,
     pub iak_idevid_name_alg: String,
     pub iak_idevid_template: String,
+    pub idevid_password: String,
+    pub iak_password: String,
+    pub idevid_handle: String,
+    pub iak_handle: String,
     pub run_as: String,
     pub agent_data_path: String,
     pub ima_ml_path: String,
@@ -327,6 +339,24 @@ impl EnvConfig {
                 "iak_idevid_template".to_string(),
                 v.to_string().into(),
             );
+        }
+        if let Some(ref v) = self.idevid_password {
+            _ = agent.insert(
+                "idevid_password".to_string(),
+                v.to_string().into(),
+            );
+        }
+        if let Some(ref v) = self.iak_password {
+            _ = agent.insert(
+                "iak_password".to_string(),
+                v.to_string().into(),
+            );
+        }
+        if let Some(ref v) = self.idevid_handle {
+            _ = agent.insert("idevid_handle".to_string(), v.to_string().into());
+        }
+        if let Some(ref v) = self.iak_handle {
+            _ = agent.insert("iak_handle".to_string(), v.to_string().into());
         }
         if let Some(ref v) = self.run_as {
             _ = agent.insert("run_as".to_string(), v.to_string().into());
@@ -526,6 +556,22 @@ impl Source for KeylimeConfig {
             self.agent.iak_idevid_template.to_string().into(),
         );
         _ = m.insert(
+            "idevid_password".to_string(),
+            self.agent.idevid_password.to_string().into(),
+        );
+        _ = m.insert(
+            "iak_password".to_string(),
+            self.agent.iak_password.to_string().into(),
+        );
+        _ = m.insert(
+            "idevid_handle".to_string(),
+            self.agent.idevid_handle.to_string().into(),
+        );
+        _ = m.insert(
+            "iak_handle".to_string(),
+            self.agent.iak_handle.to_string().into(),
+        );
+        _ = m.insert(
             "run_as".to_string(),
             self.agent.run_as.to_string().into(),
         );
@@ -606,6 +652,10 @@ impl Default for AgentConfig {
                 .to_string(),
             iak_idevid_name_alg: DEFAULT_IAK_IDEVID_NAME_ALG.to_string(),
             iak_idevid_template: DEFAULT_IAK_IDEVID_TEMPLATE.to_string(),
+            idevid_password: DEFAULT_IDEVID_PASSWORD.to_string(),
+            iak_password: DEFAULT_IAK_PASSWORD.to_string(),
+            idevid_handle: DEFAULT_IDEVID_HANDLE.to_string(),
+            iak_handle: DEFAULT_IAK_HANDLE.to_string(),
             ima_ml_path: "default".to_string(),
             measuredboot_ml_path: "default".to_string(),
         }
@@ -1124,6 +1174,10 @@ mod tests {
             ),
             ("IAK_IDEVID_NAME_ALG", "override_iak_idevid_name_alg"),
             ("IAK_IDEVID_TEMPLATE", "override_iak_idevid_template"),
+            ("IDEVID_PASSWORD", "override_idevid_password"),
+            ("IAK_PASSWORD", "override_iak_password"),
+            ("IDEVID_HANDLE", "override_idevid_handle"),
+            ("IAK_HANDLE", "override_iak_handle"),
             ("RUN_AS", "override_run_as"),
             ("AGENT_DATA_PATH", "override_agent_data_path"),
             ("IMA_ML_PATH", "override_ima_ml_path"),


### PR DESCRIPTION
This PR adds into the config the ability to specify handles and auth values for IDevID and IAK keys. The auth values function in the same way as the TPM ownerpassword in that they can be [hex values](https://github.com/keylime/rust-keylime/pull/769).

The new config options are:
```
idevid_password = ""
idevid_handle = ""

iak_password = ""
iak_handle = ""
```