### PR TITLE
keylime-agent.conf: only mention ecdsa and rsassa for signing

### DIFF
--- a/keylime-agent.conf
+++ b/keylime-agent.conf
@@ -218,7 +218,7 @@ allow_payload_revocation_actions = true
 # Currently accepted values include:
 # - hashing:    sha512, sha384, sha256 or sha1
 # - encryption: ecc or rsa
-# - signing:    rsassa, rsapss, ecdsa, ecdaa or ecschnorr
+# - signing:    rsassa or ecdsa
 #
 # To override tpm_hash_alg, set KEYLIME_AGENT_TPM_HASH_ALG environment variable.
 # To override tpm_encryption_alg, set KEYLIME_AGENT_TPM_ENCRYPTION_ALG


### PR DESCRIPTION
The other algorithms, while supported by the TPM, are not supported on the Keylime verifier side.

