### PR TITLE
Move Agent identity information from the `RegistrarClient` structure to the new structure AgentIdentity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ tests/actions/__pycache__
 tests/unzipped/__pycache__
 **/tarpaulin-report.*
 **/__pycache__
+*.swp
+*.orig

--- a/keylime/src/agent_identity.rs
+++ b/keylime/src/agent_identity.rs
@@ -1,0 +1,353 @@
+use log::*;
+use openssl::x509::X509;
+use thiserror::Error;
+
+use crate::crypto::{x509_to_der, x509_to_pem, CryptoError};
+
+#[derive(Error, Debug)]
+pub enum AgentIdentityBuilderError {
+    /// Agent public AK not set
+    #[error("Agent public AK not set")]
+    AKPubNotSet,
+
+    /// Agent contact IP or hostname not set
+    #[error("Agent contact IP or hostname not set")]
+    AgentContactIPNotSet,
+
+    /// Agent port not set
+    #[error("Agent port not set")]
+    AgentPortNotSet,
+
+    /// Agent UUID not set
+    #[error("Agent UUID not set")]
+    AgentUUIDNotSet,
+
+    /// Failed to convert certificate type
+    #[error("Failed to convert certificate type")]
+    CertConvert(#[source] CryptoError),
+
+    /// Agent public EK not set
+    #[error("Agent public EK not set")]
+    EKPubNotSet,
+
+    /// Accepted API versions not set
+    #[error("List of enabled API versions not set")]
+    EnabledAPIVersionsNotSet,
+}
+
+#[derive(Debug, Default)]
+pub struct AgentIdentityBuilder<'a> {
+    ak_pub: Option<&'a [u8]>,
+    ek_cert: Option<String>,
+    ek_pub: Option<&'a [u8]>,
+    enabled_api_versions: Option<Vec<&'a str>>,
+    iak_attest: Option<Vec<u8>>,
+    iak_cert: Option<X509>,
+    iak_pub: Option<&'a [u8]>,
+    iak_sign: Option<Vec<u8>>,
+    idevid_cert: Option<X509>,
+    idevid_pub: Option<&'a [u8]>,
+    ip: Option<String>,
+    mtls_cert: Option<X509>,
+    port: Option<u32>,
+    uuid: Option<&'a str>,
+}
+
+impl<'a> AgentIdentityBuilder<'a> {
+    /// Create a new AgentIdentityBuilder object
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the public Attestation Key (AK)
+    ///
+    /// # Arguments:
+    ///
+    /// * ak_pub (&'a [u8]): The buffer containing the marshalled public AK
+    pub fn ak_pub(mut self, ak_pub: &'a [u8]) -> Self {
+        self.ak_pub = Some(ak_pub);
+        self
+    }
+
+    /// Set the API versions that are enabled
+    ///
+    /// # Arguments:
+    ///
+    /// * api_versions (Vec<&'a str>): The enabled API versions
+    pub fn enabled_api_versions(
+        mut self,
+        api_versions: Vec<&'a str>,
+    ) -> Self {
+        self.enabled_api_versions = Some(api_versions);
+        self
+    }
+
+    /// Set the public Endorsement Key (EK)
+    ///
+    /// # Arguments:
+    ///
+    /// * ek_pub (&'a [u8]): The buffer containing the marshalled public EK
+    pub fn ek_pub(mut self, ek_pub: &'a [u8]) -> Self {
+        self.ek_pub = Some(ek_pub);
+        self
+    }
+
+    /// Set the Endorsement Key (EK) certificate
+    ///
+    /// # Arguments:
+    ///
+    /// * ek_cert (String): A string containing the EK certificate in PEM format
+    pub fn ek_cert(mut self, ek_cert: String) -> Self {
+        self.ek_cert = Some(ek_cert);
+        self
+    }
+
+    /// Set the IAK attestation evidence
+    ///
+    /// This is obtained by certifying the IAK with the AK
+    ///
+    /// # Arguments:
+    ///
+    /// * iak_attest (Vec<u8>): A vector containing the IAK attestation
+    pub fn iak_attest(mut self, iak_attest: Vec<u8>) -> Self {
+        self.iak_attest = Some(iak_attest);
+        self
+    }
+
+    /// Set the IAK certificate
+    ///
+    /// # Arguments:
+    ///
+    /// * iak_cert (X509): The IAK certificate
+    pub fn iak_cert(mut self, iak_cert: X509) -> Self {
+        self.iak_cert = Some(iak_cert);
+        self
+    }
+
+    /// Set the IAK attestation signature
+    ///
+    /// # Arguments:
+    ///
+    /// * iak_sign (Vec<u8>): A vector containing the IAK attestation signature
+    pub fn iak_sign(mut self, iak_sign: Vec<u8>) -> Self {
+        self.iak_sign = Some(iak_sign);
+        self
+    }
+
+    /// Set the public IAK
+    ///
+    /// # Arguments:
+    ///
+    /// * iak_pub <&'a [u8]>: The buffer containing the marshalled public IAK
+    pub fn iak_pub(mut self, iak_pub: &'a [u8]) -> Self {
+        self.iak_pub = Some(iak_pub);
+        self
+    }
+
+    /// Set the IDevID certificate
+    ///
+    /// # Arguments:
+    ///
+    /// * idevid_cert (X509): The IDevID certificate
+    pub fn idevid_cert(mut self, idevid_cert: X509) -> Self {
+        self.idevid_cert = Some(idevid_cert);
+        self
+    }
+
+    /// Set the IDevID public key
+    ///
+    /// # Arguments:
+    ///
+    /// * idevid_pub: The IDevID public key
+    pub fn idevid_pub(mut self, idevid_pub: &'a [u8]) -> Self {
+        self.idevid_pub = Some(idevid_pub);
+        self
+    }
+
+    /// Set the Agent contact IP
+    ///
+    /// This is the Agent IP or hostname to be contacted when making requests
+    ///
+    /// # Arguments:
+    ///
+    /// * ip (String): The Agent contact IP
+    pub fn ip(mut self, ip: String) -> Self {
+        self.ip = Some(ip);
+        self
+    }
+
+    /// Set the Agent mTLS certificate
+    ///
+    /// This is the certificate used when creating TLS connections to contact the Agent
+    ///
+    /// # Arguments:
+    ///
+    /// * mtls_cert (X509): The Agent mTLS certificate
+    pub fn mtls_cert(mut self, mtls_cert: X509) -> Self {
+        self.mtls_cert = Some(mtls_cert);
+        self
+    }
+
+    /// Set the Agent port
+    ///
+    /// # Arguments:
+    ///
+    /// * port (u32): The port the Agent will listen to receive requests
+    pub fn port(mut self, port: u32) -> Self {
+        self.port = Some(port);
+        self
+    }
+
+    /// Set the agent UUID
+    ///
+    /// # Arguments:
+    ///
+    /// * uuid (&'a str): The agent UUID
+    pub fn uuid(mut self, uuid: &'a str) -> Self {
+        self.uuid = Some(uuid);
+        self
+    }
+
+    /// Generate the AgentIdentity object using the previously set options
+    pub async fn build(
+        mut self,
+    ) -> Result<AgentIdentity<'a>, AgentIdentityBuilderError> {
+        // Check that required fields were set and take from the builder
+        let Some(ak_pub) = self.ak_pub else {
+            return Err(AgentIdentityBuilderError::AKPubNotSet);
+        };
+
+        let Some(ip) = self.ip.take() else {
+            return Err(AgentIdentityBuilderError::AgentContactIPNotSet);
+        };
+
+        let Some(port) = self.port else {
+            return Err(AgentIdentityBuilderError::AgentPortNotSet);
+        };
+
+        let Some(uuid) = self.uuid.take() else {
+            return Err(AgentIdentityBuilderError::AgentUUIDNotSet);
+        };
+
+        let Some(ek_pub) = self.ek_pub else {
+            return Err(AgentIdentityBuilderError::EKPubNotSet);
+        };
+
+        let mtls_cert = match self.mtls_cert.take() {
+            Some(cert) => Some(
+                x509_to_pem(&cert)
+                    .map_err(AgentIdentityBuilderError::CertConvert)?,
+            ),
+            None => Some("disabled".to_string()),
+        };
+
+        let idevid_cert = match self.idevid_cert.take() {
+            Some(cert) => Some(
+                x509_to_der(&cert)
+                    .map_err(AgentIdentityBuilderError::CertConvert)?,
+            ),
+            None => None,
+        };
+
+        let iak_cert = match self.iak_cert.take() {
+            Some(cert) => Some(
+                x509_to_der(&cert)
+                    .map_err(AgentIdentityBuilderError::CertConvert)?,
+            ),
+            None => None,
+        };
+
+        // Take the enabled_api_versions
+        let Some(enabled_api_versions) = self.enabled_api_versions.take()
+        else {
+            return Err(AgentIdentityBuilderError::EnabledAPIVersionsNotSet);
+        };
+
+        Ok(AgentIdentity {
+            ak_pub,
+            ek_cert: self.ek_cert,
+            ek_pub,
+            enabled_api_versions,
+            iak_attest: self.iak_attest.take(),
+            iak_cert,
+            iak_pub: self.iak_pub,
+            iak_sign: self.iak_sign.take(),
+            idevid_cert,
+            idevid_pub: self.idevid_pub,
+            ip,
+            mtls_cert,
+            port,
+            uuid,
+        })
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct AgentIdentity<'a> {
+    pub ak_pub: &'a [u8],
+    pub ek_cert: Option<String>,
+    pub ek_pub: &'a [u8],
+    pub enabled_api_versions: Vec<&'a str>,
+    pub iak_attest: Option<Vec<u8>>,
+    pub iak_cert: Option<Vec<u8>>,
+    pub iak_pub: Option<&'a [u8]>,
+    pub iak_sign: Option<Vec<u8>>,
+    pub idevid_cert: Option<Vec<u8>>,
+    pub idevid_pub: Option<&'a [u8]>,
+    pub ip: String,
+    pub mtls_cert: Option<String>,
+    pub port: u32,
+    pub uuid: &'a str,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[actix_rt::test]
+    async fn test_build_missing_required() {
+        let mock_data = [0u8; 1];
+        let required = [
+            "ak_pub",
+            "ek_pub",
+            "enabled_api_versions",
+            "ip",
+            "port",
+            "uuid",
+        ];
+
+        for to_skip in required.iter() {
+            // Add all required fields but the one to skip
+            let to_add: Vec<&str> =
+                required.iter().filter(|&x| x != to_skip).copied().collect();
+            let mut builder = AgentIdentityBuilder::new();
+
+            if to_add.contains(&"ak_pub") {
+                builder = builder.ak_pub(&mock_data);
+            }
+
+            if to_add.contains(&"ek_pub") {
+                builder = builder.ek_pub(&mock_data);
+            }
+
+            if to_add.contains(&"enabled_api_versions") {
+                builder = builder.enabled_api_versions(vec!["1.2"]);
+            }
+
+            if to_add.contains(&"ip") {
+                builder = builder.ip("1.2.3.4".to_string());
+            }
+
+            if to_add.contains(&"port") {
+                builder = builder.port(0);
+            }
+
+            if to_add.contains(&"uuid") {
+                builder = builder.uuid("uuid");
+            }
+
+            let result = builder.build().await;
+            assert!(result.is_err());
+        }
+    }
+}

--- a/keylime/src/keylime_error.rs
+++ b/keylime/src/keylime_error.rs
@@ -11,6 +11,10 @@ use tss_esapi::{
 pub enum Error {
     #[error("HttpServer error: {0}")]
     ActixWeb(#[from] actix_web::Error),
+    #[error("Failed to build Agent Identity")]
+    AgentIdentityBuilder(
+        #[from] crate::agent_identity::AgentIdentityBuilderError,
+    ),
     #[error("TSS2 Error: {err:?}, kind: {kind:?}, {message}")]
     Tss2 {
         err: tss_esapi::Error,

--- a/keylime/src/lib.rs
+++ b/keylime/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent_data;
+pub mod agent_identity;
 pub mod agent_registration;
 pub mod algorithms;
 pub mod cert;

--- a/keylime/src/registrar_client.rs
+++ b/keylime/src/registrar_client.rs
@@ -1,15 +1,11 @@
-use crate::serialization::*;
+use crate::{agent_identity::AgentIdentity, serialization::*};
 use log::*;
-use openssl::x509::X509;
 use serde::{Deserialize, Serialize};
 use serde_json::Number;
 use std::net::IpAddr;
 use thiserror::Error;
 
-use crate::{
-    crypto::{x509_to_der, x509_to_pem, CryptoError},
-    version::KeylimeRegistrarVersion,
-};
+use crate::version::KeylimeRegistrarVersion;
 
 pub const UNKNOWN_API_VERSION: &str = "unknown";
 
@@ -19,41 +15,6 @@ fn is_empty(buf: &[u8]) -> bool {
 
 #[derive(Error, Debug)]
 pub enum RegistrarClientBuilderError {
-    /// Agent public AK not set
-    #[error("Agent public AK not set")]
-    AKPubNotSet,
-
-    /// Agent contact IP or hostname not set
-    #[error("Agent contact IP or hostname not set")]
-    AgentContactIPNotSet,
-
-    /// Agent port not set
-    #[error("Agent port not set")]
-    AgentPortNotSet,
-
-    /// Agent UUID not set
-    #[error("Agent UUID not set")]
-    AgentUUIDNotSet,
-
-    /// Failed to convert certificate type
-    #[error("Failed to convert certificate type")]
-    CertConvert(#[source] CryptoError),
-
-    /// Agent public EK not set
-    #[error("Agent public EK not set")]
-    EKPubNotSet,
-
-    /// Accepted API versions not set
-    #[error("List of enabled API versions not set")]
-    EnabledAPIVersionsNotSet,
-
-    /// Incompatible configured API versions
-    #[error("Registrar and agent API versions are incompatible: agent enabled APIs '{agent_enabled}', registrar supported APIs '{registrar_supported}'")]
-    IncompatibleAPI {
-        agent_enabled: String,
-        registrar_supported: String,
-    },
-
     /// Registrar IP or hostname not set
     #[error("Registrar IP or hostname not set")]
     RegistrarIPNotSet,
@@ -72,178 +33,27 @@ pub enum RegistrarClientBuilderError {
 }
 
 #[derive(Debug, Default)]
-pub struct RegistrarClientBuilder<'a> {
-    ak_pub: Option<&'a [u8]>,
-    ek_pub: Option<&'a [u8]>,
-    ek_cert: Option<String>,
-    enabled_api_versions: Option<Vec<&'a str>>,
-    iak_attest: Option<Vec<u8>>,
-    iak_cert: Option<X509>,
-    iak_sign: Option<Vec<u8>>,
-    iak_pub: Option<&'a [u8]>,
-    idevid_cert: Option<X509>,
-    idevid_pub: Option<&'a [u8]>,
-    ip: Option<String>,
-    mtls_cert: Option<X509>,
-    parsed_registrar_ip: Option<String>,
-    port: Option<u32>,
-    registrar_ip: Option<String>,
+pub struct RegistrarClientBuilder {
+    registrar_current_api_version: Option<String>,
+    registrar_supported_api_versions: Option<Vec<String>>,
+    registrar_address: Option<String>,
     registrar_port: Option<u32>,
-    uuid: Option<&'a str>,
 }
 
-impl<'a> RegistrarClientBuilder<'a> {
+impl RegistrarClientBuilder {
     /// Create a new RegistrarClientBuilder object
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Set the public Attestation Key (AK) to include in the registration request
-    ///
-    /// # Arguments:
-    ///
-    /// * ak_pub (&'a [u8]): The buffer containing the marshalled public AK
-    pub fn ak_pub(mut self, ak_pub: &'a [u8]) -> Self {
-        self.ak_pub = Some(ak_pub);
-        self
-    }
-
-    /// Set the registrar API versions that are enabled
-    ///
-    /// # Arguments:
-    ///
-    /// * api_versions (Vec<&'a str>): The enabled API versions
-    pub fn enabled_api_versions(
-        mut self,
-        api_versions: Vec<&'a str>,
-    ) -> Self {
-        self.enabled_api_versions = Some(api_versions);
-        self
-    }
-
-    /// Set the public Endorsement Key (EK) to include in the registration request
-    ///
-    /// # Arguments:
-    ///
-    /// * ek_pub (&'a [u8]): The buffer containing the marshalled public EK
-    pub fn ek_pub(mut self, ek_pub: &'a [u8]) -> Self {
-        self.ek_pub = Some(ek_pub);
-        self
-    }
-
-    /// Set the Endorsement Key (EK) certificate to include in the registration request
-    ///
-    /// # Arguments:
-    ///
-    /// * ek_cert (String): A string containing the EK certificate in PEM format
-    pub fn ek_cert(mut self, ek_cert: String) -> Self {
-        self.ek_cert = Some(ek_cert);
-        self
-    }
-
-    /// Set the IAK attestation to include in the registration request
-    ///
-    /// This is obtained by certifying the IAK with the AK
-    ///
-    /// # Arguments:
-    ///
-    /// * iak_attest (Vec<u8>): A vector containing the IAK attestation
-    pub fn iak_attest(mut self, iak_attest: Vec<u8>) -> Self {
-        self.iak_attest = Some(iak_attest);
-        self
-    }
-
-    /// Set the IAK certificate to include in the registration request
-    ///
-    /// # Arguments:
-    ///
-    /// * iak_cert (X509): The IAK certificate
-    pub fn iak_cert(mut self, iak_cert: X509) -> Self {
-        self.iak_cert = Some(iak_cert);
-        self
-    }
-
-    /// Set the IAK attestation signature to include in the registration request
-    ///
-    /// # Arguments:
-    ///
-    /// * iak_sign (Vec<u8>): A vector containing the IAK attestation signature
-    pub fn iak_sign(mut self, iak_sign: Vec<u8>) -> Self {
-        self.iak_sign = Some(iak_sign);
-        self
-    }
-
-    /// Set the public IAK to include in the registration request
-    ///
-    /// # Arguments:
-    ///
-    /// * iak_pub <&'a [u8]>: The buffer containing the marshalled public IAK
-    pub fn iak_pub(mut self, iak_pub: &'a [u8]) -> Self {
-        self.iak_pub = Some(iak_pub);
-        self
-    }
-
-    /// Set the IDevID certificate to include in the registration request
-    ///
-    /// # Arguments:
-    ///
-    /// * idevid_cert (X509): The IDevID certificate
-    pub fn idevid_cert(mut self, idevid_cert: X509) -> Self {
-        self.idevid_cert = Some(idevid_cert);
-        self
-    }
-
-    /// Set the IDevID public key to include in the registration request
-    ///
-    /// # Arguments:
-    ///
-    /// * idevid_pub: The IDevID public key
-    pub fn idevid_pub(mut self, idevid_pub: &'a [u8]) -> Self {
-        self.idevid_pub = Some(idevid_pub);
-        self
-    }
-
-    /// Set the Agent contact IP to include in the registration request
-    ///
-    /// This is the Agent IP or hostname to be contacted when making requests
-    ///
-    /// # Arguments:
-    ///
-    /// * ip (String): The Agent contact IP
-    pub fn ip(mut self, ip: String) -> Self {
-        self.ip = Some(ip);
-        self
-    }
-
-    /// Set the Agent mTLS certificate to include in the registration request
-    ///
-    /// This is the certificate used when creating TLS connections to contact the Agent
-    ///
-    /// # Arguments:
-    ///
-    /// * mtls_cert (X509): The Agent mTLS certificate
-    pub fn mtls_cert(mut self, mtls_cert: X509) -> Self {
-        self.mtls_cert = Some(mtls_cert);
-        self
-    }
-
-    /// Set the Agent port to include in the registration request
-    ///
-    /// # Arguments:
-    ///
-    /// * port (u32): The port the Agent will listen to receive requests
-    pub fn port(mut self, port: u32) -> Self {
-        self.port = Some(port);
-        self
     }
 
     /// Set the registrar IP address or hostname to contact when registering the agent
     ///
     /// # Arguments:
     ///
-    /// * ip (String): The registrar IP or hostname
-    pub fn registrar_ip(mut self, ip: String) -> Self {
-        self.registrar_ip = Some(ip);
+    /// * address (String): The registrar IP or hostname
+    pub fn registrar_address(mut self, address: String) -> Self {
+        let a = RegistrarClientBuilder::parse_registrar_address(address);
+        self.registrar_address = Some(a);
         self
     }
 
@@ -257,64 +67,37 @@ impl<'a> RegistrarClientBuilder<'a> {
         self
     }
 
-    /// Set the agent UUID to include in the registration request
-    ///
-    /// # Arguments:
-    ///
-    /// * uuid (&'a str): The agent UUID
-    pub fn uuid(mut self, uuid: &'a str) -> Self {
-        self.uuid = Some(uuid);
-        self
-    }
-
-    /// Parse self.registrar_ip and store the result in self.parsed_registrar_ip
-    pub fn parse_registrar_ip(
-        &mut self,
-    ) -> Result<String, RegistrarClientBuilderError> {
-        if let Some(ref parsed_registrar_ip) = self.parsed_registrar_ip {
-            return Ok(parsed_registrar_ip.clone());
-        }
-
-        let Some(ref registrar_ip) = self.registrar_ip else {
-            return Err(RegistrarClientBuilderError::RegistrarIPNotSet);
-        };
-
+    /// Parse the received address
+    fn parse_registrar_address(address: String) -> String {
         // Parse the registrar IP or hostname
-        let remote_ip = match registrar_ip.parse::<IpAddr>() {
+        match address.parse::<IpAddr>() {
             Ok(addr) => {
                 // Add brackets if the address is IPv6
                 if addr.is_ipv6() {
-                    format!("[{registrar_ip}]")
+                    format!("[{address}]")
                 } else {
-                    registrar_ip.to_string()
+                    address.to_string()
                 }
             }
             Err(_) => {
                 // The registrar_ip option can also be a hostname.
-                // If it is the case, the hostname was already validated during configuration
-                registrar_ip.to_string()
+                // If it is the case, it is expected that the hostname was
+                // already validated during configuration
+                address.to_string()
             }
-        };
-
-        // Store the parsed IP or hostname
-        self.parsed_registrar_ip = Some(remote_ip.clone());
-        Ok(remote_ip)
+        }
     }
 
-    /// Get the registrar API version from the '/version' endpoint
-    pub async fn get_registrar_api_version(
+    /// Get the registrar API version from the Registrar '/version' endpoint
+    async fn get_registrar_api_version(
         &mut self,
     ) -> Result<String, RegistrarClientBuilderError> {
-        let registrar_ip = self.parse_registrar_ip()?;
+        let Some(ref registrar_ip) = self.registrar_address else {
+            return Err(RegistrarClientBuilderError::RegistrarIPNotSet);
+        };
 
         let Some(registrar_port) = self.registrar_port else {
             return Err(RegistrarClientBuilderError::RegistrarPortNotSet);
-        };
-
-        let Some(enabled_apis) = &self.enabled_api_versions else {
-            return Err(
-                RegistrarClientBuilderError::EnabledAPIVersionsNotSet,
-            );
         };
 
         // Try to reach the registrar
@@ -335,86 +118,24 @@ impl<'a> RegistrarClientBuilder<'a> {
 
         let resp: Response<KeylimeRegistrarVersion> = resp.json().await?;
 
-        let registrar_api_version = &resp.results.current_version;
+        self.registrar_current_api_version =
+            Some(resp.results.current_version.clone());
+        self.registrar_supported_api_versions =
+            Some(resp.results.supported_versions);
 
-        if enabled_apis.contains(&registrar_api_version.as_str()) {
-            Ok(registrar_api_version.to_string())
-        } else {
-            // Check if one of the API versions that the registrar supports is enabled
-            // from the latest to the oldest, assuming the reported versions are ordered from the
-            // oldest to the newest
-            for reg_supported_version in
-                resp.results.supported_versions.iter().rev()
-            {
-                if enabled_apis.contains(&reg_supported_version.as_str()) {
-                    return Ok(reg_supported_version.to_string());
-                }
-            }
-
-            warn!("Registrar at '{addr}' does not support any API version: agent enabled versions = '[{}]', registrar supported versions = '[{}]'", enabled_apis.join(", "), resp.results.supported_versions.join(", "));
-            Err(RegistrarClientBuilderError::IncompatibleAPI {
-                agent_enabled: enabled_apis.join(", "),
-                registrar_supported: resp
-                    .results
-                    .supported_versions
-                    .join(", "),
-            })
-        }
+        Ok(resp.results.current_version)
     }
 
     /// Generate the RegistrarClient object using the previously set options
     pub async fn build(
-        mut self,
-    ) -> Result<RegistrarClient<'a>, RegistrarClientBuilderError> {
-        let registrar_ip = self.parse_registrar_ip()?;
-
-        // Check that required fields were set and take from the builder
-        let Some(ak_pub) = self.ak_pub else {
-            return Err(RegistrarClientBuilderError::AKPubNotSet);
-        };
-
-        let Some(ip) = self.ip.take() else {
-            return Err(RegistrarClientBuilderError::AgentContactIPNotSet);
-        };
-
-        let Some(port) = self.port else {
-            return Err(RegistrarClientBuilderError::AgentPortNotSet);
-        };
-
-        let Some(uuid) = self.uuid.take() else {
-            return Err(RegistrarClientBuilderError::AgentUUIDNotSet);
-        };
-
-        let Some(ek_pub) = self.ek_pub else {
-            return Err(RegistrarClientBuilderError::EKPubNotSet);
+        &mut self,
+    ) -> Result<RegistrarClient, RegistrarClientBuilderError> {
+        let Some(registrar_ip) = self.registrar_address.clone() else {
+            return Err(RegistrarClientBuilderError::RegistrarIPNotSet);
         };
 
         let Some(registrar_port) = self.registrar_port else {
             return Err(RegistrarClientBuilderError::RegistrarPortNotSet);
-        };
-
-        let mtls_cert = match self.mtls_cert.take() {
-            Some(cert) => Some(
-                x509_to_pem(&cert)
-                    .map_err(RegistrarClientBuilderError::CertConvert)?,
-            ),
-            None => Some("disabled".to_string()),
-        };
-
-        let idevid_cert = match self.idevid_cert.take() {
-            Some(cert) => Some(
-                x509_to_der(&cert)
-                    .map_err(RegistrarClientBuilderError::CertConvert)?,
-            ),
-            None => None,
-        };
-
-        let iak_cert = match self.iak_cert.take() {
-            Some(cert) => Some(
-                x509_to_der(&cert)
-                    .map_err(RegistrarClientBuilderError::CertConvert)?,
-            ),
-            None => None,
         };
 
         // Get the registrar API version. If it was caused by an error in the request, set the
@@ -432,32 +153,13 @@ impl<'a> RegistrarClientBuilder<'a> {
                 },
             };
 
-        // Take the enabled_api_versions after calling get_registrar_api_version which uses it
-        let Some(enabled_api_versions) = self.enabled_api_versions.take()
-        else {
-            // This should never be reachable as get_registrar_api_version() checks that this is
-            // set
-            unreachable!();
-        };
-
         Ok(RegistrarClient {
-            enabled_api_versions,
-            ak_pub,
+            supported_api_versions: self
+                .registrar_supported_api_versions
+                .clone(),
             api_version: registrar_api_version,
-            ek_pub,
-            ek_cert: self.ek_cert,
-            iak_attest: self.iak_attest.take(),
-            iak_cert,
-            iak_sign: self.iak_sign.take(),
-            iak_pub: self.iak_pub,
-            idevid_cert,
-            idevid_pub: self.idevid_pub,
-            ip,
-            mtls_cert,
-            port,
             registrar_ip,
             registrar_port,
-            uuid,
         })
     }
 }
@@ -471,6 +173,17 @@ pub enum RegistrarClientError {
     /// All tried API versions were rejected
     #[error("None of the tried API versions were enabled: tried '{0}'")]
     AllAPIVersionsRejected(String),
+
+    /// Incompatible configured API versions
+    #[error("Registrar and agent API versions are incompatible: agent enabled APIs '{agent_enabled}', registrar supported APIs '{registrar_supported}'")]
+    IncompatibleAPI {
+        agent_enabled: String,
+        registrar_supported: String,
+    },
+
+    /// The information provided by the Registrar is inconsistent
+    #[error("Inconsistent information from registrar: current API version = '{0}', but no list of supported API versions was provided")]
+    Inconsistent(String),
 
     /// Error has no code
     #[error("cannot get error code for type {0}")]
@@ -486,24 +199,11 @@ pub enum RegistrarClientError {
 }
 
 #[derive(Default, Debug)]
-pub struct RegistrarClient<'a> {
-    ak_pub: &'a [u8],
+pub struct RegistrarClient {
     api_version: String,
-    ek_cert: Option<String>,
-    ek_pub: &'a [u8],
-    enabled_api_versions: Vec<&'a str>,
-    iak_attest: Option<Vec<u8>>,
-    iak_cert: Option<Vec<u8>>,
-    iak_pub: Option<&'a [u8]>,
-    iak_sign: Option<Vec<u8>>,
-    idevid_cert: Option<Vec<u8>>,
-    idevid_pub: Option<&'a [u8]>,
-    ip: String,
-    mtls_cert: Option<String>,
-    port: u32,
+    supported_api_versions: Option<Vec<String>>,
     registrar_ip: String,
     registrar_port: u32,
-    uuid: &'a str,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -570,34 +270,35 @@ struct Register<'a> {
     port: Option<u32>,
 }
 
-impl RegistrarClient<'_> {
+impl RegistrarClient {
     async fn try_register_agent(
         &self,
+        ai: &AgentIdentity<'_>,
         api_version: &str,
     ) -> Result<Vec<u8>, RegistrarClientError> {
         let data = Register {
-            aik_tpm: self.ak_pub,
-            ek_tpm: self.ek_pub,
-            ekcert: self.ek_cert.clone(),
-            iak_attest: self.iak_attest.clone(),
-            iak_cert: self.iak_cert.clone(),
-            iak_sign: self.iak_sign.clone(),
-            iak_tpm: self.iak_pub,
-            idevid_cert: self.idevid_cert.clone(),
-            idevid_tpm: self.idevid_pub,
-            ip: Some(self.ip.clone()),
-            mtls_cert: self.mtls_cert.clone(),
-            port: Some(self.port),
+            aik_tpm: ai.ak_pub,
+            ek_tpm: ai.ek_pub,
+            ekcert: ai.ek_cert.clone(),
+            iak_attest: ai.iak_attest.clone(),
+            iak_cert: ai.iak_cert.clone(),
+            iak_sign: ai.iak_sign.clone(),
+            iak_tpm: ai.iak_pub,
+            idevid_cert: ai.idevid_cert.clone(),
+            idevid_tpm: ai.idevid_pub,
+            ip: Some(ai.ip.clone()),
+            mtls_cert: ai.mtls_cert.clone(),
+            port: Some(ai.port),
         };
 
         let addr = format!(
             "http://{}:{}/v{}/agents/{}",
-            &self.registrar_ip, &self.registrar_port, api_version, &self.uuid
+            &self.registrar_ip, &self.registrar_port, api_version, &ai.uuid
         );
 
         info!(
             "Requesting agent registration from {} for {}",
-            &addr, &self.uuid
+            &addr, &ai.uuid
         );
 
         let resp = reqwest::Client::new()
@@ -618,6 +319,20 @@ impl RegistrarClient<'_> {
         Ok(resp.results.blob.unwrap_or_default())
     }
 
+    /// Log the warning about incompatible registrar and agent APIs and return the appropriate
+    /// error
+    fn incompatible(
+        &self,
+        agent_enabled: String,
+        registrar_supported: String,
+    ) -> RegistrarClientError {
+        warn!("Registrar at '{}' does not support any enabled API version: agent enabled versions = '[{agent_enabled}]', registrar supported versions = '[{registrar_supported}]'", self.registrar_ip);
+        RegistrarClientError::IncompatibleAPI {
+            agent_enabled,
+            registrar_supported,
+        }
+    }
+
     /// Register the agent using the previously set of parameters and receive the encrypted
     /// challenge as a binary blob.
     ///
@@ -629,47 +344,77 @@ impl RegistrarClient<'_> {
     /// * Encodes the AK name together with the encrypted challenge using base64
     pub async fn register_agent(
         &mut self,
+        ai: &AgentIdentity<'_>,
     ) -> Result<Vec<u8>, RegistrarClientError> {
+        // The current Registrar API version is enabled and should work
+        if ai.enabled_api_versions.contains(&self.api_version.as_ref()) {
+            return self.try_register_agent(ai, &self.api_version).await;
+        }
+
         // In case the registrar does not support the '/version' endpoint, try the enabled API
         // versions
         if self.api_version == UNKNOWN_API_VERSION {
             // Assume the list of enabled versions is ordered from the oldest to the newest
-            for api_version in self.enabled_api_versions.iter().rev() {
+            for api_version in ai.enabled_api_versions.iter().rev() {
                 info!("Trying to register agent using API version {api_version}");
-                let r = self.try_register_agent(api_version).await;
+                let r = self.try_register_agent(ai, api_version).await;
 
-                // If the registration was successful, register the API version to use for
-                // following requests
+                // If successful, cache the API version for future requests
                 if r.is_ok() {
                     self.api_version = api_version.to_string();
                     return r;
                 }
             }
+            // All enabled API versions were tried
+            Err(RegistrarClientError::AllAPIVersionsRejected(
+                ai.enabled_api_versions.join(", "),
+            ))
         } else {
-            return self.try_register_agent(&self.api_version).await;
-        }
+            // The current Registrar API version is not enabled.
+            // Find the latest enabled version that is supported
+            if let Some(ref supported) = self.supported_api_versions {
+                for api_version in ai.enabled_api_versions.iter().rev() {
+                    if supported.contains(&api_version.to_string()) {
+                        // Found a compatible API version, it should work
+                        let r =
+                            self.try_register_agent(ai, api_version).await;
 
-        // All enabled API versions were tried
-        Err(RegistrarClientError::AllAPIVersionsRejected(
-            self.enabled_api_versions.join(", "),
-        ))
+                        // If successful, cache the API version for future requests
+                        if r.is_ok() {
+                            self.api_version = api_version.to_string();
+                            return r;
+                        }
+                    }
+                }
+                // None of the enabled APIs is supported
+                Err(self.incompatible(
+                    ai.enabled_api_versions.join(", "),
+                    supported.join(", "),
+                ))
+            } else {
+                Err(RegistrarClientError::Inconsistent(
+                    self.api_version.to_string(),
+                ))
+            }
+        }
     }
 
     async fn try_activate_agent(
         &self,
         auth_tag: &str,
+        ai: &AgentIdentity<'_>,
         api_version: &str,
     ) -> Result<(), RegistrarClientError> {
         let data = Activate { auth_tag };
 
         let addr = format!(
             "http://{}:{}/v{}/agents/{}",
-            &self.registrar_ip, &self.registrar_port, api_version, &self.uuid
+            &self.registrar_ip, &self.registrar_port, api_version, &ai.uuid
         );
 
         info!(
             "Requesting agent activation from {} for {}",
-            &addr, &self.uuid
+            &addr, &ai.uuid
         );
 
         let resp =
@@ -702,35 +447,68 @@ impl RegistrarClient<'_> {
     ///
     /// # Arguments:
     ///
+    /// * ai (&AgentIdentity<'_>): The identity data of the Agent to be activated
     /// * auth_tag (&str): The authentication tag
     pub async fn activate_agent(
         &mut self,
+        ai: &AgentIdentity<'_>,
         auth_tag: &str,
     ) -> Result<(), RegistrarClientError> {
+        // The current Registrar API version is enabled and should work
+        if ai.enabled_api_versions.contains(&self.api_version.as_ref()) {
+            return self
+                .try_activate_agent(auth_tag, ai, &self.api_version)
+                .await;
+        }
+
         // In case the registrar does not support the '/version' endpoint, try the enabled API
         // versions
         if self.api_version == UNKNOWN_API_VERSION {
-            for api_version in &self.enabled_api_versions {
+            // Assume the list of enabled versions is ordered from the oldest to the newest
+            for api_version in ai.enabled_api_versions.iter().rev() {
                 info!("Trying to register agent using API version {api_version}");
-                let r = self.try_activate_agent(auth_tag, api_version).await;
+                let r =
+                    self.try_activate_agent(auth_tag, ai, api_version).await;
 
-                // If the registration was successful, register the API version to use for
-                // following requests
+                // If successful, cache the API version for future requests
                 if r.is_ok() {
                     self.api_version = api_version.to_string();
                     return r;
                 }
             }
+            // All enabled API versions were tried
+            Err(RegistrarClientError::AllAPIVersionsRejected(
+                ai.enabled_api_versions.join(", "),
+            ))
         } else {
-            return self
-                .try_activate_agent(auth_tag, &self.api_version)
-                .await;
-        }
+            // The current Registrar API version is not enabled.
+            // Find the latest enabled version that is supported
+            if let Some(ref supported) = self.supported_api_versions {
+                for api_version in ai.enabled_api_versions.iter().rev() {
+                    if supported.contains(&api_version.to_string()) {
+                        // Found a compatible API version, it should work
+                        let r = self
+                            .try_activate_agent(auth_tag, ai, api_version)
+                            .await;
 
-        // All enabled API versions were tried
-        Err(RegistrarClientError::AllAPIVersionsRejected(
-            self.enabled_api_versions.join(", "),
-        ))
+                        // If successful, cache the API version for future requests
+                        if r.is_ok() {
+                            self.api_version = api_version.to_string();
+                            return r;
+                        }
+                    }
+                }
+                // None of the enabled APIs is supported
+                Err(self.incompatible(
+                    ai.enabled_api_versions.join(", "),
+                    supported.join(", "),
+                ))
+            } else {
+                Err(RegistrarClientError::Inconsistent(
+                    self.api_version.to_string(),
+                ))
+            }
+        }
     }
 }
 
@@ -738,7 +516,7 @@ impl RegistrarClient<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crypto;
+    use crate::{agent_identity::AgentIdentityBuilder, crypto};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -792,7 +570,7 @@ mod tests {
             .build()
             .unwrap(); //#[allow_ci]
 
-        let response = RegistrarClientBuilder::new()
+        let ai = AgentIdentityBuilder::new()
             .ak_pub(&mock_data)
             .ek_pub(&mock_data)
             .ek_cert(mock_chain)
@@ -806,15 +584,21 @@ mod tests {
             .ip("1.2.3.4".to_string())
             .mtls_cert(cert.clone())
             .port(0)
-            .registrar_ip(ip.to_string())
-            .registrar_port(port)
             .uuid("uuid")
             .build()
+            .await
+            .expect("failed to build Agent Identity");
+
+        let response = RegistrarClientBuilder::new()
+            .registrar_address(ip.to_string())
+            .registrar_port(port)
+            .build()
             .await;
+
         assert!(response.is_ok(), "error: {:?}", response);
         let mut registrar_client = response.unwrap(); //#[allow_ci]
-        let response = registrar_client.register_agent().await;
-        assert!(response.is_ok());
+        let response = registrar_client.register_agent(&ai).await;
+        assert!(response.is_ok(), "error: {:?}", response);
     }
 
     #[actix_rt::test]
@@ -851,7 +635,7 @@ mod tests {
             .build()
             .unwrap(); //#[allow_ci]
 
-        let builder = RegistrarClientBuilder::new()
+        let ai = AgentIdentityBuilder::new()
             .ak_pub(&mock_data)
             .ek_pub(&mock_data)
             .ek_cert(mock_chain)
@@ -859,14 +643,19 @@ mod tests {
             .mtls_cert(cert)
             .ip("1.2.3.4".to_string())
             .port(0)
-            .registrar_ip(ip.to_string())
-            .registrar_port(port)
-            .uuid("uuid");
+            .uuid("uuid")
+            .build()
+            .await
+            .expect("failed to build Agent Identity");
+
+        let mut builder = RegistrarClientBuilder::new()
+            .registrar_address(ip.to_string())
+            .registrar_port(port);
 
         let mut registrar_client = builder.build().await.unwrap(); //#[allow_ci]
 
-        let response = registrar_client.register_agent().await;
-        assert!(response.is_ok());
+        let response = registrar_client.register_agent(&ai).await;
+        assert!(response.is_ok(), "error: {:?}", response);
     }
 
     #[actix_rt::test]
@@ -917,7 +706,7 @@ mod tests {
             .build()
             .unwrap(); //#[allow_ci]
 
-        let builder = RegistrarClientBuilder::new()
+        let ai = AgentIdentityBuilder::new()
             .ak_pub(&mock_data)
             .ek_pub(&mock_data)
             .ek_cert(mock_chain)
@@ -925,14 +714,19 @@ mod tests {
             .mtls_cert(cert)
             .ip("1.2.3.4".to_string())
             .port(0)
-            .registrar_ip(ip.to_string())
-            .registrar_port(port)
-            .uuid("uuid");
+            .uuid("uuid")
+            .build()
+            .await
+            .expect("failed to build Agent Identity");
+
+        let mut builder = RegistrarClientBuilder::new()
+            .registrar_address(ip.to_string())
+            .registrar_port(port);
 
         let mut registrar_client = builder.build().await.unwrap(); //#[allow_ci]
 
-        let response = registrar_client.register_agent().await;
-        assert!(response.is_ok());
+        let response = registrar_client.register_agent(&ai).await;
+        assert!(response.is_ok(), "error: {:?}", response);
     }
 
     #[actix_rt::test]
@@ -984,21 +778,26 @@ mod tests {
             .build()
             .unwrap(); //#[allow_ci]
 
-        let builder = RegistrarClientBuilder::new()
+        let ai = AgentIdentityBuilder::new()
             .ak_pub(&mock_data)
             .ek_pub(&mock_data)
             .enabled_api_versions(vec!["1.2"])
             .mtls_cert(cert)
             .ip("1.2.3.4".to_string())
             .port(0)
-            .registrar_ip(ip.to_string())
-            .registrar_port(port)
-            .uuid("uuid");
+            .uuid("uuid")
+            .build()
+            .await
+            .expect("failed to build Agent Identity");
+
+        let mut builder = RegistrarClientBuilder::new()
+            .registrar_address(ip.to_string())
+            .registrar_port(port);
 
         let mut registrar_client = builder.build().await.unwrap(); //#[allow_ci]
 
-        let response = registrar_client.register_agent().await;
-        assert!(response.is_ok());
+        let response = registrar_client.register_agent(&ai).await;
+        assert!(response.is_ok(), "error: {:?}", response);
     }
 
     #[actix_rt::test]
@@ -1022,20 +821,25 @@ mod tests {
             .build()
             .unwrap(); //#[allow_ci]
 
-        let builder = RegistrarClientBuilder::new()
+        let ai = AgentIdentityBuilder::new()
             .ak_pub(&mock_data)
             .ek_pub(&mock_data)
             .enabled_api_versions(vec!["1.2"])
             .mtls_cert(cert)
             .ip("1.2.3.4".to_string())
             .port(0)
-            .registrar_ip(ip.to_string())
-            .registrar_port(port)
-            .uuid("uuid");
+            .uuid("uuid")
+            .build()
+            .await
+            .expect("failed to build Agent Identity");
+
+        let mut builder = RegistrarClientBuilder::new()
+            .registrar_address(ip.to_string())
+            .registrar_port(port);
 
         let mut registrar_client = builder.build().await.unwrap(); //#[allow_ci]
 
-        let response = registrar_client.register_agent().await;
+        let response = registrar_client.register_agent(&ai).await;
         assert!(response.is_err());
     }
 
@@ -1090,8 +894,7 @@ mod tests {
             .build()
             .unwrap(); //#[allow_ci]
 
-        // Try to register with an unsupported API version
-        let response = RegistrarClientBuilder::new()
+        let ai = AgentIdentityBuilder::new()
             .ak_pub(&mock_data)
             .ek_pub(&mock_data)
             .ek_cert(mock_chain)
@@ -1099,13 +902,23 @@ mod tests {
             .mtls_cert(cert)
             .ip("1.2.3.4".to_string())
             .port(0)
-            .registrar_ip(ip.to_string())
-            .registrar_port(port)
             .uuid("uuid")
+            .build()
+            .await
+            .expect("failed to build Agent Identity");
+
+        // Try to register with an unsupported API version
+        let response = RegistrarClientBuilder::new()
+            .registrar_address(ip.to_string())
+            .registrar_port(port)
             .build()
             .await;
 
-        // The build process should fail as there is no compatible API version
+        // The build process should work, but the registration should fail
+        assert!(response.is_ok(), "error: {:?}", response);
+        let mut registrar_client =
+            response.expect("failed to build Registrar Client");
+        let response = registrar_client.register_agent(&ai).await;
         assert!(response.is_err());
     }
 
@@ -1151,20 +964,25 @@ mod tests {
 
         let mock_data = [0u8; 1];
 
-        let builder = RegistrarClientBuilder::new()
+        let ai = AgentIdentityBuilder::new()
             .ak_pub(&mock_data)
             .ek_pub(&mock_data)
             .enabled_api_versions(vec!["1.2"])
             .ip("1.2.3.4".to_string())
             .port(0)
-            .registrar_ip(ip.to_string())
-            .registrar_port(port)
-            .uuid("uuid");
+            .uuid("uuid")
+            .build()
+            .await
+            .expect("failed to build Agent Identity");
+
+        let mut builder = RegistrarClientBuilder::new()
+            .registrar_address(ip.to_string())
+            .registrar_port(port);
 
         let mut registrar_client = builder.build().await.unwrap(); //#[allow_ci]
 
-        let response = registrar_client.activate_agent("tag").await;
-        assert!(response.is_ok());
+        let response = registrar_client.activate_agent(&ai, "tag").await;
+        assert!(response.is_ok(), "error: {:?}", response);
     }
 
     #[actix_rt::test]
@@ -1193,21 +1011,26 @@ mod tests {
 
         let mock_data = [0u8; 1];
 
-        // Enable only a newer API version in the client
-        let builder = RegistrarClientBuilder::new()
+        let ai = AgentIdentityBuilder::new()
             .ak_pub(&mock_data)
             .ek_pub(&mock_data)
             .enabled_api_versions(vec!["1.2", "3.4"])
             .ip("1.2.3.4".to_string())
             .port(0)
-            .registrar_ip(ip.to_string())
-            .registrar_port(port)
-            .uuid("uuid");
+            .uuid("uuid")
+            .build()
+            .await
+            .expect("failed to build Agent Identity");
+
+        // Enable only a newer API version in the client
+        let mut builder = RegistrarClientBuilder::new()
+            .registrar_address(ip.to_string())
+            .registrar_port(port);
 
         let mut registrar_client = builder.build().await.unwrap(); //#[allow_ci]
 
-        let response = registrar_client.activate_agent("tag").await;
-        assert!(response.is_ok());
+        let response = registrar_client.activate_agent(&ai, "tag").await;
+        assert!(response.is_ok(), "error: {:?}", response);
     }
 
     #[actix_rt::test]
@@ -1253,20 +1076,26 @@ mod tests {
 
         let mock_data = [0u8; 1];
 
-        let builder = RegistrarClientBuilder::new()
+        let ai = AgentIdentityBuilder::new()
             .ak_pub(&mock_data)
             .ek_pub(&mock_data)
             .enabled_api_versions(vec!["1.2", "3.4"])
             .ip("1.2.3.4".to_string())
             .port(0)
-            .registrar_ip(ip.to_string())
+            .uuid("uuid")
+            .build()
+            .await
+            .expect("failed to build Agent Identity");
+
+        let mut registrar_client = RegistrarClientBuilder::new()
+            .registrar_address(ip.to_string())
             .registrar_port(port)
-            .uuid("uuid");
+            .build()
+            .await
+            .expect("failed top build Registrar Client");
 
-        let mut registrar_client = builder.build().await.unwrap(); //#[allow_ci]
-
-        let response = registrar_client.activate_agent("tag").await;
-        assert!(response.is_ok());
+        let response = registrar_client.activate_agent(&ai, "tag").await;
+        assert!(response.is_ok(), "error: {:?}", response);
     }
 
     #[actix_rt::test]
@@ -1313,20 +1142,30 @@ mod tests {
 
         let mock_data = [0u8; 1];
 
-        // Try to activate with an unsupported API version
-        let response = RegistrarClientBuilder::new()
+        let ai = AgentIdentityBuilder::new()
             .ak_pub(&mock_data)
             .ek_pub(&mock_data)
             .enabled_api_versions(vec!["1.2"])
             .ip("1.2.3.4".to_string())
             .port(0)
-            .registrar_ip(ip.to_string())
-            .registrar_port(port)
             .uuid("uuid")
+            .build()
+            .await
+            .expect("failed to build Agent Identity");
+
+        // Try to activate with an unsupported API version
+        let response = RegistrarClientBuilder::new()
+            .registrar_address(ip.to_string())
+            .registrar_port(port)
             .build()
             .await;
 
-        // The build process should fail as there is no compatible API version
+        // The build process should work, but the activation should fail as
+        // there is no compatible API version
+        assert!(response.is_ok(), "error: {:?}", response);
+        let mut registrar_client =
+            response.expect("failed to build Registrar Client");
+        let response = registrar_client.activate_agent(&ai, "tag").await;
         assert!(response.is_err());
     }
 
@@ -1345,35 +1184,33 @@ mod tests {
 
         let mock_data = [0u8; 1];
 
-        let builder = RegistrarClientBuilder::new()
+        let ai = AgentIdentityBuilder::new()
             .ak_pub(&mock_data)
             .ek_pub(&mock_data)
             .enabled_api_versions(vec!["1.2"])
             .ip("1.2.3.4".to_string())
             .port(0)
-            .registrar_ip(ip.to_string())
-            .registrar_port(port)
-            .uuid("uuid");
+            .uuid("uuid")
+            .build()
+            .await
+            .expect("failed to build Agent Identity");
 
-        let mut registrar_client = builder.build().await.unwrap(); //#[allow_ci]
+        let mut builder = RegistrarClientBuilder::new()
+            .registrar_address(ip.to_string())
+            .registrar_port(port);
 
-        let response = registrar_client.activate_agent("tag").await;
+        let mut registrar_client = builder
+            .build()
+            .await
+            .expect("failed to build Registrar Client");
+
+        let response = registrar_client.activate_agent(&ai, "tag").await;
         assert!(response.is_err());
     }
 
     #[actix_rt::test]
     async fn test_build_missing_required() {
-        let mock_data = [0u8; 1];
-        let required = [
-            "ak_pub",
-            "ek_pub",
-            "enabled_api_versions",
-            "ip",
-            "port",
-            "registrar_ip",
-            "registrar_port",
-            "uuid",
-        ];
+        let required = ["registrar_address", "registrar_port"];
 
         for to_skip in required.iter() {
             // Add all required fields but the one to skip
@@ -1381,36 +1218,12 @@ mod tests {
                 required.iter().filter(|&x| x != to_skip).copied().collect();
             let mut builder = RegistrarClientBuilder::new();
 
-            if to_add.contains(&"ak_pub") {
-                builder = builder.ak_pub(&mock_data);
-            }
-
-            if to_add.contains(&"ek_pub") {
-                builder = builder.ek_pub(&mock_data);
-            }
-
-            if to_add.contains(&"enabled_api_versions") {
-                builder = builder.enabled_api_versions(vec!["1.2"]);
-            }
-
-            if to_add.contains(&"ip") {
-                builder = builder.ip("1.2.3.4".to_string());
-            }
-
-            if to_add.contains(&"port") {
-                builder = builder.port(0);
-            }
-
-            if to_add.contains(&"registrar_ip") {
-                builder = builder.registrar_ip("1.2.3.5".to_string());
+            if to_add.contains(&"registrar_address") {
+                builder = builder.registrar_address("1.2.3.5".to_string());
             }
 
             if to_add.contains(&"registrar_port") {
                 builder = builder.registrar_port(8891);
-            }
-
-            if to_add.contains(&"uuid") {
-                builder = builder.uuid("uuid");
             }
 
             let result = builder.build().await;


### PR DESCRIPTION
Introduce a new `AgentIdentity` structure that contains the Agent identity information, removing the corresponding data from the `RegistrarClient` structure.