### PR TITLE
Add Capabilities Negotiations resp. missing fields

### DIFF
--- a/keylime/src/structures/capabilities_negotiation.rs
+++ b/keylime/src/structures/capabilities_negotiation.rs
@@ -96,6 +96,10 @@ pub struct ResponseData {
 pub struct ResponseAttributes {
     pub stage: String,
     pub evidence_requested: Vec<EvidenceRequested>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities_received_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub challenges_expire_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -679,6 +683,9 @@ mod tests {
                             }))),
                         },
                     ],
+                    capabilities_received_at: Some("2025-07-11T08:49:51.734539Z".parse().unwrap()), //#[allow_ci]
+                    challenges_expire_at: Some("2025-07-12T08:49:51.734539Z".parse().unwrap()), //#[allow_ci]
+
                 },
             },
         };
@@ -720,7 +727,9 @@ mod tests {
             "signature_scheme": "rsassa"
           }
         }
-      ]
+      ],
+      "capabilities_received_at": "2025-07-11T08:49:51.734539Z",
+      "challenges_expire_at": "2025-07-12T08:49:51.734539Z"
     }
   }
 }"#
@@ -772,6 +781,8 @@ mod tests {
                             })),
                         },
                     ],
+                    capabilities_received_at: Some("2025-07-11T08:49:51.734539Z".parse().unwrap()), //#[allow_ci]
+                    challenges_expire_at: Some("2025-07-12T08:49:51.734539Z".parse().unwrap()), //#[allow_ci]
                 },
             },
         };
@@ -829,7 +840,9 @@ mod tests {
             "starting_offset": 25
           }
         }
-      ]
+      ],
+      "capabilities_received_at": "2025-07-11T08:49:51.734539Z",
+      "challenges_expire_at": "2025-07-12T08:49:51.734539Z"
     }
   }
 }"#


### PR DESCRIPTION
This change enhances the capabilities negotiation phase of the push-attestation protocol by adding two timestamp fields to the verifier's response: capabilities_received_at and challenges_expire_at.

This change aligns the Rust data structures with the complete protocol specification, allowing the agent to correctly deserialize and process the time-sensitive information sent by the verifier.

ResponseAttributes Struct Updated: The ResponseAttributes struct in keylime/src/structures/capabilities_negotiation.rs has been modified to include two new optional fields:

* capabilities_received_at: Option<DateTime<Utc>>: Records the exact time when the verifier processed the agent's initial capabilities request, establishing a baseline for the session.

* challenges_expire_at: Option<DateTime<Utc>>: Specifies the deadline by which the agent must generate and submit its evidence.

* Unit Tests Updated: The serialization tests for AttestationResponse have been updated to include these new fields. This verifies that the Rust structs can correctly serialize and deserialize a JSON payload containing the new timestamps, ensuring compatibility with the verifier.