### PR TITLE
packit: Add compatibility/api_version_compatibility test

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -35,6 +35,7 @@
        - /functional/basic-attestation-on-localhost
        # now change IMA policy to signing and run all tests
        - /setup/configure_kernel_ima_module/ima_policy_signing
+       - /compatibility/api_version_compatibility
        - /compatibility/basic-attestation-on-localhost-api-version-bump
        - /compatibility/basic-attestation-on-localhost-with-allowlist-excludelist
        - /functional/agent_UUID_assignment_options


### PR DESCRIPTION
The test tries all API versions supported by the agent against the latest server components.