### PR TITLE
tests: Use Fedora 41 to generate code coverage

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -81,8 +81,8 @@
       - how: shell
         script:
          - yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-     # disable code coverage measurement everywhere except F39 and CS9
-   - when: distro != fedora-39
+     # disable code coverage measurement everywhere except F41 and CS9
+   - when: distro != fedora-41
      environment+:
         KEYLIME_RUST_CODE_COVERAGE: 0
      discover+:

--- a/scripts/download_packit_coverage.sh
+++ b/scripts/download_packit_coverage.sh
@@ -34,8 +34,8 @@ PROJECT="keylime/rust-keylime"
 
 # TF_JOB_DESC points to a Testing farm job that does code coverage measurement and
 # uploads coverage XML files to a web drive
-# currently we are doing that in a job running tests on Fedora-39
-TF_JOB_DESC="testing-farm:fedora-39-x86_64"
+# currently we are doing that in a job running tests on Fedora-41
+TF_JOB_DESC="testing-farm:fedora-41-x86_64"
 TF_TEST_OUTPUT="/setup/generate_upstream_rust_keylime_code_coverage.*/output.txt"
 TF_ARTIFACTS_URL_PREFIX="https://artifacts.dev.testing-farm.io"
 


### PR DESCRIPTION
Replace the Fedora 39 usage to generate code coverage with Fedora 41.

This is necessary because Fedora 39 is now EOL and the tests are not executed for it anymore.