### PR TITLE
Add disallowed_signing_algorithms, avoid ecschnorr

### DIFF
--- a/keylime-push-model-agent/src/main.rs
+++ b/keylime-push-model-agent/src/main.rs
@@ -234,6 +234,9 @@ fn init_context<T: PushModelConfigTrait>(
                     tpm_hash_alg: config.tpm_hash_alg().to_string(),
                     tpm_signing_alg: config.tpm_signing_alg().to_string(),
                     agent_data_path: config.agent_data_path().to_string(),
+                    disabled_signing_algorithms: config
+                        .disabled_signing_algorithms()
+                        .clone(),
                 },
             )?;
             Ok(Some(context_info))

--- a/keylime-push-model-agent/src/registration.rs
+++ b/keylime-push-model-agent/src/registration.rs
@@ -101,6 +101,7 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: "".to_string(),
+            disabled_signing_algorithms: vec![],
         };
         let mut context_info = ContextInfo::new_from_str(alg_config)
             .expect("Failed to create context info from string");

--- a/keylime-push-model-agent/src/struct_filler.rs
+++ b/keylime-push-model-agent/src/struct_filler.rs
@@ -669,6 +669,7 @@ mod tests {
                 tpm_hash_alg: config.tpm_hash_alg().to_string(),
                 tpm_signing_alg: config.tpm_signing_alg().to_string(),
                 agent_data_path: "".to_string(),
+                disabled_signing_algorithms: vec![],
             },
         )
         .expect("Failed to create context info from string");
@@ -693,6 +694,7 @@ mod tests {
                 tpm_hash_alg: config.tpm_hash_alg().to_string(),
                 tpm_signing_alg: config.tpm_signing_alg().to_string(),
                 agent_data_path: "".to_string(),
+                disabled_signing_algorithms: vec![],
             },
         )
         .expect("Failed to create context info from string");
@@ -717,6 +719,7 @@ mod tests {
                 tpm_hash_alg: config.tpm_hash_alg().to_string(),
                 tpm_signing_alg: config.tpm_signing_alg().to_string(),
                 agent_data_path: "".to_string(),
+                disabled_signing_algorithms: vec![],
             },
         )
         .expect("Failed to create context info from string");

--- a/keylime/src/config/base.rs
+++ b/keylime/src/config/base.rs
@@ -84,6 +84,7 @@ pub static DEFAULT_SERVER_KEY_PASSWORD: &str = "";
 pub static DEFAULT_TRUSTED_CLIENT_CA: &str = "cv_ca/cacert.crt";
 
 // Push attestation agent option defaults
+pub const DEFAULT_DISABLED_SIGNING_ALGORITHMS: &[&str] = &["ecschnorr"];
 pub const DEFAULT_IMA_LOGS_APPENDABLE: bool = true;
 pub const DEFAULT_IMA_LOGS_FORMATS: &str = "text/plain";
 pub const DEFAULT_IMA_LOGS_SUPPORTS_PARTIAL_ACCESS: bool = true;
@@ -106,6 +107,7 @@ pub static DEFAULT_PUSH_EK_HANDLE: &str = "";
 pub struct AgentConfig {
     pub agent_data_path: String,
     pub api_versions: String,
+    pub disabled_signing_algorithms: Vec<String>,
     pub ek_handle: String,
     pub enable_iak_idevid: bool,
     pub iak_cert: String,
@@ -251,6 +253,10 @@ impl Default for AgentConfig {
             contact_ip: DEFAULT_CONTACT_IP.to_string(),
             contact_port: DEFAULT_CONTACT_PORT,
             dec_payload_file: DEFAULT_DEC_PAYLOAD_FILE.to_string(),
+            disabled_signing_algorithms: DEFAULT_DISABLED_SIGNING_ALGORITHMS
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
             ek_handle: DEFAULT_EK_HANDLE.to_string(),
             enable_agent_mtls: DEFAULT_ENABLE_AGENT_MTLS,
             enable_iak_idevid: DEFAULT_ENABLE_IAK_IDEVID,

--- a/keylime/src/config/push_model.rs
+++ b/keylime/src/config/push_model.rs
@@ -36,6 +36,7 @@ pub struct PushModelConfig {
     certification_keys_server_identifier: String,
     contact_ip: String,
     contact_port: u32,
+    disabled_signing_algorithms: Vec<String>,
     enable_iak_idevid: bool,
     #[transform(using = override_default_ek_handle, error = OverrideError)]
     ek_handle: String,


### PR DESCRIPTION
This change introduces a new configuration option, disabled_signing_algorithms, to prevent the agent from using certain signing schemes, even if they are reported as supported by the TPM.

The primary motivation is to avoid issues with the `ecschnorr` algorithm, which, while technically supported by some TPMs, has been observed to cause rejection from Verifier.