### PR TITLE
Make the API configuration modular

### DIFF
--- a/keylime-agent/src/api.rs
+++ b/keylime-agent/src/api.rs
@@ -1,0 +1,174 @@
+use crate::{
+    agent_handler,
+    common::{JsonWrapper, API_VERSION},
+    config, errors_handler, keys_handler, notifications_handler,
+    quotes_handler,
+};
+use actix_web::{http, web, HttpRequest, HttpResponse, Responder, Scope};
+use log::*;
+use thiserror::Error;
+
+pub const SUPPORTED_API_VERSIONS: &[&str] = &[API_VERSION];
+
+#[derive(Error, Debug, PartialEq)]
+pub enum APIError {
+    #[error("API version \"{0}\" not supported")]
+    UnsupportedVersion(String),
+}
+
+/// Handles the default case for the API version scope
+async fn api_default(req: HttpRequest) -> impl Responder {
+    let error;
+    let response;
+    let message;
+
+    match req.head().method {
+        http::Method::GET => {
+            error = 400;
+            message =
+                "Not Implemented: Use /agent, /keys, or /quotes interfaces";
+            response = HttpResponse::BadRequest()
+                .json(JsonWrapper::error(error, message));
+        }
+        http::Method::POST => {
+            error = 400;
+            message =
+                "Not Implemented: Use /keys or /notifications interfaces";
+            response = HttpResponse::BadRequest()
+                .json(JsonWrapper::error(error, message));
+        }
+        _ => {
+            error = 405;
+            message = "Method is not supported";
+            response = HttpResponse::MethodNotAllowed()
+                .insert_header(http::header::Allow(vec![
+                    http::Method::GET,
+                    http::Method::POST,
+                ]))
+                .json(JsonWrapper::error(error, message));
+        }
+    };
+
+    warn!(
+        "{} returning {} response. {}",
+        req.head().method,
+        error,
+        message
+    );
+
+    response
+}
+
+/// Configure the endpoints supported by API version 2.1
+///
+/// Version 2.1 is the base API version
+fn configure_api_v2_1(cfg: &mut web::ServiceConfig) {
+    _ = cfg
+        .service(
+            web::scope("/keys")
+                .configure(keys_handler::configure_keys_endpoints),
+        )
+        .service(web::scope("/notifications").configure(
+            notifications_handler::configure_notifications_endpoints,
+        ))
+        .service(
+            web::scope("/quotes")
+                .configure(quotes_handler::configure_quotes_endpoints),
+        )
+        .default_service(web::to(api_default))
+}
+
+/// Configure the endpoints supported by API version 2.2
+///
+/// The version 2.2 added the /agent/info endpoint
+fn configure_api_v2_2(cfg: &mut web::ServiceConfig) {
+    // Configure the endpoints shared with version 2.1
+    configure_api_v2_1(cfg);
+
+    // Configure added endpoints
+    _ = cfg.service(
+        web::scope("/agent")
+            .configure(agent_handler::configure_agent_endpoints),
+    )
+}
+
+/// Get a scope configured for the given API version
+pub(crate) fn get_api_scope(version: &str) -> Result<Scope, APIError> {
+    match version {
+        "v2.1" => Ok(web::scope(version).configure(configure_api_v2_1)),
+        "v2.2" => Ok(web::scope(version).configure(configure_api_v2_2)),
+        _ => Err(APIError::UnsupportedVersion(version.into())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{test, web, App};
+    use serde_json::{json, Value};
+
+    #[actix_rt::test]
+    async fn test_configure_api() {
+        // Test that invalid version results in error
+        let result = get_api_scope("invalid");
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert_eq!(e, APIError::UnsupportedVersion("invalid".into()));
+        }
+
+        // Test that a valid version is successful
+        let version = SUPPORTED_API_VERSIONS.last().unwrap(); //#[allow_ci]
+        let result = get_api_scope(version);
+        assert!(result.is_ok());
+        let scope = result.unwrap(); //#[allow_ci]
+    }
+
+    #[actix_rt::test]
+    async fn test_api_default() {
+        let mut app = test::init_service(
+            App::new().service(web::resource("/").to(api_default)),
+        )
+        .await;
+
+        let req = test::TestRequest::get().uri("/").to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_client_error());
+
+        let result: JsonWrapper<Value> = test::read_body_json(resp).await;
+
+        assert_eq!(result.results, json!({}));
+        assert_eq!(result.code, 400);
+
+        let req = test::TestRequest::post()
+            .uri("/")
+            .data("some data")
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_client_error());
+
+        let result: JsonWrapper<Value> = test::read_body_json(resp).await;
+
+        assert_eq!(result.results, json!({}));
+        assert_eq!(result.code, 400);
+
+        let req = test::TestRequest::delete().uri("/").to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_client_error());
+
+        let headers = resp.headers();
+
+        assert!(headers.contains_key("allow"));
+        assert_eq!(
+            headers.get("allow").unwrap().to_str().unwrap(), //#[allow_ci]
+            "GET, POST"
+        );
+
+        let result: JsonWrapper<Value> = test::read_body_json(resp).await;
+
+        assert_eq!(result.results, json!({}));
+        assert_eq!(result.code, 405);
+    }
+}

--- a/keylime-agent/src/errors_handler.rs
+++ b/keylime-agent/src/errors_handler.rs
@@ -127,39 +127,6 @@ pub(crate) async fn agent_default(req: HttpRequest) -> impl Responder {
     response
 }
 
-pub(crate) async fn notifications_default(
-    req: HttpRequest,
-) -> impl Responder {
-    let error;
-    let response;
-    let message;
-
-    match req.head().method {
-        http::Method::POST => {
-            error = 400;
-            message = "URI not supported, only /revocation is supported for POST in /notifications/ interface";
-            response = HttpResponse::BadRequest()
-                .json(JsonWrapper::error(error, message));
-        }
-        _ => {
-            error = 405;
-            message = "Method is not supported in /notifications/ interface";
-            response = HttpResponse::MethodNotAllowed()
-                .insert_header(http::header::Allow(vec![http::Method::POST]))
-                .json(JsonWrapper::error(error, message));
-        }
-    };
-
-    warn!(
-        "{} returning {} response. {}",
-        req.head().method,
-        error,
-        message
-    );
-
-    response
-}
-
 pub(crate) async fn version_not_supported(
     req: HttpRequest,
     version: web::Path<APIVersion>,
@@ -286,12 +253,6 @@ mod tests {
     #[actix_rt::test]
     async fn test_api_default() {
         test_default(web::resource("/").to(api_default), "GET, POST").await
-    }
-
-    #[actix_rt::test]
-    async fn test_notifications_default() {
-        test_default(web::resource("/").to(notifications_default), "POST")
-            .await
     }
 
     #[actix_rt::test]

--- a/keylime-agent/src/errors_handler.rs
+++ b/keylime-agent/src/errors_handler.rs
@@ -96,37 +96,6 @@ pub(crate) async fn api_default(req: HttpRequest) -> impl Responder {
     response
 }
 
-pub(crate) async fn quotes_default(req: HttpRequest) -> impl Responder {
-    let error;
-    let response;
-    let message;
-
-    match req.head().method {
-        http::Method::GET => {
-            error = 400;
-            message = "URI not supported, only /identity and /integrity are supported for GET in /quotes/ interface";
-            response = HttpResponse::BadRequest()
-                .json(JsonWrapper::error(error, message));
-        }
-        _ => {
-            error = 405;
-            message = "Method is not supported in /quotes/ interface";
-            response = HttpResponse::MethodNotAllowed()
-                .insert_header(http::header::Allow(vec![http::Method::GET]))
-                .json(JsonWrapper::error(error, message));
-        }
-    };
-
-    warn!(
-        "{} returning {} response. {}",
-        req.head().method,
-        error,
-        message
-    );
-
-    response
-}
-
 pub(crate) async fn agent_default(req: HttpRequest) -> impl Responder {
     let error;
     let response;
@@ -317,11 +286,6 @@ mod tests {
     #[actix_rt::test]
     async fn test_api_default() {
         test_default(web::resource("/").to(api_default), "GET, POST").await
-    }
-
-    #[actix_rt::test]
-    async fn test_quotes_default() {
-        test_default(web::resource("/").to(quotes_default), "GET").await
     }
 
     #[actix_rt::test]

--- a/keylime-agent/src/errors_handler.rs
+++ b/keylime-agent/src/errors_handler.rs
@@ -54,48 +54,6 @@ pub(crate) async fn app_default(req: HttpRequest) -> impl Responder {
     response
 }
 
-pub(crate) async fn api_default(req: HttpRequest) -> impl Responder {
-    let error;
-    let response;
-    let message;
-
-    match req.head().method {
-        http::Method::GET => {
-            error = 400;
-            message =
-                "Not Implemented: Use /agent, /keys, or /quotes interfaces";
-            response = HttpResponse::BadRequest()
-                .json(JsonWrapper::error(error, message));
-        }
-        http::Method::POST => {
-            error = 400;
-            message =
-                "Not Implemented: Use /keys or /notifications interfaces";
-            response = HttpResponse::BadRequest()
-                .json(JsonWrapper::error(error, message));
-        }
-        _ => {
-            error = 405;
-            message = "Method is not supported";
-            response = HttpResponse::MethodNotAllowed()
-                .insert_header(http::header::Allow(vec![
-                    http::Method::GET,
-                    http::Method::POST,
-                ]))
-                .json(JsonWrapper::error(error, message));
-        }
-    };
-
-    warn!(
-        "{} returning {} response. {}",
-        req.head().method,
-        error,
-        message
-    );
-
-    response
-}
-
 pub(crate) async fn version_not_supported(
     req: HttpRequest,
     version: web::Path<APIVersion>,
@@ -217,11 +175,6 @@ mod tests {
     #[actix_rt::test]
     async fn test_app_default() {
         test_default(web::resource("/").to(app_default), "GET, POST").await
-    }
-
-    #[actix_rt::test]
-    async fn test_api_default() {
-        test_default(web::resource("/").to(api_default), "GET, POST").await
     }
 
     #[derive(Serialize, Deserialize)]

--- a/keylime-agent/src/errors_handler.rs
+++ b/keylime-agent/src/errors_handler.rs
@@ -96,46 +96,6 @@ pub(crate) async fn api_default(req: HttpRequest) -> impl Responder {
     response
 }
 
-pub(crate) async fn keys_default(req: HttpRequest) -> impl Responder {
-    let error;
-    let response;
-    let message;
-
-    match req.head().method {
-        http::Method::GET => {
-            error = 400;
-            message = "URI not supported, only /pubkey and /verify are supported for GET in /keys interface";
-            response = HttpResponse::BadRequest()
-                .json(JsonWrapper::error(error, message));
-        }
-        http::Method::POST => {
-            error = 400;
-            message = "URI not supported, only /ukey and /vkey are supported for POST in /keys interface";
-            response = HttpResponse::BadRequest()
-                .json(JsonWrapper::error(error, message));
-        }
-        _ => {
-            error = 405;
-            message = "Method is not supported in /keys interface";
-            response = HttpResponse::MethodNotAllowed()
-                .insert_header(http::header::Allow(vec![
-                    http::Method::GET,
-                    http::Method::POST,
-                ]))
-                .json(JsonWrapper::error(error, message));
-        }
-    };
-
-    warn!(
-        "{} returning {} response. {}",
-        req.head().method,
-        error,
-        message
-    );
-
-    response
-}
-
 pub(crate) async fn quotes_default(req: HttpRequest) -> impl Responder {
     let error;
     let response;
@@ -357,11 +317,6 @@ mod tests {
     #[actix_rt::test]
     async fn test_api_default() {
         test_default(web::resource("/").to(api_default), "GET, POST").await
-    }
-
-    #[actix_rt::test]
-    async fn test_keys_default() {
-        test_default(web::resource("/").to(keys_default), "GET, POST").await
     }
 
     #[actix_rt::test]

--- a/keylime-agent/src/errors_handler.rs
+++ b/keylime-agent/src/errors_handler.rs
@@ -96,37 +96,6 @@ pub(crate) async fn api_default(req: HttpRequest) -> impl Responder {
     response
 }
 
-pub(crate) async fn agent_default(req: HttpRequest) -> impl Responder {
-    let error;
-    let response;
-    let message;
-
-    match req.head().method {
-        http::Method::GET => {
-            error = 400;
-            message = "URI not supported, only /info is supported for GET in /agent interface";
-            response = HttpResponse::BadRequest()
-                .json(JsonWrapper::error(error, message));
-        }
-        _ => {
-            error = 405;
-            message = "Method is not supported in /agent interface";
-            response = HttpResponse::MethodNotAllowed()
-                .insert_header(http::header::Allow(vec![http::Method::GET]))
-                .json(JsonWrapper::error(error, message));
-        }
-    };
-
-    warn!(
-        "{} returning {} response. {}",
-        req.head().method,
-        error,
-        message
-    );
-
-    response
-}
-
 pub(crate) async fn version_not_supported(
     req: HttpRequest,
     version: web::Path<APIVersion>,
@@ -253,11 +222,6 @@ mod tests {
     #[actix_rt::test]
     async fn test_api_default() {
         test_default(web::resource("/").to(api_default), "GET, POST").await
-    }
-
-    #[actix_rt::test]
-    async fn test_agent_default() {
-        test_default(web::resource("/").to(agent_default), "GET").await
     }
 
     #[derive(Serialize, Deserialize)]

--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -920,18 +920,9 @@ async fn main() -> Result<()> {
                                     errors_handler::notifications_default,
                                 )),
                         )
-                        .service(
-                            web::scope("/quotes")
-                                .service(web::resource("/identity").route(
-                                    web::get().to(quotes_handler::identity),
-                                ))
-                                .service(web::resource("/integrity").route(
-                                    web::get().to(quotes_handler::integrity),
-                                ))
-                                .default_service(web::to(
-                                    errors_handler::quotes_default,
-                                )),
-                        )
+                        .service(web::scope("/quotes").configure(
+                            quotes_handler::configure_quotes_endpoints,
+                        ))
                         .default_service(web::to(
                             errors_handler::api_default,
                         )),

--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -897,15 +897,9 @@ async fn main() -> Result<()> {
                 )
                 .service(
                     web::scope(&format!("/{API_VERSION}"))
-                        .service(
-                            web::scope("/agent")
-                                .service(web::resource("/info").route(
-                                    web::get().to(agent_handler::info),
-                                ))
-                                .default_service(web::to(
-                                    errors_handler::agent_default,
-                                )),
-                        )
+                        .service(web::scope("/agent").configure(
+                                agent_handler::configure_agent_endpoints,
+                        ))
                         .service(web::scope("/keys").configure(
                             keys_handler::configure_keys_endpoints,
                         ))

--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -906,24 +906,9 @@ async fn main() -> Result<()> {
                                     errors_handler::agent_default,
                                 )),
                         )
-                        .service(
-                            web::scope("/keys")
-                                .service(web::resource("/pubkey").route(
-                                    web::get().to(keys_handler::pubkey),
-                                ))
-                                .service(web::resource("/ukey").route(
-                                    web::post().to(keys_handler::u_key),
-                                ))
-                                .service(web::resource("/verify").route(
-                                    web::get().to(keys_handler::verify),
-                                ))
-                                .service(web::resource("/vkey").route(
-                                    web::post().to(keys_handler::v_key),
-                                ))
-                                .default_service(web::to(
-                                    errors_handler::keys_default,
-                                )),
-                        )
+                        .service(web::scope("/keys").configure(
+                            keys_handler::configure_keys_endpoints,
+                        ))
                         .service(
                             web::scope("/notifications")
                                 .service(web::resource("/revocation").route(

--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -910,16 +910,9 @@ async fn main() -> Result<()> {
                             keys_handler::configure_keys_endpoints,
                         ))
                         .service(
-                            web::scope("/notifications")
-                                .service(web::resource("/revocation").route(
-                                    web::post().to(
-                                        notifications_handler::revocation,
-                                    ),
-                                ))
-                                .default_service(web::to(
-                                    errors_handler::notifications_default,
-                                )),
-                        )
+                            web::scope("/notifications").configure(
+                            notifications_handler::configure_notifications_endpoints,
+                        ))
                         .service(web::scope("/quotes").configure(
                             quotes_handler::configure_quotes_endpoints,
                         ))

--- a/keylime-agent/src/notifications_handler.rs
+++ b/keylime-agent/src/notifications_handler.rs
@@ -6,13 +6,13 @@ use crate::{
     revocation::{Revocation, RevocationMessage},
     Error, QuoteData, Result,
 };
-use actix_web::{web, HttpRequest, HttpResponse, Responder};
+use actix_web::{http, web, HttpRequest, HttpResponse, Responder};
 use log::*;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 // This is Revocation request from the cloud verifier via REST API
-pub(crate) async fn revocation(
+async fn revocation(
     body: web::Json<Revocation>,
     req: HttpRequest,
     data: web::Data<QuoteData>,
@@ -35,15 +35,96 @@ pub(crate) async fn revocation(
     }
 }
 
+async fn notifications_default(req: HttpRequest) -> impl Responder {
+    let error;
+    let response;
+    let message;
+
+    match req.head().method {
+        http::Method::POST => {
+            error = 400;
+            message = "URI not supported, only /revocation is supported for POST in /notifications/ interface";
+            response = HttpResponse::BadRequest()
+                .json(JsonWrapper::error(error, message));
+        }
+        _ => {
+            error = 405;
+            message = "Method is not supported in /notifications/ interface";
+            response = HttpResponse::MethodNotAllowed()
+                .insert_header(http::header::Allow(vec![http::Method::POST]))
+                .json(JsonWrapper::error(error, message));
+        }
+    };
+
+    warn!(
+        "{} returning {} response. {}",
+        req.head().method,
+        error,
+        message
+    );
+
+    response
+}
+
+/// Configure the endpoints for the /notifications scope
+pub(crate) fn configure_notifications_endpoints(
+    cfg: &mut web::ServiceConfig,
+) {
+    _ = cfg
+        .service(
+            web::resource("/revocation").route(web::post().to(revocation)),
+        )
+        .default_service(web::to(notifications_default));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::common::API_VERSION;
     use actix_rt::Arbiter;
     use actix_web::{test, web, App};
-    use serde_json::json;
+    use serde_json::{json, Value};
     use std::{fs, path::Path};
     use tokio::sync::mpsc;
+
+    #[actix_rt::test]
+    async fn test_notifications_default() {
+        let mut app = test::init_service(
+            App::new().service(web::resource("/").to(notifications_default)),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/")
+            .data("some data")
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_client_error());
+
+        let result: JsonWrapper<Value> = test::read_body_json(resp).await;
+
+        assert_eq!(result.results, json!({}));
+        assert_eq!(result.code, 400);
+
+        let req = test::TestRequest::delete().uri("/").to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_client_error());
+
+        let headers = resp.headers();
+
+        assert!(headers.contains_key("allow"));
+        assert_eq!(
+            headers.get("allow").unwrap().to_str().unwrap(), //#[allow_ci]
+            "POST"
+        );
+
+        let result: JsonWrapper<Value> = test::read_body_json(resp).await;
+
+        assert_eq!(result.results, json!({}));
+        assert_eq!(result.code, 405);
+    }
 
     #[cfg(feature = "testing")]
     #[actix_rt::test]


### PR DESCRIPTION
Move the configuration of the API for each scope into the respective handler file.
Also, move the API configuration into a dedicated file, and make it modular.

This is a preparation to add support for multiple API versions.