### PR TITLE
Fix race conditions in tests

### DIFF
--- a/keylime-agent/src/payloads.rs
+++ b/keylime-agent/src/payloads.rs
@@ -343,6 +343,13 @@ mod tests {
     };
     use tokio::sync::mpsc;
 
+    #[cfg(feature = "testing")]
+    use std::sync::OnceLock;
+    #[cfg(feature = "testing")]
+    use tokio::sync::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard};
+    #[cfg(feature = "testing")]
+    pub static MUTEX: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+
     // Enough length for testing both AES-128 and AES-256
     const U: &[u8; AES_256_KEY_LEN] = b"01234567890123456789012345678901";
     const V: &[u8; AES_256_KEY_LEN] = b"ABCDEFGHIJABCDEFGHIJABCDEFGHIJAB";
@@ -466,6 +473,10 @@ echo hello > test-output
     #[cfg(feature = "testing")]
     #[actix_rt::test]
     async fn test_run_encrypted_payload() {
+        let _mutex = MUTEX
+            .get_or_init(|| Arc::new(AsyncMutex::new(())))
+            .lock()
+            .await;
         let test_config = KeylimeConfig::default();
         let temp_workdir = tempfile::tempdir().unwrap(); //#[allow_ci]
         let secure_mount =
@@ -510,6 +521,10 @@ echo hello > test-output
     #[cfg(feature = "testing")]
     #[actix_rt::test]
     async fn test_payload_worker() {
+        let _mutex = MUTEX
+            .get_or_init(|| Arc::new(AsyncMutex::new(())))
+            .lock()
+            .await;
         use crate::{config::DEFAULT_PAYLOAD_SCRIPT, secure_mount};
 
         let test_config = KeylimeConfig::default();

--- a/keylime/src/cert.rs
+++ b/keylime/src/cert.rs
@@ -91,62 +91,54 @@ mod tests {
 
     #[test]
     fn test_cert_from_server_key() {
-        const TEST_CERT_PATH: &str = "test_cert.pem";
-        const TEST_KEY_PATH: &str = "test_key.pem";
-        // Ensure the test cert file does not exist before the test
-        let _ = std::fs::remove_file(TEST_CERT_PATH);
-        let _ = std::fs::remove_file(TEST_KEY_PATH);
+        let temp_dir =
+            tempfile::tempdir().expect("failed to create temporary dir");
+        let cert_path = temp_dir.path().join("test_cert.pem");
+        let key_path = temp_dir.path().join("test_key.pem");
         let config = CertificateConfig {
             agent_uuid: "test-uuid".to_string(),
             contact_ip: "1.2.3.4".to_string(),
             contact_port: 8080,
-            server_cert: TEST_CERT_PATH.to_string(),
-            server_key: TEST_KEY_PATH.to_string(),
+            server_cert: cert_path.display().to_string(),
+            server_key: key_path.display().to_string(),
             server_key_password: "test_password".to_string(),
         };
         let result = cert_from_server_key(&config);
         assert!(result.is_ok());
-        // Clean up the test cert file after the test
-        let _ = std::fs::remove_file(TEST_CERT_PATH);
-        let _ = std::fs::remove_file(TEST_KEY_PATH);
     } // test_cert_from_server_key
 
     #[test]
     fn test_cert_no_server_key() {
-        const TEST_CERT_PATH: &str = "test_cert2.pem";
-        // Ensure the test cert file does not exist before the test
-        let _ = std::fs::remove_file(TEST_CERT_PATH);
+        let temp_dir =
+            tempfile::tempdir().expect("failed to create temporary dir");
+        let cert_path = temp_dir.path().join("test_cert.pem");
         let config = CertificateConfig {
             agent_uuid: "test-uuid".to_string(),
             contact_ip: "1.2.3.4".to_string(),
             contact_port: 8080,
-            server_cert: TEST_CERT_PATH.to_string(),
+            server_cert: cert_path.display().to_string(),
             server_key: "".to_string(),
             server_key_password: "test_password2".to_string(),
         };
         let result = cert_from_server_key(&config);
         assert!(result.is_ok());
-        // Clean up the test cert file after the test
-        let _ = std::fs::remove_file(TEST_CERT_PATH);
     } // test_cert_no_server_key
 
     #[test]
     fn test_cert_no_server_cert() {
-        // Ensure the test cert file does not exist before the test
-        const TEST_KEY_PATH: &str = "test_key.pem";
-        let _ = std::fs::remove_file(TEST_KEY_PATH);
+        let temp_dir =
+            tempfile::tempdir().expect("failed to create temporary dir");
+        let key_path = temp_dir.path().join("test_key.pem");
         let config = CertificateConfig {
             agent_uuid: "test-uuid".to_string(),
             contact_ip: "1.2.3.4".to_string(),
             contact_port: 8080,
             server_cert: "".to_string(),
-            server_key: TEST_KEY_PATH.to_string(),
+            server_key: key_path.display().to_string(),
             server_key_password: "test_password".to_string(),
         };
         let result = cert_from_server_key(&config);
         assert!(result.is_ok());
-        // Clean up the test key file after the test
-        let _ = std::fs::remove_file(TEST_KEY_PATH);
     } // test_cert_no_server_cert
 
     #[test]
@@ -165,23 +157,19 @@ mod tests {
 
     #[test]
     fn test_cert_correct_server_key_path() {
-        const TEST_KEY_PATH: &str = "test_key2.pem";
-        const TEST_CERT_PATH: &str = "test_cert4.pem";
-        // Ensure the test key file does not exist before the test
-        let _ = std::fs::remove_file(TEST_KEY_PATH);
-        let _ = std::fs::remove_file(TEST_CERT_PATH);
+        let temp_dir =
+            tempfile::tempdir().expect("failed to create temporary dir");
+        let cert_path = temp_dir.path().join("test_cert.pem");
+        let key_path = temp_dir.path().join("test_key.pem");
         let config = CertificateConfig {
             agent_uuid: "test-uuid".to_string(),
             contact_ip: "1.2.3.4".to_string(),
             contact_port: 8080,
-            server_cert: TEST_CERT_PATH.to_string(),
-            server_key: TEST_KEY_PATH.to_string(),
+            server_cert: cert_path.display().to_string(),
+            server_key: key_path.display().to_string(),
             server_key_password: "test_password4".to_string(),
         };
         let result = cert_from_server_key(&config);
         assert!(result.is_ok());
-        // Clean up files after the test
-        let _ = std::fs::remove_file(TEST_KEY_PATH);
-        let _ = std::fs::remove_file(TEST_CERT_PATH);
     } // test_cert_correct_server_key_path
 }


### PR DESCRIPTION
Some tests could fail due to race conditions:

- In `keylime-agent/src/payloads.rs`, the `test_run_encrypted_payload()` and `test_payload_worker()` could affect each other because both set the environment variable `KEYLIME_TEST_DIR`
- In `keylime/src/cert.rs`, the `test_cert_no_server_cert()` and `test_server_from_server_key()` could delete each other's files because they used the same path
  - This was fixed by using a temporary directory for each test, which also avoids the need for cleanup before and after the test