### PR TITLE
Use ${DESTDIR} for config

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,9 +31,9 @@ clean::
 
 .PHONY: install
 install: all
-	mkdir -p /etc/keylime/
-	mkdir -p /etc/keylime/agent.conf.d
-	cp ${CONFFILE} /etc/keylime/agent.conf
+	mkdir -p ${DESTDIR}/etc/keylime/
+	mkdir -p ${DESTDIR}/etc/keylime/agent.conf.d
+	cp ${CONFFILE} ${DESTDIR}/etc/keylime/agent.conf
 	for f in $(programs); do \
 		install -D -t ${DESTDIR}/usr/bin "$$f"; \
 	done


### PR DESCRIPTION
Prepends ${DESTDIR} for config dir creation and config file copying, so its in line with the other artifacts. Makes no sense to be able to install to dir X but config files being created in the system /etc/ dir