### PR TITLE
main: Remove unnecessary lifetime

### DIFF
--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -1015,7 +1015,7 @@ mod testing {
         }
     }
 
-    impl<'a> QuoteData<'a> {
+    impl QuoteData<'_> {
         pub(crate) async fn fixture() -> std::result::Result<
             (Self, AsyncMutexGuard<'static, ()>),
             MainTestError,


### PR DESCRIPTION
This fixes a waning on newer rust compilers that complains about it.