### PR TITLE
Fix showing wrong UUID, remove unused library

### DIFF
--- a/keylime-agent/src/config.rs
+++ b/keylime-agent/src/config.rs
@@ -685,7 +685,7 @@ fn get_uuid(agent_uuid_config: &str) -> String {
             Err(_) => {
                 warn!("Misformatted UUID: {}", &uuid_config);
                 let agent_uuid = Uuid::new_v4();
-                info!("Using generated UUID: {}", &uuid_config);
+                info!("Using generated UUID: {}", &agent_uuid);
                 agent_uuid.to_string()
             }
         },


### PR DESCRIPTION
In case of invalid UUID agent showed:
```
WARN  keylime_agent::config > Misformatted UUID: invalid-uuid-0909
INFO  keylime_agent::config > Using generated UUID: invalid-uuid-0909
```
and warning while compiling:
```
warning: unused import: `std::io::prelude`
    --> keylime/src/tpm.rs:1816:9
     |
1816 |     use std::io::prelude::*;
     |         ^^^^^^^^^^^^^^^^
     |
     = note: `#[warn(unused_imports)]` on by default
```