### PR TITLE
Move AuthTag and EncryptedData from the common.rs to the Keylime library

### DIFF
--- a/keylime-agent/src/common.rs
+++ b/keylime-agent/src/common.rs
@@ -33,11 +33,6 @@ use tss_esapi::{
     structures::PcrSlot, traits::UnMarshall, utils::TpmsContext,
 };
 
-/*
- * Constants and static variables
- */
-pub const AUTH_TAG_LEN: usize = 48;
-
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct APIVersion {
     major: u32,
@@ -79,32 +74,6 @@ where
             code: 200,
             status: String::from("Success"),
             results,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AuthTag {
-    bytes: Vec<u8>,
-}
-
-impl AsRef<[u8]> for AuthTag {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes.as_slice()
-    }
-}
-
-impl TryFrom<&[u8]> for AuthTag {
-    type Error = String;
-
-    fn try_from(v: &[u8]) -> std::result::Result<Self, Self::Error> {
-        match v.len() {
-            AUTH_TAG_LEN => {
-                Ok(AuthTag { bytes: v.to_vec() })
-            }
-            other => Err(format!(
-                "auth tag length {other} does not correspond to valid SHA-384 HMAC",
-            )),
         }
     }
 }

--- a/keylime-agent/src/common.rs
+++ b/keylime-agent/src/common.rs
@@ -78,29 +78,6 @@ where
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct EncryptedData {
-    bytes: Vec<u8>,
-}
-
-impl AsRef<[u8]> for EncryptedData {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes.as_slice()
-    }
-}
-
-impl From<&[u8]> for EncryptedData {
-    fn from(v: &[u8]) -> Self {
-        EncryptedData { bytes: v.to_vec() }
-    }
-}
-
-impl From<Vec<u8>> for EncryptedData {
-    fn from(v: Vec<u8>) -> Self {
-        EncryptedData { bytes: v }
-    }
-}
-
 // TPM data and agent related that can be persisted and loaded on agent startup.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct AgentData {

--- a/keylime-agent/src/keys_handler.rs
+++ b/keylime-agent/src/keys_handler.rs
@@ -2,7 +2,7 @@
 // Copyright 2021 Keylime Authors
 
 use crate::{
-    common::{EncryptedData, JsonWrapper},
+    common::JsonWrapper,
     config::KeylimeConfig,
     payloads::{Payload, PayloadMessage},
     Error, QuoteData, Result,
@@ -11,8 +11,9 @@ use actix_web::{http, web, HttpRequest, HttpResponse, Responder};
 use base64::{engine::general_purpose, Engine as _};
 use keylime::crypto::{
     self,
-    symmkey::{KeySet, SymmKey},
     auth_tag::AuthTag,
+    encrypted_data::EncryptedData,
+    symmkey::{KeySet, SymmKey},
 };
 use log::*;
 use serde::{Deserialize, Serialize};

--- a/keylime-agent/src/keys_handler.rs
+++ b/keylime-agent/src/keys_handler.rs
@@ -2,7 +2,7 @@
 // Copyright 2021 Keylime Authors
 
 use crate::{
-    common::{AuthTag, EncryptedData, JsonWrapper},
+    common::{EncryptedData, JsonWrapper},
     config::KeylimeConfig,
     payloads::{Payload, PayloadMessage},
     Error, QuoteData, Result,
@@ -12,6 +12,7 @@ use base64::{engine::general_purpose, Engine as _};
 use keylime::crypto::{
     self,
     symmkey::{KeySet, SymmKey},
+    auth_tag::AuthTag,
 };
 use log::*;
 use serde::{Deserialize, Serialize};

--- a/keylime-agent/src/payloads.rs
+++ b/keylime-agent/src/payloads.rs
@@ -2,7 +2,6 @@
 // Copyright 2021 Keylime Authors
 
 use crate::{
-    common::EncryptedData,
     config,
     revocation::{Revocation, RevocationMessage},
     Error, Result,
@@ -13,6 +12,7 @@ use crate::revocation::ZmqMessage;
 
 use keylime::crypto::{
     self,
+    encrypted_data::EncryptedData,
     symmkey::{KeySet, SymmKey},
 };
 use log::*;

--- a/keylime/src/crypto.rs
+++ b/keylime/src/crypto.rs
@@ -2,6 +2,7 @@
 // Copyright 2021 Keylime Authors
 
 pub mod auth_tag;
+pub mod encrypted_data;
 pub mod symmkey;
 pub mod x509;
 

--- a/keylime/src/crypto.rs
+++ b/keylime/src/crypto.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2021 Keylime Authors
 
+pub mod auth_tag;
 pub mod symmkey;
 pub mod x509;
 
@@ -34,6 +35,7 @@ use thiserror::Error;
 pub const AES_128_KEY_LEN: usize = 16;
 pub const AES_256_KEY_LEN: usize = 32;
 pub const AES_BLOCK_SIZE: usize = 16;
+pub const AUTH_TAG_LEN: usize = 48;
 
 #[derive(Error, Debug)]
 pub enum CryptoError {

--- a/keylime/src/crypto/auth_tag.rs
+++ b/keylime/src/crypto/auth_tag.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Keylime Authors
+
+use crate::crypto::AUTH_TAG_LEN;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AuthTagError {
+    // Invalid authentication tag size
+    #[error("auth tag length {0} does not correspond to valid SHA-384 HMAC")]
+    InvalidAuthTagSize(usize),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthTag {
+    bytes: Vec<u8>,
+}
+
+impl AsRef<[u8]> for AuthTag {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_slice()
+    }
+}
+
+impl TryFrom<&[u8]> for AuthTag {
+    type Error = AuthTagError;
+
+    fn try_from(v: &[u8]) -> std::result::Result<Self, Self::Error> {
+        match v.len() {
+            AUTH_TAG_LEN => Ok(AuthTag { bytes: v.to_vec() }),
+            _ => Err(AuthTagError::InvalidAuthTagSize(v.len())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert() {
+        let a: [u8; AUTH_TAG_LEN] = [0xAA; AUTH_TAG_LEN];
+        let invalid: [u8; 32] = [0xBB; 32];
+
+        let r = AuthTag::try_from(a.as_ref());
+        assert!(r.is_ok());
+
+        let r = AuthTag::try_from(invalid.as_ref());
+        assert!(r.is_err());
+    }
+}

--- a/keylime/src/crypto/encrypted_data.rs
+++ b/keylime/src/crypto/encrypted_data.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Keylime Authors
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EncryptedData {
+    bytes: Vec<u8>,
+}
+
+impl AsRef<[u8]> for EncryptedData {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_slice()
+    }
+}
+
+impl From<&[u8]> for EncryptedData {
+    fn from(v: &[u8]) -> Self {
+        EncryptedData { bytes: v.to_vec() }
+    }
+}
+
+impl From<Vec<u8>> for EncryptedData {
+    fn from(v: Vec<u8>) -> Self {
+        EncryptedData { bytes: v }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_encrypted_data_as_ref() {
+        let a = EncryptedData {
+            bytes: vec![0x0A, 16],
+        };
+
+        let r = a.as_ref();
+        assert_eq!(r, vec![0x0A, 16]);
+    }
+
+    #[test]
+    fn test_encrypted_data_from_slice() {
+        let a: [u8; 16] = [0x0B; 16];
+        let expected = EncryptedData {
+            bytes: vec![0x0B; 16],
+        };
+
+        let r = EncryptedData::from(a.as_ref());
+
+        assert_eq!(r, expected);
+    }
+
+    #[test]
+    fn test_encrypted_data_from_vec() {
+        let a: Vec<u8> = vec![0x0C; 16];
+        let expected = EncryptedData {
+            bytes: vec![0x0C; 16],
+        };
+
+        let r = EncryptedData::from(a);
+
+        assert_eq!(r, expected);
+    }
+}


### PR DESCRIPTION
Move the EncryptedData and AuthTag structures from common.rs into the keylime library.

This is to continue the effort to move the code that can be shared from the keylime-agent application to the keylime library
