### PR TITLE
Fix leftover 'unnecessary qualification' warnings on tests

### DIFF
--- a/keylime-agent/src/errors_handler.rs
+++ b/keylime-agent/src/errors_handler.rs
@@ -266,7 +266,7 @@ pub(crate) fn wrap_404<B>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use actix_web::{middleware, test, App, Resource};
+    use actix_web::{test, App, Resource};
     use core::future::Future;
     use serde::{Deserialize, Serialize};
     use serde_json::{json, Value};
@@ -379,7 +379,7 @@ mod tests {
         let mut app = test::init_service(
             App::new()
                 .wrap(
-                    middleware::ErrorHandlers::new()
+                    ErrorHandlers::new()
                         .handler(http::StatusCode::NOT_FOUND, wrap_404),
                 )
                 .app_data(

--- a/keylime-agent/src/keys_handler.rs
+++ b/keylime-agent/src/keys_handler.rs
@@ -970,10 +970,7 @@ mod tests {
 
         // Send Shutdown message to the workers for a graceful shutdown
         keys_tx.send((KeyMessage::Shutdown, None)).await.unwrap(); //#[allow_ci]
-        payload_tx
-            .send(payloads::PayloadMessage::Shutdown)
-            .await
-            .unwrap(); //#[allow_ci]
+        payload_tx.send(PayloadMessage::Shutdown).await.unwrap(); //#[allow_ci]
         arbiter.join();
     }
 

--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -1066,7 +1066,7 @@ mod testing {
 
         /// CryptoTest error
         #[error("CryptoTestError")]
-        CryptoTestError(#[from] crate::crypto::testing::CryptoTestError),
+        CryptoTestError(#[from] crypto::testing::CryptoTestError),
 
         /// IO error
         #[error("IOError")]
@@ -1078,7 +1078,7 @@ mod testing {
 
         /// TPM error
         #[error("TPMError")]
-        TPMError(#[from] keylime::tpm::TpmError),
+        TPMError(#[from] tpm::TpmError),
 
         /// TSS esapi error
         #[error("TSSError")]


### PR DESCRIPTION
Fix leftover 'unnecessary qualification' warnings generated when running the tests (`cargo test --features=testing`) with newer rust compilers.