### PR TITLE
workflows: Submit the coverage for merged PR from Fedora 41

### DIFF
--- a/.github/workflows/submit-HEAD-coverage.yaml
+++ b/.github/workflows/submit-HEAD-coverage.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Install testing-farm script
       run: pip3 -v install tft-cli
     - name: Run tests on Testing Farm
-      run: testing-farm request --context distro=fedora-39 --arch x86_64 --compose Fedora-39 --plan '/e2e' -e UPLOAD_COVERAGE=1 2>&1 | tee tt_output
+      run: testing-farm request --context distro=fedora-41 --arch x86_64 --compose Fedora-41 --plan '/e2e' -e UPLOAD_COVERAGE=1 2>&1 | tee tt_output
       env:
         TESTING_FARM_API_TOKEN: ${{ secrets.TESTING_FARM_API_TOKEN }}
     - name: Find PR Packit tests to finish and download e2e_coverage.txt and upstream_coverage.xml coverage files.


### PR DESCRIPTION
The coverage for merged PRs should be obtained from the Fedora 41 run.

This change was missing on the previous PR #873 