### PR TITLE
scripts: Fix regex in download_packit_coverage.sh

### DIFF
--- a/scripts/download_packit_coverage.sh
+++ b/scripts/download_packit_coverage.sh
@@ -144,7 +144,7 @@ echo "TMPFILE=${TMPFILE}"
 
 for REPORT in e2e_coverage.txt upstream_coverage.xml; do
   # download test coverage
-  COVERAGE_URL=$( grep "$REPORT report is available at" ${TMPFILE} | grep -E -o "https://[^[:space:]]*" )
+  COVERAGE_URL=$( grep "$REPORT report is available at" ${TMPFILE} | grep -E -o "https?://[^[:space:]]*" )
   echo "COVERAGE_URL=${COVERAGE_URL}"
   if [ -z "${COVERAGE_URL}" ]; then
       echo "Could not parse $REPORT URL at from test log ${TF_TESTLOG}"


### PR DESCRIPTION
This fixes the currently failing coverage report job on CI.

The regex did not accept `http://` but only `https://` URLs. This makes the regex more flexible allowing us to use the current archive storage which provides only `http://`.