### PR TITLE
Increase coverage in evidence handling structure

### DIFF
--- a/keylime/src/structures/evidence_handling.rs
+++ b/keylime/src/structures/evidence_handling.rs
@@ -553,6 +553,7 @@ mod tests {
             }
         } //#[allow_ci]
     } // deserialize_evidence_handling_request_invalid_entries
+
     #[test]
     fn deserialize_evidence_handling_request_invalid_entry_count() {
         let json = r#"{
@@ -580,6 +581,35 @@ mod tests {
             }
         }
     } // deserialize_evidence_handling_request_invalid_entry_count
+
+    #[test]
+    fn deserialize_evidence_handling_request_invalid_entry_count_format() {
+        let json = r#"{
+    "data": {
+        "type": "attestation",
+        "attributes": {
+            "evidence_collected": [
+                {
+                    "evidence_class": "log",
+                    "evidence_type": "ima_log",
+                    "data": {
+                        "entry_count": -1,
+                        "entries": "valid_entries"
+                    }
+                }
+            ]
+        }
+    }
+}"#;
+        match serde_json::from_str::<EvidenceHandlingRequest>(json) {
+            Ok(_) => panic!("Expected error"), //#[allow_ci]
+            Err(e) => {
+                print!("Error: {e:?}"); //#[allow_ci]
+                assert!(e.to_string().contains("Invalid entry_count field")); //#[allow_ci]
+            }
+        }
+    } // deserialize_evidence_handling_request_invalid_entry_count_format
+
     #[test]
     fn deserialize_evidence_handling_missing_entries_field() {
         let json = r#"{
@@ -606,6 +636,7 @@ mod tests {
             }
         }
     } // deserialize_evidence_handling_missing_entries_field
+
     #[test]
     fn deserialize_evidence_handling_invalid_entries_field() {
         let json = r#"{


### PR DESCRIPTION
This commit adds an additional unit test to evidence_handling.rs, named deserialize_evidence_handling_request_invalid_entry_count_format to verify that the agent correctly rejects evidence payloads with a logically invalid entry_count. Specifically, it ensures that a negative value for entry_count is properly handled as an error during deserialization.

* Test Case: The new test defines a JSON payload for an EvidenceHandlingRequest. Inside an ima_log evidence block, the entry_count field is intentionally set to -1.

* Expected Behavior: The test asserts that attempting to deserialize this JSON into the Rust structs must fail. This is because the corresponding struct field is defined as a usize (an unsigned integer), which cannot represent a negative number.

* Validation: The test confirms that serde_json correctly returns an Err and that the resulting error message indicates that the entry_count field was invalid.