### PR TITLE
scripts: Fix coverage information downloading script

### DIFF
--- a/scripts/download_packit_coverage.sh
+++ b/scripts/download_packit_coverage.sh
@@ -134,7 +134,7 @@ fi
 # now we have TF_ARTIFACTS_URL so we can proceed with the download
 echo "TF_ARTIFACTS_URL=${TF_ARTIFACTS_URL}"
 
-COVERAGE_DIR=$( curl --retry 5 ${TF_ARTIFACTS_URL}/results.xml | grep -E -o "${TF_ARTIFACTS_URL}.*${TF_COVERAGE_DATA_DIR}" )
+COVERAGE_DIR=$( curl --retry 5 ${TF_ARTIFACTS_URL}/results.xml | grep -E -m 1 -o "${TF_ARTIFACTS_URL}.*${TF_COVERAGE_DATA_DIR}" )
 echo "COVERAGE_DIR=${COVERAGE_DIR}"
 
 DOWNLOADED="False"


### PR DESCRIPTION
Fix `COVERAGE_DIR` parsing from results by using the `-m 1` option in `grep` command to limit the output to a single match.