### PR TITLE
Use a single TPM context and avoid race conditions during tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,6 +1192,7 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "thiserror",
+ "tokio",
  "tss-esapi",
 ]
 

--- a/keylime-agent/src/agent_handler.rs
+++ b/keylime-agent/src/agent_handler.rs
@@ -21,7 +21,7 @@ pub(crate) struct AgentInfo {
 // It should return a AgentInfo object as JSON
 async fn info(
     req: HttpRequest,
-    data: web::Data<QuoteData>,
+    data: web::Data<QuoteData<'_>>,
 ) -> impl Responder {
     debug!("Returning agent information");
 
@@ -87,7 +87,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_agent_info() {
-        let mut quotedata = QuoteData::fixture().unwrap(); //#[allow_ci]
+        let (mut quotedata, mutex) = QuoteData::fixture().await.unwrap(); //#[allow_ci]
         quotedata.hash_alg = keylime::algorithms::HashAlgorithm::Sha256;
         quotedata.enc_alg = keylime::algorithms::EncryptionAlgorithm::Rsa;
         quotedata.sign_alg = keylime::algorithms::SignAlgorithm::RsaSsa;
@@ -112,6 +112,9 @@ mod tests {
         assert_eq!(result.results.tpm_hash_alg.as_str(), "sha256");
         assert_eq!(result.results.tpm_enc_alg.as_str(), "rsa");
         assert_eq!(result.results.tpm_sign_alg.as_str(), "rsassa");
+
+        // Explicitly drop QuoteData to cleanup keys
+        drop(data);
     }
 
     #[actix_rt::test]

--- a/keylime-agent/src/common.rs
+++ b/keylime-agent/src/common.rs
@@ -274,9 +274,10 @@ mod tests {
         Context,
     };
 
+    #[tokio::test]
     #[cfg(feature = "testing")]
-    #[test]
-    fn test_agent_data() -> Result<()> {
+    async fn test_agent_data() -> Result<()> {
+        let _mutex = tpm::testing::lock_tests().await;
         let mut config = KeylimeConfig::default();
 
         let mut ctx = tpm::Context::new()?;
@@ -319,13 +320,21 @@ mod tests {
             tpm_signing_alg,
             ek_hash.as_bytes(),
         );
+
         assert!(valid);
+
+        // Cleanup created keys
+        let ak_handle = ctx.load_ak(ek_result.key_handle, &ak)?;
+        ctx.flush_context(ak_handle.into());
+        ctx.flush_context(ek_result.key_handle.into());
+
         Ok(())
     }
 
+    #[tokio::test]
     #[cfg(feature = "testing")]
-    #[test]
-    fn test_hash() -> Result<()> {
+    async fn test_hash() -> Result<()> {
+        let _mutex = tpm::testing::lock_tests().await;
         let mut config = KeylimeConfig::default();
 
         let mut ctx = tpm::Context::new()?;
@@ -342,6 +351,10 @@ mod tests {
         let result = hash_ek_pubkey(ek_result.public);
 
         assert!(result.is_ok());
+
+        // Cleanup created keys
+        ctx.flush_context(ek_result.key_handle.into());
+
         Ok(())
     }
 }

--- a/keylime-agent/src/notifications_handler.rs
+++ b/keylime-agent/src/notifications_handler.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 async fn revocation(
     body: web::Json<Revocation>,
     req: HttpRequest,
-    data: web::Data<QuoteData>,
+    data: web::Data<QuoteData<'_>>,
 ) -> impl Responder {
     info!("Received revocation");
 
@@ -138,7 +138,7 @@ mod tests {
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/actions"),
         );
 
-        let mut fixture = QuoteData::fixture().unwrap(); //#[allow_ci]
+        let (mut fixture, mutex) = QuoteData::fixture().await.unwrap(); //#[allow_ci]
 
         // Replace the channels on the fixture with some local ones
         let (mut revocation_tx, mut revocation_rx) =
@@ -188,5 +188,8 @@ mod tests {
 
         let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
+
+        // Explicitly drop QuoteData to cleanup keys
+        drop(quotedata);
     }
 }

--- a/keylime/Cargo.toml
+++ b/keylime/Cargo.toml
@@ -21,6 +21,7 @@ thiserror.workspace = true
 tss-esapi.workspace = true
 picky-asn1-der.workspace = true
 picky-asn1-x509.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2,27 +2,63 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2021 Keylime Authors
 
+# Store the old TCTI setting
+OLD_TCTI=$TCTI
+OLD_TPM2TOOLS_TCTI=$TPM2TOOLS_TCTI
+
 set -euf -o pipefail
 
-echo "-------- Setting up Virtual TPM"
-mkdir /tmp/tpmdir
+echo "-------- Setting up Software TPM"
+
+# Create temporary directories
+TEMPDIR=$(mktemp -d)
+TPMDIR="${TEMPDIR}/tpmdir"
+mkdir -p ${TPMDIR}
+
+# Manufacture a new Software TPM
 swtpm_setup --tpm2 \
-    --tpmstate /tmp/tpmdir \
+    --tpmstate ${TPMDIR} \
     --createek --decryption --create-ek-cert \
     --create-platform-cert \
+    --lock-nvram \
+    --not-overwrite \
+    --pcr-banks sha256 \
     --display
-swtpm socket --tpm2 \
-    --tpmstate dir=/tmp/tpmdir \
-    --flags startup-clear \
-    --ctrl type=tcp,port=2322 \
-    --server type=tcp,port=2321 \
-    --daemon
-tpm2-abrmd \
-    --logger=stdout \
-    --tcti=swtpm: \
-    --allow-root \
-    --session \
-    --flush-all &
+
+function start_swtpm {
+    # Initialize the swtpm socket
+    swtpm socket --tpm2 \
+        --tpmstate dir=${TPMDIR} \
+        --flags startup-clear \
+        --ctrl type=tcp,port=2322 \
+        --server type=tcp,port=2321 \
+        --log level=1 &
+    SWTPM_PID=$!
+}
+
+function stop_swtpm {
+    # Stop swtpm if running
+    if [[ -n "$SWTPM_PID" ]]; then
+        echo "Stopping swtpm"
+        kill $SWTPM_PID
+    fi
+}
+
+# Set cleanup function to run at exit
+function cleanup {
+
+    echo "-------- Restore TCTI settings"
+    TCTI=$OLD_TCTI
+    TPM2TOOLS_TCTI=$OLD_TPM2TOOLS_TCTI
+
+    echo "-------- Cleanup processes"
+    stop_swtpm
+}
+trap cleanup EXIT
+
+# Set the TCTI to use the swtpm socket
+export TCTI=swtpm
+export TPM2TOOLS_TCTI=swtpm
 
 echo "-------- Running clippy"
 # The cargo denies are currently disabled, because that will require a bunch of dep cleanup
@@ -32,13 +68,14 @@ echo "-------- Building"
 RUST_BACKTRACE=1 cargo build
 
 echo "-------- Testing"
+start_swtpm
 mkdir -p /var/lib/keylime
-TCTI=tabrmd:bus_type=session RUST_BACKTRACE=1 RUST_LOG=info \
+RUST_BACKTRACE=1 RUST_LOG=info \
 KEYLIME_CONFIG=$PWD/keylime-agent.conf \
 cargo test --features testing -- --nocapture
 
 echo "-------- Testing with coverage"
-TCTI=tabrmd:bus_type=session RUST_BACKTRACE=1 RUST_LOG=info \
+RUST_BACKTRACE=1 RUST_LOG=info \
 KEYLIME_CONFIG=$PWD/keylime-agent.conf \
 cargo tarpaulin --verbose \
       --target-dir target/tarpaulin \
@@ -47,5 +84,4 @@ cargo tarpaulin --verbose \
       --ignore-panics --ignore-tests \
       --out Html --out Json \
       --all-features \
-      --engine llvm \
-      -- --test-threads=1
+      --engine llvm

--- a/tests/setup_swtpm.sh
+++ b/tests/setup_swtpm.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2021 Keylime Authors
+
+# Store the old TCTI setting
+OLD_TCTI=$TCTI
+OLD_TPM2TOOLS_TCTI=$TPM2TOOLS_TCTI
+
+set -euf -o pipefail
+
+if [[ $# -eq 0 ]] || [[ -z "$1" ]]; then
+    TEMPDIR=$(mktemp -d)
+    TPMDIR="${TEMPDIR}/tpmdir"
+    mkdir -p ${TPMDIR}
+else
+    echo "Using TPM state from $1"
+    TPMDIR=$1
+fi
+
+# Manufacture a new Software TPM
+swtpm_setup --tpm2 \
+    --tpmstate ${TPMDIR} \
+    --createek --decryption --create-ek-cert \
+    --create-platform-cert \
+    --lock-nvram \
+    --not-overwrite \
+    --pcr-banks sha256 \
+    --display
+
+function start_swtpm {
+    # Initialize the swtpm socket
+    swtpm socket --tpm2 \
+        --tpmstate dir=${TPMDIR} \
+        --flags startup-clear \
+        --ctrl type=tcp,port=2322 \
+        --server type=tcp,port=2321 \
+        --log level=1 &
+    SWTPM_PID=$!
+}
+
+function stop_swtpm {
+    # Stop swtpm if running
+    if [[ -n "$SWTPM_PID" ]]; then
+        echo "Stopping swtpm"
+        kill $SWTPM_PID
+    fi
+}
+
+# Set cleanup function to run at exit
+function cleanup {
+    echo "-------- Restore TCTI settings"
+    TCTI=$OLD_TCTI
+    TPM2TOOLS_TCTI=$OLD_TPM2TOOLS_TCTI
+
+    echo "-------- Cleanup processes"
+    stop_swtpm
+}
+trap cleanup EXIT
+
+# Set the TCTI to use the swtpm socket
+export TCTI=swtpm
+export TPM2TOOLS_TCTI=swtpm
+
+start_swtpm
+bash


### PR DESCRIPTION
This implements a singleton to use a single instance of the
`tss_espi::Context`.

This also avoids race conditions by using a thread-safe mutex to access
the context.

The tests were modified to cleanup generated key handles between test
cases, preventing leftover handles to fill the TPM memory.

Introduce a mutex to allow only a single test that create keys in the
TPM to run at once.  It is required that tests that create keys in the
TPM to run the `tpm::testing::lock_tests()` to obtain the mutex and be
able to continue executing without the risk of other tests filling the
TPM memory.

The `QuoteData::fixture` implementation (used only during tests) was
modified to flush the created key contexts when dropped. It also was
modified to lock the global mutex by calling the
`tpm::testing::lock_tests()` and provide the respective guard, preventing
other tests that use the fixture (which necessarily create TPM keys) to
run in parallel.

Note that it is necessary to `drop` the `QuoteData` fixture explicitly to guarantee
that the keys are flushed before releasing the global mutex.

Finally, the following changes were made to the `tests/run.sh`:

* Do not use `tpm2-abrmd` anymore, and use only the `swtpm` socket instead
* Stop the started processes at exit

With all these changes, the `tests/run.sh` can now be executed locally
without any special setting.

This also adds a script to initialize a software TPM locally for testing.

Fixes #259 