### PR TITLE
dist: Enable logging for keylime library in the service

### DIFF
--- a/dist/systemd/system/keylime_agent.service
+++ b/dist/systemd/system/keylime_agent.service
@@ -17,7 +17,7 @@ ExecStart=/usr/bin/keylime_agent
 TimeoutSec=60s
 Restart=on-failure
 RestartSec=120s
-Environment="RUST_LOG=keylime_agent=info"
+Environment="RUST_LOG=keylime_agent=info,keylime=info"
 # If using swtpm with tpm2-abrmd service, uncomment the line below to set TCTI
 # variable on the service environment
 #Environment="TCTI=tabrmd:"


### PR DESCRIPTION
Set the logging level as `INFO` for the `keylime` library in the systemd service file.

Some of the messages were moved from main to the library and would not be logged without this setting.