### PR TITLE
cargo: Bump base64 crate to version 0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ name = "keylime"
 version = "0.2.6"
 dependencies = [
  "actix-rt",
- "base64 0.21.7",
+ "base64 0.22.1",
  "hex",
  "log",
  "openssl",
@@ -1114,7 +1114,7 @@ version = "0.2.6"
 dependencies = [
  "actix-rt",
  "actix-web",
- "base64 0.21.7",
+ "base64 0.22.1",
  "cfg-if",
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.2.6"
 [workspace.dependencies]
 actix-rt = "2"
 actix-web =  { version = "4", default-features = false, features = ["macros", "openssl"] }
-base64 = "0.21"
+base64 = "0.22"
 cfg-if = "1"
 clap = { version = "4.3", features = ["derive"] }
 config = { version = "0.13", default-features = false, features = ["toml"] }


### PR DESCRIPTION
Bump `base64` crate to version `0.22.1`