### PR TITLE
Fix UEFI test to check file access in all cases

### DIFF
--- a/keylime/src/uefi/uefi_log_handler.rs
+++ b/keylime/src/uefi/uefi_log_handler.rs
@@ -359,7 +359,7 @@ mod tests {
     #[cfg(feature = "testing")]
     async fn test_uefi_log_handler() {
         let log_path = "/sys/kernel/security/tpm0/binary_bios_measurements";
-        if std::path::Path::new(log_path).exists() {
+        if std::fs::File::open(log_path).is_ok() {
             let handler = UefiLogHandler::new(log_path)
                 .expect("Failed to parse UEFI log");
             assert!(!handler.get_active_algorithms().is_empty());


### PR DESCRIPTION
This change makes the UEFI test more robust by improving how it checks for the UEFI log file.

The original code used std::path::Path::new(log_path).exists(). This check is insufficient because it only verifies that the file path exists. It does not check if the program has the necessary permissions to read the file.

In a testing environment, the file might exist but be unreadable by the user running the test (e.g., it requires root privileges). This would cause the .exists() check to pass, but the subsequent line, UefiLogHandler::new(log_path).expect(...), would fail and cause the test to panic.

The code is changed to std::fs::File::open(log_path).is_ok(). This single line of code attempts to open the file for reading and checks if the operation was successful.

This is superior because it handles all relevant cases at once:

* If the file doesn't exist, File::open fails, and .is_ok() returns false.
* If the file exists but isn't readable, File::open fails with a permission error, and .is_ok() returns false.

Only if the file exists AND is readable will .is_ok() return true.

By making this change, the test will now gracefully skip its logic if the file is not fully accessible, preventing crashes and making the test more reliable.