### PR TITLE
Move SymmKey from common to the keylime library

### DIFF
--- a/keylime-agent/src/common.rs
+++ b/keylime-agent/src/common.rs
@@ -36,11 +36,6 @@ use tss_esapi::{
 /*
  * Constants and static variables
  */
-pub const TPM_DATA_PCR: usize = 16;
-pub const IMA_PCR: usize = 10;
-pub static RSA_PUBLICKEY_EXPORTABLE: &str = "rsa placeholder";
-pub static KEY: &str = "secret";
-pub const AGENT_UUID_LEN: usize = 36;
 pub const AUTH_TAG_LEN: usize = 48;
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/keylime-agent/src/common.rs
+++ b/keylime-agent/src/common.rs
@@ -10,7 +10,7 @@ use keylime::algorithms::{
     EncryptionAlgorithm, HashAlgorithm, SignAlgorithm,
 };
 use keylime::{
-    crypto::{hash, tss_pubkey_to_pem, AES_128_KEY_LEN, AES_256_KEY_LEN},
+    crypto::{hash, tss_pubkey_to_pem},
     tpm,
 };
 use log::*;
@@ -79,55 +79,6 @@ where
             code: 200,
             status: String::from("Success"),
             results,
-        }
-    }
-}
-
-// a vector holding keys
-pub type KeySet = Vec<SymmKey>;
-
-// a key of len AES_128_KEY_LEN or AES_256_KEY_LEN
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SymmKey {
-    bytes: Vec<u8>,
-}
-
-impl SymmKey {
-    pub(crate) fn xor(&self, other: &Self) -> Result<Self> {
-        let my_bytes = self.as_ref();
-        let other_bytes = other.as_ref();
-        if my_bytes.len() != other_bytes.len() {
-            return Err(Error::Other(
-                "cannot xor differing length slices".to_string(),
-            ));
-        }
-        let mut outbuf = vec![0u8; my_bytes.len()];
-        for (out, (x, y)) in
-            outbuf.iter_mut().zip(my_bytes.iter().zip(other_bytes))
-        {
-            *out = x ^ y;
-        }
-        Ok(Self { bytes: outbuf })
-    }
-}
-
-impl AsRef<[u8]> for SymmKey {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes.as_slice()
-    }
-}
-
-impl TryFrom<&[u8]> for SymmKey {
-    type Error = String;
-
-    fn try_from(v: &[u8]) -> std::result::Result<Self, Self::Error> {
-        match v.len() {
-            AES_128_KEY_LEN | AES_256_KEY_LEN => {
-                Ok(SymmKey { bytes: v.to_vec() })
-            }
-            other => Err(format!(
-                "key length {other} does not correspond to valid GCM cipher",
-            )),
         }
     }
 }

--- a/keylime-agent/src/keys_handler.rs
+++ b/keylime-agent/src/keys_handler.rs
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2021 Keylime Authors
 
-use crate::crypto;
 use crate::{
-    common::{
-        AuthTag, EncryptedData, JsonWrapper, KeySet, SymmKey,
-    },
+    common::{AuthTag, EncryptedData, JsonWrapper},
     config::KeylimeConfig,
     payloads::{Payload, PayloadMessage},
     Error, QuoteData, Result,
 };
 use actix_web::{http, web, HttpRequest, HttpResponse, Responder};
 use base64::{engine::general_purpose, Engine as _};
+use keylime::crypto::{
+    self,
+    symmkey::{KeySet, SymmKey},
+};
 use log::*;
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/keylime-agent/src/keys_handler.rs
+++ b/keylime-agent/src/keys_handler.rs
@@ -4,8 +4,7 @@
 use crate::crypto;
 use crate::{
     common::{
-        AuthTag, EncryptedData, JsonWrapper, KeySet, SymmKey, AGENT_UUID_LEN,
-        AUTH_TAG_LEN,
+        AuthTag, EncryptedData, JsonWrapper, KeySet, SymmKey,
     },
     config::KeylimeConfig,
     payloads::{Payload, PayloadMessage},

--- a/keylime-agent/src/payloads.rs
+++ b/keylime-agent/src/payloads.rs
@@ -2,8 +2,8 @@
 // Copyright 2021 Keylime Authors
 
 use crate::{
-    common::{EncryptedData, SymmKey},
-    config, crypto,
+    common::EncryptedData,
+    config,
     revocation::{Revocation, RevocationMessage},
     Error, Result,
 };
@@ -11,6 +11,10 @@ use crate::{
 #[cfg(feature = "with-zmq")]
 use crate::revocation::ZmqMessage;
 
+use keylime::crypto::{
+    self,
+    symmkey::{KeySet, SymmKey},
+};
 use log::*;
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/keylime/src/crypto.rs
+++ b/keylime/src/crypto.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2021 Keylime Authors
 
+pub mod symmkey;
 pub mod x509;
 
 use base64::{engine::general_purpose, Engine as _};

--- a/keylime/src/crypto/symmkey.rs
+++ b/keylime/src/crypto/symmkey.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Keylime Authors
+
+use crate::crypto::{AES_128_KEY_LEN, AES_256_KEY_LEN};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SymmKeyError {
+    // Invalid key size for AES
+    #[error("invalid AES key size: {0}")]
+    InvalidKeySize(usize),
+
+    // Incompatible sizes for XOR
+    #[error("cannot XOR slices of different sizes")]
+    XorIncompatibleSizes,
+}
+
+// a vector holding keys
+pub type KeySet = Vec<SymmKey>;
+
+// a key of len AES_128_KEY_LEN or AES_256_KEY_LEN
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SymmKey {
+    bytes: Vec<u8>,
+}
+
+impl SymmKey {
+    pub fn xor(&self, other: &Self) -> Result<Self, SymmKeyError> {
+        let my_bytes = self.as_ref();
+        let other_bytes = other.as_ref();
+        if my_bytes.len() != other_bytes.len() {
+            return Err(SymmKeyError::XorIncompatibleSizes);
+        }
+        let mut outbuf = vec![0u8; my_bytes.len()];
+        for (out, (x, y)) in
+            outbuf.iter_mut().zip(my_bytes.iter().zip(other_bytes))
+        {
+            *out = x ^ y;
+        }
+        Ok(Self { bytes: outbuf })
+    }
+}
+
+impl AsRef<[u8]> for SymmKey {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_slice()
+    }
+}
+
+impl TryFrom<&[u8]> for SymmKey {
+    type Error = SymmKeyError;
+
+    fn try_from(v: &[u8]) -> std::result::Result<Self, SymmKeyError> {
+        match v.len() {
+            AES_128_KEY_LEN | AES_256_KEY_LEN => {
+                Ok(SymmKey { bytes: v.to_vec() })
+            }
+            other => Err(SymmKeyError::InvalidKeySize(other)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert() {
+        let a_128: [u8; AES_128_KEY_LEN] = [0; AES_128_KEY_LEN];
+        let a_256: [u8; AES_256_KEY_LEN] = [0; AES_256_KEY_LEN];
+        let a_unknown: [u8; 127] = [0; 127];
+
+        let r_128 = SymmKey::try_from(a_128.as_ref());
+        assert!(r_128.is_ok());
+
+        let r_256 = SymmKey::try_from(a_256.as_ref());
+        assert!(r_256.is_ok());
+
+        let r_unknown = SymmKey::try_from(a_unknown.as_ref());
+        assert!(r_unknown.is_err());
+    }
+
+    #[test]
+    fn test_xor() {
+        // Input for 128 bits keys
+        let a: [u8; AES_128_KEY_LEN] = [0xA0; AES_128_KEY_LEN];
+        let b: [u8; AES_128_KEY_LEN] = [0x0A; AES_128_KEY_LEN];
+        let axb: [u8; AES_128_KEY_LEN] = [0xAA; AES_128_KEY_LEN];
+        let r_128 =
+            SymmKey::try_from(axb.as_ref()).expect("failed to convert");
+
+        // Input for 256 bits keys
+        let c: [u8; AES_256_KEY_LEN] = [0xA0; AES_256_KEY_LEN];
+        let d: [u8; AES_256_KEY_LEN] = [0x0A; AES_256_KEY_LEN];
+        let cxd: [u8; AES_256_KEY_LEN] = [0xAA; AES_256_KEY_LEN];
+        let r_256 =
+            SymmKey::try_from(cxd.as_ref()).expect("failed to convert");
+
+        // Test for each set of inputs
+        for (i, j, expected) in [
+            (a.as_ref(), b.as_ref(), &r_128),
+            (c.as_ref(), d.as_ref(), &r_256),
+        ] {
+            let k_i =
+                SymmKey::try_from(i).expect("failed to get key from slice");
+            let k_j =
+                SymmKey::try_from(j).expect("failed to get key from slice");
+            let result = k_i.xor(&k_j);
+            assert!(result.is_ok());
+
+            let out = result.expect("xor failed");
+            assert_eq!(&out, expected);
+        }
+    }
+}


### PR DESCRIPTION
Move the SymmKey structure from `common.rs` into the keylime library (`crypto::symmkey`).

This is to continue the effort to move the code that can be shared from the `keylime-agent` application to the `keylime` library