### PR TITLE
packit: Fix RPM builds on copr

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -35,7 +35,8 @@ jobs:
         cargo build &&
         cd - &&
         cp /var/tmp/cargo-vendor-filterer/target/debug/cargo-vendor-filterer . &&
-        ./cargo-vendor-filterer --platform x86_64-unknown-linux-gnu
+        ./cargo-vendor-filterer --all-features
+            --platform x86_64-unknown-linux-gnu
             --platform powerpc64le-unknown-linux-gnu
             --platform aarch64-unknown-linux-gnu
             --platform i686-unknown-linux-gnu
@@ -61,7 +62,8 @@ jobs:
         cargo build &&
         cd - &&
         cp /var/tmp/cargo-vendor-filterer/target/debug/cargo-vendor-filterer . &&
-        ./cargo-vendor-filterer --platform x86_64-unknown-linux-gnu
+        ./cargo-vendor-filterer --all-features
+            --platform x86_64-unknown-linux-gnu
             --platform powerpc64le-unknown-linux-gnu
             --platform aarch64-unknown-linux-gnu
             --platform i686-unknown-linux-gnu


### PR DESCRIPTION
The `cargo-vendor-filterer` will drop dependencies addded by disabled features. Add the `--all-features` option to keep the dependencies added by all features in the generated vendor directory.

Without this, the RPM builds on COPR are currently failing. The RPMs used for testing are currently outdated and don't contain the changes related with the multiple API version support