### PR TITLE
Allow agent to start without root privileges

### DIFF
--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -250,12 +250,10 @@ async fn main() -> Result<()> {
             Some(&config.agent.run_as)
         }
     } else {
-        error!("Cannot drop privileges: not enough permission");
-        return Err(Error::Configuration(
-            config::KeylimeConfigError::Generic(
-                "Cannot drop privileges: not enough permission".to_string(),
-            ),
-        ));
+        if !(config.agent.run_as).is_empty() {
+            warn!("Ignoring 'run_as' option because Keylime agent has not been started as root.");
+        }
+        None
     };
 
     // Drop privileges


### PR DESCRIPTION
Currently, `keylime_agent` must be started as root, and then drops permissions later.
This is not strictly necessary, as long as the agent has permission to talk to the TPM and read the TPM/IMA logs (e.g. through a group and/or ACLs).

This PR changes the UID check on startup to allow starting without root privileges.
If `run_as` is configured but we are already running unprivileged, then the `run_as` option will be ignored with a warning.

This allows, for example, running `keylime_agent` from a systemd service with `DynamicUsers=true`.