### PR TITLE
Fix clippy warnings about uninlined format arguments

### DIFF
--- a/keylime-agent/src/keys_handler.rs
+++ b/keylime-agent/src/keys_handler.rs
@@ -331,7 +331,7 @@ async fn pubkey(
             HttpResponse::Ok().json(response)
         }
         Err(e) => {
-            debug!("Unable to retrieve public key: {:?}", e);
+            debug!("Unable to retrieve public key: {e:?}");
             HttpResponse::InternalServerError().json(JsonWrapper::error(
                 500,
                 "Unable to retrieve public key".to_string(),
@@ -415,7 +415,7 @@ async fn verify(
                 HttpResponse::Ok().json(response)
             }
             Err(e) => {
-                warn!("GET key challenge failed: {:?}", e);
+                warn!("GET key challenge failed: {e:?}");
                 HttpResponse::InternalServerError().json(JsonWrapper::error(
                     500,
                     "GET key challenge failed".to_string(),
@@ -934,7 +934,7 @@ mod tests {
             let result = worker(true, uuid_clone, keys_rx, p_tx).await;
 
             if result.is_err() {
-                debug!("keys worker failed: {:?}", result);
+                debug!("keys worker failed: {result:?}");
             }
         })));
 

--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -265,7 +265,7 @@ async fn main() -> Result<()> {
                 config::KeylimeConfigError::Generic(message),
             ));
         }
-        info!("Running the service as {}...", user_group);
+        info!("Running the service as {user_group}...");
     }
 
     // Parse the configured API versions
@@ -399,7 +399,7 @@ async fn main() -> Result<()> {
                         }
                     }
                     Err(e) => {
-                        warn!("Could not load agent data: {}", e);
+                        warn!("Could not load agent data: {e:?}");
                         None
                     }
                 }
@@ -438,7 +438,7 @@ async fn main() -> Result<()> {
         path => agent_data_new.store(Path::new(&path))?,
     }
 
-    info!("Agent UUID: {}", agent_uuid);
+    info!("Agent UUID: {agent_uuid}");
 
     // If using IAK/IDevID is enabled, obtain IAK/IDevID and respective certificates
     let mut device_id = if config.enable_iak_idevid {
@@ -590,7 +590,7 @@ async fn main() -> Result<()> {
         ) {
             Ok(t) => Ok(t),
             Err(e) => {
-                error!("Failed to load trusted CA certificates: {}", e);
+                error!("Failed to load trusted CA certificates: {e:?}");
                 Err(e)
             }
         }?;
@@ -631,7 +631,7 @@ async fn main() -> Result<()> {
     match keylime::agent_registration::register_agent(aa, &mut ctx).await {
         Ok(()) => (),
         Err(e) => {
-            error!("Failed to register agent: {}", e);
+            error!("Failed to register agent: {e:?}");
         }
     }
 
@@ -762,7 +762,7 @@ async fn main() -> Result<()> {
         Ok(ip_addr) => {
             // Add bracket if IPv6, otherwise use as it is
             if ip_addr.is_ipv6() {
-                format!("[{}]", ip_addr)
+                format!("[{ip_addr}]")
             } else {
                 ip_addr.to_string()
             }

--- a/keylime-agent/src/payloads.rs
+++ b/keylime-agent/src/payloads.rs
@@ -116,14 +116,14 @@ fn write_out_key_and_payload(
     if bytes != key.as_ref().len() {
         return Err(Error::Other(format!("Error writing symm key to {:?}: key len is {}, but {bytes} bytes were written", key_path, key.as_ref().len())));
     }
-    info!("Wrote payload decryption key to {:?}", key_path);
+    info!("Wrote payload decryption key to {key_path:?}");
 
     let mut dec_payload_file = fs::File::create(dec_payload_path)?;
     let bytes = dec_payload_file.write(dec_payload)?;
     if bytes != dec_payload.len() {
         return Err(Error::Other(format!("Error writing decrypted payload to {:?}: payload len is {}, but {bytes} bytes were written", dec_payload_path, dec_payload.len())));
     }
-    info!("Wrote decrypted payload to {:?}", dec_payload_path);
+    info!("Wrote decrypted payload to {dec_payload_path:?}");
 
     Ok(())
 }
@@ -131,7 +131,7 @@ fn write_out_key_and_payload(
 // run a script (such as the init script, if any) and check the status
 fn run(dir: &Path, script: &str) -> Result<()> {
     let script_path = dir.join(script);
-    info!("Running script: {:?}", script_path);
+    info!("Running script: {script_path:?}");
 
     if !script_path.exists() {
         info!("No payload script {script} found in {}", dir.display());
@@ -183,7 +183,7 @@ fn optional_unzip_payload(
             dec_file => {
                 let zipped_payload_path = unzipped.join(dec_file);
 
-                info!("Unzipping payload {} to {:?}", dec_file, unzipped);
+                info!("Unzipping payload {dec_file} to {unzipped:?}");
 
                 let mut source = fs::File::open(zipped_payload_path)?;
                 let mut zip = ZipArchive::new(source)?;
@@ -222,7 +222,7 @@ async fn run_encrypted_payload(
             info!("No payload script specified, skipping");
         }
         script => {
-            info!("Payload init script indicated: {}", script);
+            info!("Payload init script indicated: {script}");
             run(&unzipped, script)?;
         }
     }
@@ -312,7 +312,7 @@ pub(crate) async fn worker(
                         info!("Successfully executed encrypted payload");
                     }
                     Err(e) => {
-                        warn!("Failed to run encrypted payload: {}", e);
+                        warn!("Failed to run encrypted payload: {e:?}");
                     }
                 }
             }
@@ -565,7 +565,7 @@ echo hello > test-output
             .await;
 
             if result.is_err() {
-                debug!("payloads worker failed: {:?}", result);
+                debug!("payloads worker failed: {result:?}");
             }
 
             let timestamp_path = temp_workdir.path().join("timestamp");

--- a/keylime-agent/src/quotes_handler.rs
+++ b/keylime-agent/src/quotes_handler.rs
@@ -74,7 +74,7 @@ async fn identity(
     ) {
         Ok(quote) => quote,
         Err(e) => {
-            debug!("Unable to retrieve quote: {:?}", e);
+            debug!("Unable to retrieve quote: {e:?}");
             return HttpResponse::InternalServerError().json(
                 JsonWrapper::error(
                     500,
@@ -95,7 +95,7 @@ async fn identity(
     match crypto::pkey_pub_to_pem(&data.pub_key) {
         Ok(pubkey) => quote.pubkey = Some(pubkey),
         Err(e) => {
-            debug!("Unable to retrieve public key for quote: {:?}", e);
+            debug!("Unable to retrieve public key for quote: {e:?}");
             return HttpResponse::InternalServerError().json(
                 JsonWrapper::error(
                     500,
@@ -172,7 +172,7 @@ async fn integrity(
             let pubkey = match crypto::pkey_pub_to_pem(&data.pub_key) {
                 Ok(pubkey) => pubkey,
                 Err(e) => {
-                    debug!("Unable to retrieve public key: {:?}", e);
+                    debug!("Unable to retrieve public key: {e:?}");
                     return HttpResponse::InternalServerError().json(
                         JsonWrapper::error(
                             500,
@@ -221,7 +221,7 @@ async fn integrity(
     ) {
         Ok(tpm_quote) => tpm_quote,
         Err(e) => {
-            debug!("Unable to retrieve quote: {:?}", e);
+            debug!("Unable to retrieve quote: {e:?}");
             return HttpResponse::InternalServerError().json(
                 JsonWrapper::error(
                     500,
@@ -247,7 +247,7 @@ async fn integrity(
                 let mut ml = Vec::<u8>::new();
                 let mut f = measuredboot_ml_file.lock().unwrap(); //#[allow_ci]
                 if let Err(e) = f.rewind() {
-                    debug!("Failed to rewind measured boot file: {}", e);
+                    debug!("Failed to rewind measured boot file: {e:?}");
                     return HttpResponse::InternalServerError().json(
                         JsonWrapper::error(
                             500,
@@ -258,14 +258,14 @@ async fn integrity(
                 mb_measurement_list = match f.read_to_end(&mut ml) {
                     Ok(_) => Some(general_purpose::STANDARD.encode(ml)),
                     Err(e) => {
-                        warn!("Could not read TPM2 event log: {}", e);
+                        warn!("Could not read TPM2 event log: {e:?}");
                         None
                     }
                 };
             }
         }
         Err(e) => {
-            debug!("Unable to check PCR mask: {:?}", e);
+            debug!("Unable to check PCR mask: {e:?}");
             return HttpResponse::InternalServerError().json(
                 JsonWrapper::error(
                     500,
@@ -288,7 +288,7 @@ async fn integrity(
                     (Some(result.0), Some(result.1), Some(result.2))
                 }
                 Err(e) => {
-                    debug!("Unable to read measurement list: {:?}", e);
+                    debug!("Unable to read measurement list: {e:?}");
                     return HttpResponse::InternalServerError().json(
                         JsonWrapper::error(
                             500,

--- a/keylime-agent/src/revocation.rs
+++ b/keylime-agent/src/revocation.rs
@@ -123,7 +123,7 @@ pub(crate) fn run_action(
         allow_payload_actions,
     )?;
 
-    info!("Executing revocation action {}", action);
+    info!("Executing revocation action {action}");
 
     // Write JSON argument to a temporary file
     let raw_json = serde_json::value::to_raw_value(&json)?;
@@ -170,7 +170,7 @@ pub(crate) fn run_action(
         return Err(output.try_into()?);
     }
 
-    info!("INFO: revocation action {} successful", action);
+    info!("INFO: revocation action {action} successful");
 
     Ok(output)
 }
@@ -232,7 +232,7 @@ fn run_revocation_actions(
                     let msg = format!(
                         "error executing revocation script {action}: {e:?}"
                     );
-                    error!("{}", msg);
+                    error!("{msg}");
                     return Err(Error::Script(
                         action.to_string(),
                         e.exe_code()?,
@@ -272,8 +272,7 @@ fn process_revocation(
         let msg_payload: Value = serde_json::from_str(msg)?;
 
         debug!(
-            "Revocation signature validated for revocation: {}",
-            msg_payload
+            "Revocation signature validated for revocation: {msg_payload}"
         );
 
         let outputs = run_revocation_actions(
@@ -288,11 +287,11 @@ fn process_revocation(
         for output in outputs {
             if !output.stdout.is_empty() {
                 let out = String::from_utf8(output.stdout)?;
-                info!("Action stdout: {}", out);
+                info!("Action stdout: {out}");
             }
             if !output.stderr.is_empty() {
                 let out = String::from_utf8(output.stderr)?;
-                warn!("Action stderr: {}", out);
+                warn!("Action stderr: {out}");
             }
         }
         Ok(())
@@ -317,14 +316,11 @@ fn listen_zmq(
 
     let endpoint = format!("tcp://{ip}:{port}");
 
-    info!(
-        "Connecting to revocation notification endpoint at {}...",
-        endpoint
-    );
+    info!("Connecting to revocation notification endpoint at {endpoint}...");
 
     mysock.connect(endpoint.as_str())?;
 
-    info!("Waiting for revocation messages on 0mq {}", endpoint);
+    info!("Waiting for revocation messages on 0mq {endpoint}");
 
     Ok(rt::spawn(async move {
         // Main revocation service loop. If a message is malformed or
@@ -380,7 +376,7 @@ fn listen_zmq(
             };
             sleep(Duration::from_millis(100)).await;
         }
-        info!("Stop waiting for revocation messages on 0mq {}", endpoint);
+        info!("Stop waiting for revocation messages on 0mq {endpoint}");
         Ok(())
     }))
 }
@@ -475,7 +471,7 @@ pub(crate) async fn worker(
                                 info!("Revocation processed successfully");
                             }
                             Err(e) => {
-                                error!("Failed to process revocation: {}", e);
+                                error!("Failed to process revocation: {e:?}");
                             }
                         }
                     }

--- a/keylime-macros/src/lib.rs
+++ b/keylime-macros/src/lib.rs
@@ -233,7 +233,7 @@ pub fn define_view_trait(
     // Derive the trait name using the "Trait" suffix
     let view_name = &view_struct.ident;
     let trait_ident =
-        Ident::new(&format!("{}Trait", view_name), view_name.span());
+        Ident::new(&format!("{view_name}Trait"), view_name.span());
 
     let named_fields = match &mut view_struct.fields {
         Fields::Named(f) => &mut f.named,

--- a/keylime-push-model-agent/src/attestation.rs
+++ b/keylime-push-model-agent/src/attestation.rs
@@ -73,7 +73,7 @@ impl AttestationClient {
         let json_value =
             serde_json::to_value(filler.get_attestation_request());
         let reqcontent = json_value?.to_string();
-        debug!("Request body: {:?}", reqcontent);
+        debug!("Request body: {reqcontent:?}");
 
         let response = self
             .client
@@ -88,11 +88,11 @@ impl AttestationClient {
         let sc = response.status();
         let headers = response.headers().clone();
         info!("Response code:{}", response.status());
-        info!("Response headers: {:?}", headers);
+        info!("Response headers: {headers:?}");
 
         let response_body = response.text().await?;
         if !response_body.is_empty() {
-            info!("Response body: {}", response_body);
+            info!("Response body: {response_body}");
         }
 
         let rsp = ResponseInformation {
@@ -108,7 +108,7 @@ impl AttestationClient {
         json_body: String,
         config: &NegotiationConfig<'_>,
     ) -> Result<ResponseInformation> {
-        debug!("PATCH Request body: {:?}", json_body);
+        debug!("PATCH Request body: {json_body:?}");
 
         let response = self
             .client
@@ -124,10 +124,10 @@ impl AttestationClient {
         let headers = response.headers().clone();
         let response_body = response.text().await?;
 
-        info!("PATCH Response code:{}", sc);
-        info!("PATCH Response headers: {:?}", headers);
+        info!("PATCH Response code:{sc}");
+        info!("PATCH Response headers: {headers:?}");
         if !response_body.is_empty() {
-            info!("PATCH Response body: {}", response_body);
+            info!("PATCH Response body: {response_body}");
         }
 
         Ok(ResponseInformation {
@@ -159,7 +159,7 @@ impl AttestationClient {
                 location: Some(location_header.to_string()),
             },
         );
-        info!("Sending evidence (PATCH) to: {}", patch_url);
+        info!("Sending evidence (PATCH) to: {patch_url}");
         let mut attestation_params =
             response_handler::process_negotiation_response(
                 &neg_response.body,
@@ -168,7 +168,7 @@ impl AttestationClient {
             config.ima_log_path.map(|path| path.to_string());
         attestation_params.uefi_log_path =
             config.uefi_log_path.map(|path| path.to_string());
-        debug!("Attestation parameters: {:?}", attestation_params);
+        debug!("Attestation parameters: {attestation_params:?}");
         let mut context_info =
             context_info_handler::get_context_info(config.avoid_tpm)?
                 .ok_or_else(|| {

--- a/keylime-push-model-agent/src/main.rs
+++ b/keylime-push-model-agent/src/main.rs
@@ -112,7 +112,7 @@ async fn run(args: &Args) -> Result<()> {
     let config = AgentConfig::new()?;
     let avoid_tpm = get_avoid_tpm_from_args(args);
     context_info_handler::init_context_info(&config, avoid_tpm)?;
-    debug!("Avoid TPM: {}", avoid_tpm);
+    debug!("Avoid TPM: {avoid_tpm}");
     let ctx_info = match context_info_handler::get_context_info(avoid_tpm) {
         Ok(Some(context_info)) => Some(context_info),
         Ok(None) => {
@@ -120,7 +120,7 @@ async fn run(args: &Args) -> Result<()> {
             None
         }
         Err(e) => {
-            error!("Error obtaining context information: {}", e);
+            error!("Error obtaining context information: {e:?}");
             return Err(e);
         }
     };
@@ -128,7 +128,7 @@ async fn run(args: &Args) -> Result<()> {
         crate::registration::check_registration(&config, ctx_info).await;
     match res {
         Ok(_) => {}
-        Err(ref e) => error!("Could not register appropriately: {}", e),
+        Err(ref e) => error!("Could not register appropriately: {e:?}"),
     }
     let agent_identifier = match &args.agent_identifier {
         Some(id) => id.clone(),
@@ -141,7 +141,7 @@ async fn run(args: &Args) -> Result<()> {
             agent_identifier: Some(agent_identifier.clone()),
             location: None,
         });
-    debug!("Negotiations request URL: {}", negotiations_request_url);
+    debug!("Negotiations request URL: {negotiations_request_url}");
     let neg_config = attestation::NegotiationConfig {
         avoid_tpm,
         url: &negotiations_request_url,
@@ -175,7 +175,7 @@ async fn run(args: &Args) -> Result<()> {
             neg
         }
         Err(ref e) => {
-            error!("Error: {}", e);
+            error!("Error: {e:?}");
             &attestation::ResponseInformation {
                 status_code: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: e.to_string(),

--- a/keylime-push-model-agent/src/struct_filler.rs
+++ b/keylime-push-model-agent/src/struct_filler.rs
@@ -70,7 +70,7 @@ impl<'a> FillerFromHardware<'a> {
                 uefi_log_handler: Some(handler),
             },
             Err(e) => {
-                error!("Failed to create UEFI log handler: {}", e);
+                error!("Failed to create UEFI log handler: {e:?}");
                 FillerFromHardware {
                     tpm_context_info,
                     uefi_log_handler: None,
@@ -107,7 +107,7 @@ impl<'a> FillerFromHardware<'a> {
         let ima_log_count = match ima_log_parser {
             Ok(ima_log) => ima_log.entry_count(),
             Err(e) => {
-                error!("Failed to read IMA log: {}", e);
+                error!("Failed to read IMA log: {e:?}");
                 0
             }
         };
@@ -200,7 +200,7 @@ impl<'a> FillerFromHardware<'a> {
             match self.tpm_context_info.perform_attestation(params).await {
                 Ok(evidence) => evidence,
                 Err(e) => {
-                    error!("Failed to perform attestation: {}", e);
+                    error!("Failed to perform attestation: {e}");
                     return structures::EvidenceHandlingRequest {
                     data: structures::EvidenceHandlingRequestData {
                         data_type: "error".to_string(),

--- a/keylime-push-model-agent/src/url_selector.rs
+++ b/keylime-push-model-agent/src/url_selector.rs
@@ -40,7 +40,7 @@ pub fn get_evidence_submission_request_url(args: &UrlArgs) -> String {
         Some(loc) => loc.clone(),
         None => return "ERROR: No location provided".to_string(),
     };
-    format!("{}{}", trimmed_base, location)
+    format!("{trimmed_base}{location}")
 }
 
 #[cfg(test)]

--- a/keylime/src/algorithms.rs
+++ b/keylime/src/algorithms.rs
@@ -66,8 +66,7 @@ impl TryFrom<tss_esapi::interface_types::algorithm::HashingAlgorithm>
             tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha512 => Ok(HashAlgorithm::Sha512),
             tss_esapi::interface_types::algorithm::HashingAlgorithm::Sm3_256 => Ok(HashAlgorithm::Sm3_256),
             _ => Err(AlgorithmError::UnsupportedHashingAlgorithm(format!(
-                "Unable to convert tss-esapi HashingAlgorithm: {:?}",
-                tss_alg
+                "Unable to convert tss-esapi HashingAlgorithm: {tss_alg:?}"
             ))),
         }
     }

--- a/keylime/src/config/env.rs
+++ b/keylime/src/config/env.rs
@@ -232,10 +232,7 @@ mod test {
                 let j = obtained.get(i).unwrap(); //#[allow_ci]
                 assert!(
                     e.to_string() == j.to_string(),
-                    "Option {} mismatch: expected == '{}', obtained == '{}'",
-                    i,
-                    e,
-                    j
+                    "Option {i} mismatch: expected == '{e}', obtained == '{j}'"
                 );
             }
         }

--- a/keylime/src/config/file_config.rs
+++ b/keylime/src/config/file_config.rs
@@ -88,7 +88,7 @@ impl FileConfigBuilder {
                     let f: FileConfig = builder.build()?.try_deserialize()?;
                     return Ok(f.agent);
                 } else {
-                    warn!("Configuration set in {} environment variable not found", GLOBAL_CONFIG_OVERRIDE_ENV_VAR);
+                    warn!("Configuration set in {GLOBAL_CONFIG_OVERRIDE_ENV_VAR} environment variable not found");
                     return Err(KeylimeConfigError::MissingEnvConfigFile {
                         file: path.display().to_string(),
                     });

--- a/keylime/src/context_info.rs
+++ b/keylime/src/context_info.rs
@@ -338,8 +338,7 @@ impl ContextInfo {
         let ak_name_obj: Name =
             Name::try_from(name_content_buffer).map_err(|e| {
                 tpm::TpmError::NameFromBytesError(format!(
-                    "Failed to create Name object: {}",
-                    e
+                    "Failed to create Name object: {e:?}"
                 ))
             })?;
         Ok(hex::encode(ak_name_obj.value()))
@@ -454,8 +453,7 @@ impl ContextInfo {
         };
         let ima_log = ImaLog::new(ima_log_path.as_str()).map_err(|e| {
             ContextInfoError::Keylime(format!(
-                "Failed to read IMA log: {}",
-                e
+                "Failed to read IMA log: {e:?}",
             ))
         })?;
         let result_string = ima_log
@@ -471,16 +469,14 @@ impl ContextInfo {
         let uefi_log_handler = UefiLogHandler::new(uefi_log_path.as_str())
             .map_err(|e| {
                 ContextInfoError::Keylime(format!(
-                    "Failed to create UEFI log handler: {}",
-                    e
+                    "Failed to create UEFI log handler: {e:?}",
                 ))
             })?;
         let uefi_log = match uefi_log_handler.base_64() {
             Ok(content) => content,
             Err(e) => {
                 return Err(ContextInfoError::Keylime(format!(
-                    "Failed to read UEFI log: {}",
-                    e
+                    "Failed to read UEFI log: {e:?}",
                 )));
             }
         };

--- a/keylime/src/crypto.rs
+++ b/keylime/src/crypto.rs
@@ -403,14 +403,14 @@ pub fn check_x509_key(
                 .map_err(CryptoError::RSAGetPublicKeyError)?
                 .n()
                 .to_vec();
-            let mut cert_n_str = format!("{:?}", cert_n);
+            let mut cert_n_str = format!("{cert_n:?}");
             _ = cert_n_str.pop();
             _ = cert_n_str.remove(0);
             let key = SubjectPublicKeyInfo::try_from(tpm_key.clone())
                 .map_err(CryptoError::SubjectPublicKeyInfoFromRSAError)?;
             let key_der = picky_asn1_der::to_vec(&key)
                 .map_err(CryptoError::SubjectPublicKeyInfoToDERError)?;
-            let key_der_str = format!("{:?}", key_der);
+            let key_der_str = format!("{key_der:?}");
 
             Ok(key_der_str.contains(&cert_n_str))
         }
@@ -422,14 +422,14 @@ pub fn check_x509_key(
                 .map_err(CryptoError::RSAGetPublicKeyError)?
                 .n()
                 .to_vec();
-            let mut cert_n_str = format!("{:?}", cert_n);
+            let mut cert_n_str = format!("{cert_n:?}");
             _ = cert_n_str.pop();
             _ = cert_n_str.remove(0);
             let key = SubjectPublicKeyInfo::try_from(tpm_key.clone())
                 .map_err(CryptoError::SubjectPublicKeyInfoFromRSAError)?;
             let key_der = picky_asn1_der::to_vec(&key)
                 .map_err(CryptoError::SubjectPublicKeyInfoToDERError)?;
-            let key_der_str = format!("{:?}", key_der);
+            let key_der_str = format!("{key_der:?}");
 
             Ok(key_der_str.contains(&cert_n_str))
         }
@@ -441,14 +441,14 @@ pub fn check_x509_key(
                 .map_err(CryptoError::PublicKeyGetECCError)?
                 .public_key_to_der()
                 .map_err(CryptoError::PublicKeyToDERError)?;
-            let mut cert_n_str = format!("{:?}", cert_n);
+            let mut cert_n_str = format!("{cert_n:?}");
             _ = cert_n_str.pop();
             _ = cert_n_str.remove(0);
             let key = SubjectPublicKeyInfo::try_from(tpm_key.clone())
                 .map_err(CryptoError::SubjectPublicKeyInfoFromECCError)?;
             let key_der = picky_asn1_der::to_vec(&key)
                 .map_err(CryptoError::SubjectPublicKeyInfoToDERError)?;
-            let key_der_str = format!("{:?}", key_der);
+            let key_der_str = format!("{key_der:?}");
 
             Ok(key_der_str.contains(&cert_n_str))
         }

--- a/keylime/src/error.rs
+++ b/keylime/src/error.rs
@@ -243,14 +243,11 @@ mod tests {
         let converted_error: Error = original_tss_error.into();
 
         if let Error::Tss2 { err, kind, message } = converted_error {
-            assert_eq!(
-                format!("{:?}", err),
-                format!("{:?}", original_tss_error)
-            );
+            assert_eq!(format!("{err:?}"), format!("{original_tss_error:?}"));
             assert_eq!(message, format!("{original_tss_error}"));
             assert!(kind.is_some());
         } else {
-            panic!("Expected Tss2Error, got {:?}", converted_error); //#[allow_ci]
+            panic!("Expected Tss2Error, got {converted_error:?}"); //#[allow_ci]
         }
     }
 
@@ -275,10 +272,7 @@ mod tests {
             tss_esapi::Error::WrapperError(WrapperErrorKind::WrongParamSize);
         let converted_error: Error = original_tss_error.into();
         if let Error::Tss2 { err, kind, message } = converted_error {
-            assert_eq!(
-                format!("{:?}", err),
-                format!("{:?}", original_tss_error)
-            );
+            assert_eq!(format!("{err:?}"), format!("{original_tss_error:?}"));
             assert_eq!(kind, None);
             assert_eq!(message, format!("{original_tss_error}"));
         }
@@ -293,8 +287,7 @@ mod tests {
         let unwrapped_err = result.unwrap_err();
         if let Error::Other(msg) = unwrapped_err {
             let expected_msg = format!(
-                "cannot get execution status code for Error type {}",
-                non_execution_error
+                "cannot get execution status code for Error type {non_execution_error}"
             );
             assert_eq!(msg, expected_msg);
         }
@@ -308,8 +301,7 @@ mod tests {
         let unwrapped_err = result.unwrap_err();
         if let Error::Other(msg) = unwrapped_err {
             let expected_msg = format!(
-                "cannot get stderr for Error type {}",
-                non_execution_error
+                "cannot get stderr for Error type {non_execution_error}"
             );
             assert_eq!(msg, expected_msg);
         }
@@ -362,7 +354,7 @@ mod tests {
             assert_eq!(e.kind(), IoErrorKind::NotFound);
             assert_eq!(format!("{e}"), "file not found");
         } else {
-            panic!("Expected Error::Io, got {:?}", err); //#[allow_ci]
+            panic!("Expected Error::Io, got {err:?}"); //#[allow_ci]
         }
     }
 
@@ -373,7 +365,7 @@ mod tests {
         if let Error::InvalidIP(e) = err {
             assert_eq!(format!("{e}"), "invalid IP address syntax");
         } else {
-            panic!("Expected Error::InvalidIP, got {:?}", err); //#[allow_ci]
+            panic!("Expected Error::InvalidIP, got {err:?}"); //#[allow_ci]
         }
     }
 
@@ -387,7 +379,7 @@ mod tests {
                 "cannot parse integer from empty string"
             );
         } else {
-            panic!("Expected Error::NumParse, got {:?}", err); //#[allow_ci]
+            panic!("Expected Error::NumParse, got {err:?}"); //#[allow_ci]
         }
     }
 
@@ -401,7 +393,7 @@ mod tests {
                 "provided string was not `true` or `false`"
             );
         } else {
-            panic!("Expected Error::ParseBool, got {:?}", err); //#[allow_ci]
+            panic!("Expected Error::ParseBool, got {err:?}"); //#[allow_ci]
         }
     }
 
@@ -414,7 +406,7 @@ mod tests {
             assert_eq!(msg, "Invalid character 'Z' at position 1");
             assert!(msg.contains("Invalid character"));
         } else {
-            panic!("Expected Error::FromHex, got {:?}", err); //#[allow_ci]
+            panic!("Expected Error::FromHex, got {err:?}"); //#[allow_ci]
         }
     }
 
@@ -428,7 +420,7 @@ mod tests {
             assert!(msg
                 .contains("nul byte found in provided data at position: 1"));
         } else {
-            panic!("Expected Error::Nul, got {:?}", err); //#[allow_ci]
+            panic!("Expected Error::Nul, got {err:?}"); //#[allow_ci]
         }
     }
 
@@ -441,10 +433,10 @@ mod tests {
             if let ZipErrorSource::InvalidArchive(msg) = e {
                 assert_eq!(msg, "Invalid zip data");
             } else {
-                panic!("Expected ZipError::InvalidArchive, got {:?}", e); //#[allow_ci]
+                panic!("Expected ZipError::InvalidArchive, got {e:?}"); //#[allow_ci]
             }
         } else {
-            panic!("Expected Error::Zip, got {:?}", err); //#[allow_ci]
+            panic!("Expected Error::Zip, got {err:?}"); //#[allow_ci]
         }
     }
 
@@ -465,10 +457,10 @@ mod tests {
 
         let err = result.unwrap_err();
         if let Error::Utf8(e) = err {
-            let msg = format!("{}", e);
+            let msg = format!("{e}");
             assert!(msg.contains("invalid utf-8 sequence"));
         } else {
-            panic!("Invalid stderr: {:?}", err); //#[allow_ci]
+            panic!("Invalid stderr: {err:?}"); //#[allow_ci]
         }
     }
 
@@ -537,7 +529,7 @@ mod tests {
                 "Configuration error: Another config test"
             );
         } else {
-            panic!("Expected Error::Configuration, got {:?}", err); //#[allow_ci]
+            panic!("Expected Error::Configuration, got {err:?}"); //#[allow_ci]
         }
     }
 
@@ -549,7 +541,7 @@ mod tests {
         if let Error::IpParser(e) = err {
             assert_eq!(format!("{e}"), "Invalid input Invalid");
         } else {
-            panic!("Expected Error::IpParser, got {:?}", err); //#[allow_ci]
+            panic!("Expected Error::IpParser, got {err:?}"); //#[allow_ci]
         }
     }
 
@@ -633,9 +625,7 @@ mod tests {
         let formatted_err = format!("{err}");
         assert!(
             formatted_err.starts_with(expected_prefix),
-            "Expected error to start with '{}', but got: {}",
-            expected_prefix,
-            formatted_err
+            "Expected error to start with '{expected_prefix}', but got: {formatted_err}"
         );
     }
 
@@ -649,7 +639,7 @@ mod tests {
             let inner_msg = format!("{e}");
             assert!(inner_msg.contains("invalid character"));
         } else {
-            panic!("Expected Error::Uuid, got {:?}", err); //#[allow_ci]
+            panic!("Expected Error::Uuid, got {err:?}"); //#[allow_ci]
         }
     }
 
@@ -667,7 +657,7 @@ mod tests {
             assert!(msg.contains("Simulated task panic"),);
             assert!(e.is_panic());
         } else {
-            panic!("Expected Error::Join, got {:?}", converted_error); //#[allow_ci]
+            panic!("Expected Error::Join, got {converted_error:?}"); //#[allow_ci]
         }
     }
 }

--- a/keylime/src/ima/ima_log.rs
+++ b/keylime/src/ima/ima_log.rs
@@ -11,8 +11,7 @@ impl ImaLog {
     pub fn new(log_path: &str) -> Result<Self> {
         let contents = fs::read_to_string(log_path).map_err(|e| {
             KeylimeError::Other(format!(
-                "Unable to parse IMA file {}: {}",
-                log_path, e
+                "Unable to parse IMA file {log_path}: {e:?}"
             ))
         })?;
         let entries = contents
@@ -21,8 +20,7 @@ impl ImaLog {
             .collect::<Vec<entry::Entry>>();
         if entries.is_empty() {
             return Err(KeylimeError::Other(format!(
-                "No valid entries found in IMA log file: {}",
-                log_path
+                "No valid entries found in IMA log file: {log_path}"
             )));
         }
         Ok(Self { entries })

--- a/keylime/src/json_wrapper.rs
+++ b/keylime/src/json_wrapper.rs
@@ -38,7 +38,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let out = json!(self).to_string();
-        write!(f, "{}", out)
+        write!(f, "{out}")
     }
 }
 
@@ -54,7 +54,7 @@ mod test {
     impl Display for TestResult {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             let out = json!(self).to_string();
-            write!(f, "{}", out)
+            write!(f, "{out}")
         }
     }
 

--- a/keylime/src/permissions.rs
+++ b/keylime/src/permissions.rs
@@ -203,7 +203,7 @@ pub fn run_as(user_group: &str) -> Result<(), PermissionError> {
         return Err(PermissionError::SetUID(e));
     }
 
-    info!("Dropped privileges to run as {}", user_group);
+    info!("Dropped privileges to run as {user_group}");
 
     Ok(())
 }

--- a/keylime/src/registrar_client.rs
+++ b/keylime/src/registrar_client.rs
@@ -103,7 +103,7 @@ impl RegistrarClientBuilder {
         // Try to reach the registrar
         let addr = format!("http://{registrar_ip}:{registrar_port}/version");
 
-        info!("Requesting registrar API version to {}", addr);
+        info!("Requesting registrar API version to {addr}");
 
         let resp = reqwest::Client::new()
             .get(&addr)
@@ -291,9 +291,12 @@ impl RegistrarClient {
             port: Some(ai.port),
         };
 
+        let registrar_ip = &self.registrar_ip;
+        let registrar_port = &self.registrar_port;
+        let uuid = &ai.uuid;
+
         let addr = format!(
-            "http://{}:{}/v{}/agents/{}",
-            &self.registrar_ip, &self.registrar_port, api_version, &ai.uuid
+            "http://{registrar_ip}:{registrar_port}/v{api_version}/agents/{uuid}",
         );
 
         info!(
@@ -407,9 +410,12 @@ impl RegistrarClient {
     ) -> Result<(), RegistrarClientError> {
         let data = Activate { auth_tag };
 
+        let registrar_ip = &self.registrar_ip;
+        let registrar_port = &self.registrar_port;
+        let uuid = &ai.uuid;
+
         let addr = format!(
-            "http://{}:{}/v{}/agents/{}",
-            &self.registrar_ip, &self.registrar_port, api_version, &ai.uuid
+            "http://{registrar_ip}:{registrar_port}/v{api_version}/agents/{uuid}",
         );
 
         info!(
@@ -595,10 +601,10 @@ mod tests {
             .build()
             .await;
 
-        assert!(response.is_ok(), "error: {:?}", response);
+        assert!(response.is_ok(), "error: {response:?}");
         let mut registrar_client = response.unwrap(); //#[allow_ci]
         let response = registrar_client.register_agent(&ai).await;
-        assert!(response.is_ok(), "error: {:?}", response);
+        assert!(response.is_ok(), "error: {response:?}");
     }
 
     #[actix_rt::test]
@@ -655,7 +661,7 @@ mod tests {
         let mut registrar_client = builder.build().await.unwrap(); //#[allow_ci]
 
         let response = registrar_client.register_agent(&ai).await;
-        assert!(response.is_ok(), "error: {:?}", response);
+        assert!(response.is_ok(), "error: {response:?}");
     }
 
     #[actix_rt::test]
@@ -726,7 +732,7 @@ mod tests {
         let mut registrar_client = builder.build().await.unwrap(); //#[allow_ci]
 
         let response = registrar_client.register_agent(&ai).await;
-        assert!(response.is_ok(), "error: {:?}", response);
+        assert!(response.is_ok(), "error: {response:?}");
     }
 
     #[actix_rt::test]
@@ -797,7 +803,7 @@ mod tests {
         let mut registrar_client = builder.build().await.unwrap(); //#[allow_ci]
 
         let response = registrar_client.register_agent(&ai).await;
-        assert!(response.is_ok(), "error: {:?}", response);
+        assert!(response.is_ok(), "error: {response:?}");
     }
 
     #[actix_rt::test]
@@ -915,7 +921,7 @@ mod tests {
             .await;
 
         // The build process should work, but the registration should fail
-        assert!(response.is_ok(), "error: {:?}", response);
+        assert!(response.is_ok(), "error: {response:?}");
         let mut registrar_client =
             response.expect("failed to build Registrar Client");
         let response = registrar_client.register_agent(&ai).await;
@@ -982,7 +988,7 @@ mod tests {
         let mut registrar_client = builder.build().await.unwrap(); //#[allow_ci]
 
         let response = registrar_client.activate_agent(&ai, "tag").await;
-        assert!(response.is_ok(), "error: {:?}", response);
+        assert!(response.is_ok(), "error: {response:?}");
     }
 
     #[actix_rt::test]
@@ -1030,7 +1036,7 @@ mod tests {
         let mut registrar_client = builder.build().await.unwrap(); //#[allow_ci]
 
         let response = registrar_client.activate_agent(&ai, "tag").await;
-        assert!(response.is_ok(), "error: {:?}", response);
+        assert!(response.is_ok(), "error: {response:?}");
     }
 
     #[actix_rt::test]
@@ -1095,7 +1101,7 @@ mod tests {
             .expect("failed top build Registrar Client");
 
         let response = registrar_client.activate_agent(&ai, "tag").await;
-        assert!(response.is_ok(), "error: {:?}", response);
+        assert!(response.is_ok(), "error: {response:?}");
     }
 
     #[actix_rt::test]
@@ -1162,7 +1168,7 @@ mod tests {
 
         // The build process should work, but the activation should fail as
         // there is no compatible API version
-        assert!(response.is_ok(), "error: {:?}", response);
+        assert!(response.is_ok(), "error: {response:?}");
         let mut registrar_client =
             response.expect("failed to build Registrar Client");
         let response = registrar_client.activate_agent(&ai, "tag").await;

--- a/keylime/src/secure_mount.rs
+++ b/keylime/src/secure_mount.rs
@@ -46,18 +46,18 @@ pub fn check_mount(secure_dir: &Path) -> Result<bool> {
                             debug!("Secure store location {} already mounted on tmpfs", secure_dir.display());
                             return Ok(true);
                         } else {
-                            let message = format!("Secure storage location {} already mounted on wrong file system type: {}. Unmount to continue.", secure_dir.display(), fs_type);
-                            error!("Secure mount error: {}", message);
+                            let message = format!("Secure storage location {secure_dir} already mounted on wrong file system type: {fs_type}. Unmount to continue.", secure_dir = secure_dir.display(), fs_type = fs_type);
+                            error!("Secure mount error: {message}");
                             return Err(Error::SecureMount(message));
                         }
                     } else {
                         let message = "Mount information parsing error: missing file system type".to_string();
-                        error!("Secure mount error: {}", &message);
+                        error!("Secure mount error: {message}");
                         return Err(Error::SecureMount(message));
                     }
                 } else {
                     let message = "Separator field not found. Information line cannot be parsed".to_string();
-                    error!("Secure mount error: {}", &message);
+                    error!("Secure mount error: {message}");
                     return Err(Error::SecureMount(message));
                 }
             }
@@ -65,7 +65,7 @@ pub fn check_mount(secure_dir: &Path) -> Result<bool> {
             let message =
                 "Mount information parsing error: not enough elements"
                     .to_string();
-            error!("Secure mount error: {}", message);
+            error!("Secure mount error: {message}");
             return Err(Error::SecureMount(message));
         }
     }
@@ -96,7 +96,7 @@ pub fn mount(work_dir: &Path, secure_size: &str) -> Result<PathBuf> {
                 ))
             })?;
 
-            info!("Directory {:?} created.", secure_dir_path);
+            info!("Directory {secure_dir_path:?} created.");
             let metadata = fs::metadata(&secure_dir_path).map_err(|e| {
                 Error::SecureMount(format!(
                     "unable to get metadata for secure dir path: {e:?}"
@@ -125,8 +125,8 @@ pub fn mount(work_dir: &Path, secure_size: &str) -> Result<PathBuf> {
             Ok(output) => {
                 if !output.status.success() {
                     return Err(Error::SecureMount(format!(
-                        "unable to mount tmpfs with secure dir: exit status code {}",
-                        output.status
+                        "unable to mount tmpfs with secure dir: exit status code {status}",
+                        status = output.status
                     )));
                 }
             }

--- a/keylime/src/structures/evidence_handling.rs
+++ b/keylime/src/structures/evidence_handling.rs
@@ -548,7 +548,7 @@ mod tests {
         match serde_json::from_str::<EvidenceHandlingRequest>(json) {
             Ok(_) => panic!("Expected error"), //#[allow_ci]
             Err(e) => {
-                print!("Error: {}", e); //#[allow_ci]
+                print!("Error: {e:?}"); //#[allow_ci]
                 assert!(e.to_string().contains("Invalid entries field")); //#[allow_ci]
             }
         } //#[allow_ci]
@@ -575,7 +575,7 @@ mod tests {
         match serde_json::from_str::<EvidenceHandlingRequest>(json) {
             Ok(_) => panic!("Expected error"), //#[allow_ci]
             Err(e) => {
-                print!("Error: {}", e); //#[allow_ci]
+                print!("Error: {e:?}"); //#[allow_ci]
                 assert!(e.to_string().contains("Invalid entry_count field")); //#[allow_ci]
             }
         }
@@ -601,7 +601,7 @@ mod tests {
         match serde_json::from_str::<EvidenceHandlingRequest>(json) {
             Ok(_) => panic!("Expected error"), //#[allow_ci]
             Err(e) => {
-                print!("Error: {}", e); //#[allow_ci]
+                print!("Error: {e:?}"); //#[allow_ci]
                 assert!(e.to_string().contains("Missing entries field")); //#[allow_ci]
             }
         }
@@ -628,7 +628,7 @@ mod tests {
         match serde_json::from_str::<EvidenceHandlingRequest>(json) {
             Ok(_) => panic!("Expected error"), //#[allow_ci]
             Err(e) => {
-                print!("Error: {}", e); //#[allow_ci]
+                print!("Error: {e:?}"); //#[allow_ci]
                 assert!(e.to_string().contains("Invalid entries field")); //#[allow_ci]
             }
         }

--- a/keylime/src/tpm.rs
+++ b/keylime/src/tpm.rs
@@ -1790,7 +1790,7 @@ impl Context<'_> {
                 }
             }
         }
-        supported_algs.sort_unstable_by_key(|a| format!("{:?}", a));
+        supported_algs.sort_unstable_by_key(|a| format!("{a:?}"));
         supported_algs.dedup();
 
         Ok(supported_algs)
@@ -2159,9 +2159,7 @@ fn check_if_pcr_data_and_attestation_match(
         .map_err(|source| TpmError::OpenSSLHasherFinish { source })?;
 
     log::trace!(
-        "Attested to PCR digest: {:?}, read PCR digest: {:?}",
-        attested_pcr,
-        pcr_digest,
+        "Attested to PCR digest: {attested_pcr:?}, read PCR digest: {pcr_digest:?}"
     );
 
     Ok(memcmp::eq(attested_pcr, &pcr_digest))
@@ -2205,12 +2203,11 @@ fn perform_quote_and_pcr_read(
         }
 
         log::info!(
-            "PCR data and attestation data mismatched on attempt {}",
-            attempt
+            "PCR data and attestation data mismatched on attempt {attempt}"
         );
     }
 
-    log::error!("PCR data and attestation data mismatched on all {} attempts, giving up", NUM_ATTESTATION_ATTEMPTS);
+    log::error!("PCR data and attestation data mismatched on all {NUM_ATTESTATION_ATTEMPTS} attempts, giving up");
     Err(TpmError::TooManyAttestationMismatches {
         attempts: NUM_ATTESTATION_ATTEMPTS,
     })
@@ -2440,9 +2437,9 @@ pub mod testing {
     fn deserialize_pcrsel(pcrsel_vec: &[u8]) -> Result<TPML_PCR_SELECTION> {
         if pcrsel_vec.len() != TPML_PCR_SELECTION_SIZE {
             return Err(TpmError::InvalidRequest(format!(
-                "Unexpected PCR selection size: Expected {} but got {}",
-                TPML_PCR_SELECTION_SIZE,
-                pcrsel_vec.len()
+                "Unexpected PCR selection size: Expected {expected} but got {got}",
+                expected = TPML_PCR_SELECTION_SIZE,
+                got = pcrsel_vec.len()
             )));
         }
 
@@ -2497,9 +2494,9 @@ pub mod testing {
     fn deserialize_digest(digest_vec: &[u8]) -> Result<TPML_DIGEST> {
         if digest_vec.len() != TPML_DIGEST_SIZE {
             return Err(TpmError::InvalidRequest(format!(
-                "Unexpected digest size: Expected {} but got {}",
-                TPML_DIGEST_SIZE,
-                digest_vec.len()
+                "Unexpected digest size: Expected {expected} but got {got}",
+                expected = TPML_DIGEST_SIZE,
+                got = digest_vec.len()
             )));
         }
 
@@ -2560,8 +2557,7 @@ pub mod testing {
         // Always 1 PCR digest should follow
         if count != 1 {
             return Err(TpmError::InvalidRequest(format!(
-                "Expected 1 PCR digest, got {}",
-                count
+                "Expected 1 PCR digest, got {count}"
             )));
         }
 
@@ -2680,9 +2676,9 @@ pub mod testing {
         let quote_info = match attestation.attested() {
             AttestInfo::Quote { info } => info,
             _ => {
+                let attestation_type = attestation.attestation_type();
                 return Err(TpmError::Other(format!(
-                    "Expected attestation type TPM2_ST_ATTEST_QUOTE, got {:?}",
-                    attestation.attestation_type()
+                    "Expected attestation type TPM2_ST_ATTEST_QUOTE, got {attestation_type:?}"
                 )));
             }
         };

--- a/keylime/src/uefi/uefi_log_handler.rs
+++ b/keylime/src/uefi/uefi_log_handler.rs
@@ -486,8 +486,7 @@ mod tests {
             assert_eq!(
                 UefiLogHandler::map_event_type_to_str(event_type),
                 expected_str,
-                "Failed to map event type 0x{:08X} to string",
-                event_type
+                "Failed to map event type 0x{event_type:08X} to string"
             );
         }
     }
@@ -504,8 +503,7 @@ mod tests {
             assert_eq!(
                 UefiLogHandler::get_known_digest_size(alg_id),
                 expected_size,
-                "Failed to get known size for algorithm ID: {:#04X}",
-                alg_id
+                "Failed to get known size for algorithm ID: {alg_id:#04X}"
             );
         }
         // Test an unknown algorithm
@@ -529,8 +527,7 @@ mod tests {
             assert_eq!(
                 UefiLogHandler::map_alg_id_to_str(alg_id),
                 expected_str,
-                "Failed to map algorithm ID {:#04X} to string",
-                alg_id
+                "Failed to map algorithm ID {alg_id:#04X} to string"
             );
         }
     }


### PR DESCRIPTION
Use the arguments inline when constructing strings using `format!()` and for logging.