### PR TITLE
config: Support hostnames in registrar_ip option

### DIFF
--- a/keylime-agent/src/config.rs
+++ b/keylime-agent/src/config.rs
@@ -9,6 +9,7 @@ use config::{
 use glob::glob;
 use keylime::{
     algorithms::{EncryptionAlgorithm, HashAlgorithm, SignAlgorithm},
+    hostname_parser::parse_hostname,
     ip_parser::parse_ip,
     list_parser::parse_list,
 };
@@ -856,8 +857,12 @@ fn config_translate_keywords(
 
     let ip = parse_ip(config.agent.ip.as_ref())?.to_string();
     let contact_ip = parse_ip(config.agent.contact_ip.as_ref())?.to_string();
-    let registrar_ip =
-        parse_ip(config.agent.registrar_ip.as_ref())?.to_string();
+    let registrar_ip = match parse_ip(config.agent.registrar_ip.as_ref()) {
+        Ok(ip) => ip.to_string(),
+        Err(_) => {
+            parse_hostname(config.agent.registrar_ip.as_ref())?.to_string()
+        }
+    };
 
     // Validate the configuration
 

--- a/keylime-agent/src/error.rs
+++ b/keylime-agent/src/error.rs
@@ -47,6 +47,10 @@ pub(crate) enum Error {
     Io(#[from] std::io::Error),
     #[error("Failed to parse IP")]
     IpParserError(#[from] keylime::ip_parser::IpParsingError),
+    #[error("Failed to parse hostname")]
+    HostnameParserError(
+        #[from] keylime::hostname_parser::HostnameParsingError,
+    ),
     #[error("Text decoding error: {0}")]
     Utf8(#[from] std::string::FromUtf8Error),
     #[error("Secure Mount error: {0})")]

--- a/keylime-agent/src/registrar_agent.rs
+++ b/keylime-agent/src/registrar_agent.rs
@@ -84,12 +84,20 @@ pub(crate) async fn do_activate_agent(
 ) -> crate::error::Result<()> {
     let data = Activate { auth_tag };
 
-    // Add brackets if the address is IPv6
-    let parsed_ip = registrar_ip.parse::<IpAddr>()?;
-    let remote_ip = if parsed_ip.is_ipv6() {
-        format!("[{registrar_ip}]")
-    } else {
-        registrar_ip.to_string()
+    let remote_ip = match registrar_ip.parse::<IpAddr>() {
+        Ok(addr) => {
+            // Add brackets if the address is IPv6
+            if addr.is_ipv6() {
+                format!("[{registrar_ip}]")
+            } else {
+                registrar_ip.to_string()
+            }
+        }
+        Err(_) => {
+            // The registrar_ip option can also be a hostname. If it is the case, the hostname was
+            // already validated during configuration
+            registrar_ip.to_string()
+        }
     };
 
     #[cfg(test)]
@@ -173,12 +181,20 @@ pub(crate) async fn do_register_agent(
         port: Some(port),
     };
 
-    // Add brackets if the address is IPv6
-    let parsed_ip = registrar_ip.parse::<IpAddr>()?;
-    let remote_ip = if parsed_ip.is_ipv6() {
-        format!("[{registrar_ip}]")
-    } else {
-        registrar_ip.to_string()
+    let remote_ip = match registrar_ip.parse::<IpAddr>() {
+        Ok(addr) => {
+            // Add brackets if the address is IPv6
+            if addr.is_ipv6() {
+                format!("[{registrar_ip}]")
+            } else {
+                registrar_ip.to_string()
+            }
+        }
+        Err(_) => {
+            // The registrar_ip option can also be a hostname. If it is the case, the hostname was
+            // already validated during configuration
+            registrar_ip.to_string()
+        }
     };
 
     #[cfg(test)]

--- a/keylime/src/hostname.pest
+++ b/keylime/src/hostname.pest
@@ -1,0 +1,2 @@
+hostname = {SOI ~ label ~ ("." ~ label)* ~ EOI}
+label = { ASCII_ALPHANUMERIC+ ~ ("-"+ ~ ASCII_ALPHANUMERIC+)*}

--- a/keylime/src/hostname_parser.rs
+++ b/keylime/src/hostname_parser.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Keylime Authors
+
+use pest::Parser;
+use pest_derive::Parser;
+use thiserror::Error;
+
+#[derive(Parser)]
+#[grammar = "hostname.pest"]
+pub struct HostnameParser;
+
+#[derive(Error, Debug)]
+pub enum HostnameParsingError {
+    #[error("Invalid input {0}")]
+    InvalidInput(String),
+
+    #[error("failed to parse the input {input}")]
+    ParseError {
+        input: String,
+        source: Box<pest::error::Error<Rule>>,
+    },
+}
+
+/// Parses a hostname from a string slice following RFC-1123
+///
+/// Valid hostnames are formed by labels separated by dots ('.').
+///
+/// The labels can only contain alphanumeric characters ('a'..'z' | 'A'..'Z' | '0'..'9') and the
+/// hyphen ('-'). The labels cannot begin or end with an hyphen.
+///
+/// # Arguments
+///
+/// * `hostname` the string to be parsed
+///
+/// # Returns
+///
+/// The obtained hostname as a &str if it is a valid hostname
+///
+/// # Examples
+///
+/// Valid hostnames:
+///
+/// * `hostname`
+/// * `host-name`
+/// * `a.b.c`
+/// * `a-b.c-d.e-f`
+///
+/// Invalid hostnames:
+///
+/// * `a_b.c`
+/// * `a.b-.c`
+/// * `a.-b.c`
+pub fn parse_hostname(hostname: &str) -> Result<&str, HostnameParsingError> {
+    let Some(pair) = HostnameParser::parse(Rule::hostname, hostname)
+        .map_err(|e| HostnameParsingError::ParseError {
+            input: hostname.to_string(),
+            source: Box::new(e),
+        })?
+        .next()
+    else {
+        return Err(HostnameParsingError::InvalidInput(hostname.to_string()));
+    };
+    return Ok(pair.as_str());
+}
+
+// Unit Testing
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_hostname() {
+        // Sanity: most common case
+        assert_eq!(parse_hostname("hostname").unwrap(), "hostname"); //#[allow_ci]
+        assert_eq!(parse_hostname("ab.cd.ef").unwrap(), "ab.cd.ef"); //#[allow_ci]
+        assert_eq!(parse_hostname("ab-cd-ef").unwrap(), "ab-cd-ef"); //#[allow_ci]
+
+        // More advanced cases
+        assert_eq!(
+            parse_hostname("hostname-123.test").unwrap(), //#[allow_ci]
+            "hostname-123.test"
+        );
+        assert_eq!(parse_hostname("123-456.789").unwrap(), "123-456.789"); //#[allow_ci]
+        assert_eq!(parse_hostname("1----9").unwrap(), "1----9"); //#[allow_ci]
+
+        // Invalid input
+        assert!(parse_hostname("-host-na.me").is_err());
+        assert!(parse_hostname("host-na.me-").is_err());
+        assert!(parse_hostname(".host-na.me").is_err());
+        assert!(parse_hostname("host-na.me.").is_err());
+        assert!(parse_hostname("host_name").is_err());
+        assert!(parse_hostname("host..name").is_err());
+    }
+}

--- a/keylime/src/lib.rs
+++ b/keylime/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod algorithms;
 pub mod crypto;
+pub mod hostname_parser;
 pub mod ima;
 pub mod ip_parser;
 pub mod list_parser;


### PR DESCRIPTION
This restores previous behavior where hostnames could be used to set the 'registrar_ip' configuration option.

The configuration will try to parse the input configuration string as an IP and in case of failure, try to parse the string as a hostname.

Fixes: #794 