### PR TITLE
fix IAK SHA512 template to match IDevID

### DIFF
--- a/keylime/src/tpm.rs
+++ b/keylime/src/tpm.rs
@@ -918,7 +918,7 @@ impl Context {
             ),
             HashingAlgorithm::Sha512 => (
                 IAK_AUTH_POLICY_SHA512[0..64].to_vec(),
-                RsaKeyBits::Rsa2048,
+                RsaKeyBits::Rsa4096,
                 EccCurve::NistP521,
             ),
             _ => (


### PR DESCRIPTION
This is a fix to change to Rsa 4096 for the IAK sha512 template. This is already the case for the IDevID template and the two should match.