### PR TITLE
packit: Add identifier for each copr_build job

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -23,6 +23,7 @@ jobs:
 - job: copr_build
   trigger: commit
   branch: master
+  identifier: fedora
   specfile_path: rpm/fedora/keylime-agent-rust.spec
   files_to_sync:
     - rpm/fedora/*
@@ -50,6 +51,7 @@ jobs:
 - job: copr_build
   trigger: commit
   branch: master
+  identifier: centos
   specfile_path: rpm/centos/keylime-agent-rust.spec
   files_to_sync:
     - rpm/centos/*


### PR DESCRIPTION
Following guidance from packit team, and as documented in [1], add an identifier for each `copr_build` job in the packit configuration.

This can help packit to properly identify the jobs and report the results properly, avoiding checks to hang.

[1] https://packit.dev/docs/configuration/upstream/copr_build#optional-parameters