### PR TITLE
tests: Do not assume `/var/lib/keylime` exists

### DIFF
--- a/keylime-agent/src/keys_handler.rs
+++ b/keylime-agent/src/keys_handler.rs
@@ -607,7 +607,6 @@ mod tests {
         encrypt_aead, pkey_pub_from_pem, rsa_oaep_encrypt,
     };
     use crate::{
-        config::KeylimeConfig,
         crypto::{compute_hmac, AES_128_KEY_LEN, AES_256_KEY_LEN},
         payloads,
     };
@@ -627,6 +626,9 @@ mod tests {
         path::{Path, PathBuf},
     };
     use tokio::sync::mpsc;
+
+    #[cfg(feature = "testing")]
+    use crate::config::get_testing_config;
 
     // Enough length for testing both AES-128 and AES-256
     const U: &[u8; AES_256_KEY_LEN] = b"01234567890123456789012345678901";
@@ -877,11 +879,12 @@ mod tests {
 
     #[cfg(feature = "testing")]
     async fn test_u_or_v_key(key_len: usize, payload: Option<&[u8]>) {
-        let test_config = KeylimeConfig::default();
-        let (mut fixture, mutex) = QuoteData::fixture().await.unwrap(); //#[allow_ci]
-
         // Create temporary working directory and secure mount
         let temp_workdir = tempfile::tempdir().unwrap(); //#[allow_ci]
+        let test_config = get_testing_config(temp_workdir.path());
+
+        let (mut fixture, mutex) = QuoteData::fixture().await.unwrap(); //#[allow_ci]
+
         fixture.secure_mount =
             PathBuf::from(&temp_workdir.path().join("tmpfs-dev"));
         fs::create_dir(&fixture.secure_mount).unwrap(); //#[allow_ci]

--- a/keylime-agent/src/revocation.rs
+++ b/keylime-agent/src/revocation.rs
@@ -521,9 +521,15 @@ mod tests {
     // Used to create symbolic links
     use std::os::unix::fs::symlink;
 
+    #[cfg(feature = "testing")]
+    use keylime::config::get_testing_config;
+
+    #[cfg(feature = "testing")]
     #[test]
     fn revocation_scripts_ok() {
-        let test_config = KeylimeConfig::default();
+        let work_dir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+        let test_config = get_testing_config(work_dir.path());
         let json_file = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/tests/unzipped/test_ok.json"
@@ -532,7 +538,6 @@ mod tests {
         let json = serde_json::from_str(&json_str).unwrap(); //#[allow_ci]
         let actions_dir =
             &Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/actions/");
-        let work_dir = tempfile::tempdir().unwrap(); //#[allow_ci]
         let tmpfs_dir = work_dir.path().join("tmpfs-dev"); //#[allow_ci]
         fs::create_dir(&tmpfs_dir).unwrap(); //#[allow_ci]
         let unzipped_dir =
@@ -560,9 +565,12 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "testing")]
     #[test]
     fn revocation_scripts_err() {
-        let test_config = KeylimeConfig::default();
+        let work_dir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+        let test_config = get_testing_config(work_dir.path());
         let json_file = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/tests/unzipped/test_err.json"
@@ -571,7 +579,6 @@ mod tests {
         let json = serde_json::from_str(&json_str).unwrap(); //#[allow_ci]
         let actions_dir =
             &Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/actions/");
-        let work_dir = tempfile::tempdir().unwrap(); //#[allow_ci]
         let tmpfs_dir = work_dir.path().join("tmpfs-dev"); //#[allow_ci]
         fs::create_dir(&tmpfs_dir).unwrap(); //#[allow_ci]
         let unzipped_dir =
@@ -588,9 +595,12 @@ mod tests {
         assert!(outputs.is_err());
     }
 
+    #[cfg(feature = "testing")]
     #[test]
     fn revocation_scripts_from_config() {
-        let mut test_config = KeylimeConfig::default();
+        let work_dir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+        let test_config = get_testing_config(work_dir.path());
         let json_file = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/tests/unzipped/test_ok.json"
@@ -606,7 +616,6 @@ mod tests {
         let json = serde_json::from_str(&json_str).unwrap(); //#[allow_ci]
         let actions_dir =
             &Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/actions/");
-        let work_dir = tempfile::tempdir().unwrap(); //#[allow_ci]
         let tmpfs_dir = work_dir.path().join("tmpfs-dev"); //#[allow_ci]
         fs::create_dir(&tmpfs_dir).unwrap(); //#[allow_ci]
         let unzipped_dir =
@@ -754,9 +763,12 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "testing")]
     #[test]
     fn test_process_revocation() {
-        let test_config = KeylimeConfig::default();
+        let work_dir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+        let test_config = get_testing_config(work_dir.path());
 
         let sig_path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("test-data/revocation.sig");
@@ -776,8 +788,7 @@ mod tests {
         let actions_dir =
             Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/actions");
 
-        let work_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
-        let tmpfs_dir = work_dir.join("tmpfs-dev");
+        let tmpfs_dir = work_dir.path().join("tmpfs-dev");
 
         let result = process_revocation(
             revocation,
@@ -785,7 +796,7 @@ mod tests {
             &actions_dir,
             None,
             test_config.agent.allow_payload_revocation_actions,
-            &work_dir,
+            work_dir.path(),
             &tmpfs_dir,
         );
 

--- a/keylime/src/agent_data.rs
+++ b/keylime/src/agent_data.rs
@@ -71,15 +71,15 @@ impl AgentData {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        algorithms::EncryptionAlgorithm, config::KeylimeConfig, hash_ek,
-    };
+    use crate::{algorithms::EncryptionAlgorithm, config, hash_ek};
 
     #[tokio::test]
-    #[cfg(feature = "testing")]
     async fn test_agent_data() -> Result<()> {
         let _mutex = tpm::testing::lock_tests().await;
-        let config = KeylimeConfig::default();
+
+        let tempdir =
+            tempfile::tempdir().expect("failed to create temporary dir");
+        let config = config::get_testing_config(tempdir.path());
 
         let mut ctx = tpm::Context::new().unwrap(); //#[allow_ci]
 
@@ -136,7 +136,9 @@ mod test {
     #[tokio::test]
     async fn test_hash() -> Result<()> {
         let _mutex = tpm::testing::lock_tests().await;
-        let config = KeylimeConfig::default();
+        let tempdir =
+            tempfile::tempdir().expect("failed to create temporary dir");
+        let config = config::get_testing_config(tempdir.path());
 
         let mut ctx = tpm::Context::new().unwrap(); //#[allow_ci]
 

--- a/keylime/src/config/base.rs
+++ b/keylime/src/config/base.rs
@@ -759,9 +759,12 @@ mod tests {
 
     #[test]
     fn test_hostname_support() {
+        let tempdir =
+            tempfile::tempdir().expect("failed to create temporary dir");
         let default = AgentConfig::default();
 
         let modified = AgentConfig {
+            keylime_dir: tempdir.path().display().to_string(),
             ip: "localhost".to_string(),
             contact_ip: "contact.ip".to_string(),
             registrar_ip: "registrar.ip".to_string(),
@@ -798,8 +801,12 @@ mod tests {
 
     #[test]
     fn get_revocation_cert_path_absolute() {
+        let tempdir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 revocation_cert: "/test/cert.crt".to_string(),
                 ..Default::default()
             },
@@ -814,8 +821,12 @@ mod tests {
 
     #[test]
     fn get_revocation_cert_path_relative() {
+        let tempdir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 revocation_cert: "cert.crt".to_string(),
                 ..Default::default()
             },
@@ -833,8 +844,12 @@ mod tests {
 
     #[test]
     fn get_revocation_notification_ip_empty() {
+        let tempdir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 enable_revocation_notifications: true,
                 revocation_notification_ip: "".to_string(),
                 ..Default::default()
@@ -845,6 +860,7 @@ mod tests {
         assert!(result.is_err());
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 enable_revocation_notifications: false,
                 revocation_notification_ip: "".to_string(),
                 ..Default::default()
@@ -863,8 +879,12 @@ mod tests {
 
     #[test]
     fn get_revocation_cert_empty() {
+        let tempdir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 enable_revocation_notifications: true,
                 revocation_cert: "".to_string(),
                 ..Default::default()
@@ -875,6 +895,7 @@ mod tests {
         assert!(result.is_err());
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 enable_revocation_notifications: false,
                 revocation_cert: "".to_string(),
                 ..Default::default()
@@ -888,8 +909,12 @@ mod tests {
 
     #[test]
     fn get_revocation_actions_dir_empty() {
+        let tempdir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 enable_revocation_notifications: true,
                 revocation_actions_dir: "".to_string(),
                 ..Default::default()
@@ -900,6 +925,7 @@ mod tests {
         assert!(result.is_err());
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 enable_revocation_notifications: false,
                 revocation_actions_dir: "".to_string(),
                 ..Default::default()
@@ -913,8 +939,12 @@ mod tests {
 
     #[test]
     fn test_invalid_revocation_actions_dir() {
+        let tempdir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 enable_revocation_notifications: true,
                 revocation_actions_dir: "/invalid".to_string(),
                 ..Default::default()
@@ -925,6 +955,7 @@ mod tests {
         assert!(result.is_err());
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 enable_revocation_notifications: false,
                 revocation_actions_dir: "/invalid".to_string(),
                 ..Default::default()
@@ -953,9 +984,13 @@ mod tests {
 
     #[test]
     fn test_invalid_api_versions() {
+        let tempdir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+
         // Check that invalid API versions are ignored
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 api_versions: "invalid.api".to_string(),
                 ..Default::default()
             },
@@ -966,6 +1001,7 @@ mod tests {
         // Check that unsupported API versions are ignored
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 api_versions: "['0.0']".to_string(),
                 ..Default::default()
             },
@@ -976,6 +1012,7 @@ mod tests {
         // Check that 'latest' keyword is supported
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 api_versions: "\"latest\"".to_string(),
                 ..Default::default()
             },
@@ -986,8 +1023,12 @@ mod tests {
 
     #[test]
     fn test_translate_api_versions_latest_keyword() {
+        let tempdir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 api_versions: "latest".to_string(),
                 ..Default::default()
             },
@@ -1004,13 +1045,17 @@ mod tests {
         assert_eq!(version, expected);
     }
 
-    #[cfg(feature = "testing")]
     #[test]
     fn test_translate_api_versions_default_keyword() {
         let tempdir =
             tempfile::tempdir().expect("failed to create temporary dir");
-        let default = get_testing_config(tempdir.path());
-        let result = config_translate_keywords(&default);
+        let test_config = KeylimeConfig {
+            agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
+                ..Default::default()
+            },
+        };
+        let result = config_translate_keywords(&test_config);
         assert!(result.is_ok());
         let config = result.unwrap(); //#[allow_ci]
         let version = config.agent.api_versions;
@@ -1024,10 +1069,13 @@ mod tests {
 
     #[test]
     fn test_translate_api_versions_old_supported() {
+        let tempdir =
+            tempfile::tempdir().expect("failed to create temporary dir");
         let old = SUPPORTED_API_VERSIONS[0];
 
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 api_versions: old.to_string(),
                 ..Default::default()
             },
@@ -1041,10 +1089,13 @@ mod tests {
 
     #[test]
     fn test_translate_invalid_api_versions_filtered() {
+        let tempdir =
+            tempfile::tempdir().expect("failed to create temporary dir");
         let old = SUPPORTED_API_VERSIONS[0];
 
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 api_versions: format!("a.b, {old}, c.d"),
                 ..Default::default()
             },
@@ -1058,10 +1109,13 @@ mod tests {
 
     #[test]
     fn test_translate_invalid_api_versions_fallback_default() {
+        let tempdir =
+            tempfile::tempdir().expect("failed to create temporary dir");
         let old = SUPPORTED_API_VERSIONS;
 
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 api_versions: "a.b, c.d".to_string(),
                 ..Default::default()
             },
@@ -1075,6 +1129,8 @@ mod tests {
 
     #[test]
     fn test_translate_api_versions_sort() {
+        let tempdir =
+            tempfile::tempdir().expect("failed to create temporary dir");
         let old = SUPPORTED_API_VERSIONS;
         let reversed = SUPPORTED_API_VERSIONS
             .iter()
@@ -1085,6 +1141,7 @@ mod tests {
 
         let test_config = KeylimeConfig {
             agent: AgentConfig {
+                keylime_dir: tempdir.path().display().to_string(),
                 api_versions: reversed,
                 ..Default::default()
             },


### PR DESCRIPTION
The tests would fail when executed in an environment where the `/var/lib/keylime` path does not exist or is not accessible.
This makes the tests to not rely on the existence of  `/var/lib/keylime` and use a temporary directory instead.

For this a `get_testing_config()` method was added to the `config` crate, available only when the `testing` feature  is enabled. This method returns a `KeylimeConfig` structure, but with the `keylime_dir` option set to the given directory.

In tests, the calls to `KeylimeConfig::default()` were replaced by calls to `get_testing_config()`. Alternatively, when the `KeylimeConfig` structure was constructed manually, the `keylime_dir` option was set as an existing temporary directory.

The goal is to make the tests to pass even when executed in an environment where Keylime is not installed yet, for example during packit RPM building which is currently broken.