### PR TITLE
Add resilient_client for exponential backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,7 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "tokio",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.9.1",
  "sha1",
  "smallvec",
  "tokio",
@@ -939,8 +939,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1343,6 +1345,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,6 +1402,7 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "anyhow",
+ "async-trait",
  "base64 0.22.1",
  "byteorder",
  "chrono",
@@ -1404,12 +1419,15 @@ dependencies = [
  "picky-asn1-der",
  "picky-asn1-x509",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
+ "retry-policies 0.3.0",
  "serde",
  "serde_derive",
  "serde_json",
  "static_assertions",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tss-esapi",
  "uuid",
@@ -1424,7 +1442,7 @@ version = "0.2.7"
 dependencies = [
  "quote",
  "syn 2.0.90",
- "thiserror",
+ "thiserror 2.0.12",
  "trybuild",
 ]
 
@@ -1452,7 +1470,7 @@ dependencies = [
  "serde_json",
  "static_assertions",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tss-esapi",
  "uuid",
@@ -1470,7 +1488,7 @@ dependencies = [
  "log",
  "openssl",
  "signal-hook",
- "thiserror",
+ "thiserror 2.0.12",
  "tss-esapi",
 ]
 
@@ -1800,12 +1818,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.3",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -1852,7 +1895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -2025,12 +2068,33 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2040,7 +2104,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2128,6 +2201,63 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-registry",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.1.0",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.16",
+ "http 1.1.0",
+ "hyper",
+ "parking_lot 0.11.2",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies 0.4.0",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "wasm-timer",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "493b4243e32d6eedd29f9a398896e35c6943a123b55eec97dcaee98310d25810"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2478,11 +2608,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2527,7 +2677,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio 1.0.3",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.8",
@@ -2924,6 +3074,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ picky-asn1-x509 = "0.12"
 predicates = { version = "3.1.3" }
 pretty_env_logger = "0.5"
 reqwest = {version = "0.12", default-features = false, features = ["json", "native-tls"]}
+reqwest-middleware = "0.4.2"
+reqwest-retry = "0.7.0"
+retry-policies = "0.3.0"
 serde = "1.0.80"
 serde_derive = "1.0.80"
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/keylime-push-model-agent/Cargo.toml
+++ b/keylime-push-model-agent/Cargo.toml
@@ -28,6 +28,8 @@ tokio.workspace = true
 [dev-dependencies]
 actix-rt.workspace = true
 tempfile.workspace = true
+wiremock = {version = "0.6"}
+
 
 [features]
 # The features enabled by default

--- a/keylime-push-model-agent/src/main.rs
+++ b/keylime-push-model-agent/src/main.rs
@@ -152,6 +152,9 @@ async fn run(args: &Args) -> Result<()> {
         insecure: args.insecure,
         ima_log_path: Some(config.ima_ml_path.as_str()),
         uefi_log_path: Some(config.measuredboot_ml_path.as_str()),
+        max_retries: config.expbackoff_max_retries.unwrap_or(5),
+        initial_delay_ms: config.expbackoff_initial_delay.unwrap_or(1000),
+        max_delay_ms: config.expbackoff_max_delay,
     };
     let attestation_client =
         attestation::AttestationClient::new(&neg_config)?;

--- a/keylime/Cargo.toml
+++ b/keylime/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 actix-web.workspace = true
 anyhow.workspace = true
+async-trait.workspace = true
 base64.workspace = true
 byteorder.workspace = true
 chrono.workspace = true
@@ -24,6 +25,9 @@ openssl.workspace = true
 pest.workspace = true
 pest_derive.workspace = true
 reqwest.workspace = true
+reqwest-middleware.workspace = true
+reqwest-retry.workspace = true
+retry-policies.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
@@ -34,10 +38,6 @@ tss-esapi.workspace = true
 picky-asn1-der.workspace = true
 picky-asn1-x509.workspace = true
 tokio.workspace = true
-# wiremock was moved to be a regular dependency because optional
-# dev-dependencies are not supported
-# see: https://github.com/rust-lang/cargo/issues/1596
-wiremock = {version = "0.6", optional = true}
 uuid.workspace = true
 zip.workspace = true
 zmq = {version = "0.9.2", optional = true}
@@ -45,11 +45,9 @@ zmq = {version = "0.9.2", optional = true}
 [dev-dependencies]
 tempfile.workspace = true
 actix-rt.workspace = true
+wiremock = {version = "0.6"}
 
 [features]
-# This feature enables tests that require a TPM and the TCTI environment
-# variable properly configured
-# This should change to dev-dependencies when we have integration testing
-testing = ["wiremock"]
+testing = []
 # This feature is deprecated and will be removed on next major release
 with-zmq = ["zmq"]

--- a/keylime/src/config/base.rs
+++ b/keylime/src/config/base.rs
@@ -98,6 +98,11 @@ pub const DEFAULT_UEFI_LOGS_SUPPORTS_PARTIAL_ACCESS: bool = true;
 pub const DEFAULT_UEFI_LOGS_BINARY_FILE_PATH: &str =
     "/sys/kernel/security/tpm0/binary_bios_measurements";
 
+// Default values for exponential backoff
+pub const DEFAULT_EXP_BACKOFF_INITIAL_DELAY: u32 = 2000; // 1 second
+pub const DEFAULT_EXP_BACKOFF_MAX_RETRIES: u32 = 5;
+pub const DEFAULT_EXP_BACKOFF_MAX_DELAY: u32 = 60000; // 60 seconds
+
 // TODO These should be temporary
 pub const DEFAULT_CERTIFICATION_KEYS_SERVER_IDENTIFIER: &str = "ak";
 pub static DEFAULT_PUSH_API_VERSIONS: &[&str] = &["3.0"];
@@ -109,6 +114,9 @@ pub struct AgentConfig {
     pub api_versions: String,
     pub disabled_signing_algorithms: Vec<String>,
     pub ek_handle: String,
+    pub expbackoff_max_delay: Option<u64>,
+    pub expbackoff_max_retries: Option<u32>,
+    pub expbackoff_initial_delay: Option<u64>,
     pub enable_iak_idevid: bool,
     pub iak_cert: String,
     pub iak_handle: String,
@@ -264,6 +272,11 @@ impl Default for AgentConfig {
             enable_revocation_notifications:
                 DEFAULT_ENABLE_REVOCATION_NOTIFICATIONS,
             enc_keyname: DEFAULT_ENC_KEYNAME.to_string(),
+            expbackoff_max_delay: Some(DEFAULT_EXP_BACKOFF_MAX_DELAY as u64),
+            expbackoff_max_retries: Some(DEFAULT_EXP_BACKOFF_MAX_RETRIES),
+            expbackoff_initial_delay: Some(
+                DEFAULT_EXP_BACKOFF_INITIAL_DELAY as u64,
+            ),
             extract_payload_zip: DEFAULT_EXTRACT_PAYLOAD_ZIP,
             iak_cert: "default".to_string(),
             iak_handle: DEFAULT_IAK_HANDLE.to_string(),

--- a/keylime/src/config/base.rs
+++ b/keylime/src/config/base.rs
@@ -99,7 +99,7 @@ pub const DEFAULT_UEFI_LOGS_BINARY_FILE_PATH: &str =
     "/sys/kernel/security/tpm0/binary_bios_measurements";
 
 // Default values for exponential backoff
-pub const DEFAULT_EXP_BACKOFF_INITIAL_DELAY: u32 = 2000; // 1 second
+pub const DEFAULT_EXP_BACKOFF_INITIAL_DELAY: u32 = 2000; // 2 seconds
 pub const DEFAULT_EXP_BACKOFF_MAX_RETRIES: u32 = 5;
 pub const DEFAULT_EXP_BACKOFF_MAX_DELAY: u32 = 60000; // 60 seconds
 

--- a/keylime/src/config/push_model.rs
+++ b/keylime/src/config/push_model.rs
@@ -37,6 +37,9 @@ pub struct PushModelConfig {
     contact_ip: String,
     contact_port: u32,
     disabled_signing_algorithms: Vec<String>,
+    expbackoff_max_delay: Option<u64>,
+    expbackoff_max_retries: Option<u32>,
+    expbackoff_initial_delay: Option<u64>,
     enable_iak_idevid: bool,
     #[transform(using = override_default_ek_handle, error = OverrideError)]
     ek_handle: String,

--- a/keylime/src/lib.rs
+++ b/keylime/src/lib.rs
@@ -19,6 +19,7 @@ pub mod list_parser;
 pub mod permissions;
 pub mod quote;
 pub mod registrar_client;
+pub mod resilient_client;
 pub mod secure_mount;
 pub mod serialization;
 pub mod structures;

--- a/keylime/src/resilient_client.rs
+++ b/keylime/src/resilient_client.rs
@@ -3,8 +3,8 @@ use reqwest_middleware::{
     ClientBuilder, ClientWithMiddleware, Error, RequestBuilder,
 };
 use reqwest_retry::{
-    policies::ExponentialBackoff, RetryTransientMiddleware, Retryable,
-    RetryableStrategy,
+    policies::ExponentialBackoff, Jitter, RetryTransientMiddleware,
+    Retryable, RetryableStrategy,
 };
 use serde::Serialize;
 use std::time::Duration;
@@ -57,6 +57,7 @@ impl ResilientClient {
 
         let retry_policy = ExponentialBackoff::builder()
             .retry_bounds(initial_delay, final_max_delay)
+            .jitter(Jitter::None)
             .build_with_max_retries(max_retries);
 
         let client_with_middleware = ClientBuilder::new(base_client)

--- a/keylime/src/resilient_client.rs
+++ b/keylime/src/resilient_client.rs
@@ -1,0 +1,300 @@
+use reqwest::{Client, Method, Response, StatusCode};
+use reqwest_middleware::{
+    ClientBuilder, ClientWithMiddleware, Error, RequestBuilder,
+};
+use reqwest_retry::{
+    policies::ExponentialBackoff, RetryTransientMiddleware, Retryable,
+    RetryableStrategy,
+};
+use serde::Serialize;
+use std::time::Duration;
+
+const DEFAULT_MAX_DELAY: Duration = Duration::from_secs(60);
+
+/// Custom strategy to determine which responses are retryable.
+/// It considers any status code NOT in the `success_codes` list as a potential transient error.
+#[derive(Clone)]
+struct StopOnSuccessStrategy {
+    success_codes: Vec<StatusCode>,
+}
+
+impl RetryableStrategy for StopOnSuccessStrategy {
+    fn handle(&self, res: &Result<Response, Error>) -> Option<Retryable> {
+        match res {
+            // If we got a response, check its status code.
+            Ok(response) => {
+                // If the status code is one of our defined success codes, it's NOT retryable.
+                if self.success_codes.contains(&response.status()) {
+                    None
+                } else {
+                    // For any other status, let the default strategy decide if it's a transient error.
+                    Some(Retryable::Transient)
+                }
+            }
+            // If there was a network error, it's always a transient error.
+            Err(_) => Some(Retryable::Transient),
+        }
+    }
+}
+
+/// A client that transparently handles retries with exponential backoff.
+#[derive(Debug, Clone)]
+pub struct ResilientClient {
+    client: ClientWithMiddleware,
+}
+
+impl ResilientClient {
+    /// Creates a new client with a defined retry strategy.
+    pub fn new(
+        client: Option<Client>,
+        initial_delay: Duration,
+        max_retries: u32,
+        success_codes: &[StatusCode],
+        max_delay: Option<Duration>,
+    ) -> Self {
+        let base_client = client.unwrap_or_default();
+        let final_max_delay = max_delay.unwrap_or(DEFAULT_MAX_DELAY);
+
+        let retry_policy = ExponentialBackoff::builder()
+            .retry_bounds(initial_delay, final_max_delay)
+            .build_with_max_retries(max_retries);
+
+        let client_with_middleware = ClientBuilder::new(base_client)
+            .with(RetryTransientMiddleware::new_with_policy_and_strategy(
+                retry_policy,
+                StopOnSuccessStrategy {
+                    success_codes: success_codes.to_vec(),
+                },
+            ))
+            .build();
+
+        Self {
+            client: client_with_middleware,
+        }
+    }
+
+    /// Prepares a request with a JSON body, returning a Result.
+    pub fn send_json<T: Serialize>(
+        &self,
+        method: Method,
+        url: &str,
+        json_serializable: &T,
+    ) -> Result<RequestBuilder, serde_json::Error> {
+        // Use the `?` operator to propagate a serialization error instead of panicking.
+        let body_as_string = serde_json::to_string(json_serializable)?;
+
+        let builder = self
+            .client
+            .request(method, url)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body_as_string);
+
+        // Wrap the successful result in Ok().
+        Ok(builder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header;
+    use serde_json::json;
+    use std::net::TcpListener;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn test_resilient_client_creation() {
+        let mock_server = MockServer::start().await;
+        // The mock server will only respond with 200 if the custom header is present.
+        Mock::given(method("GET"))
+            .and(path("/test"))
+            .and(header("X-Test", "true"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        // Create a pre-configured client with a default header.
+        let mut headers = header::HeaderMap::new();
+        headers.insert("X-Test", "true".parse().unwrap()); //#[allow_ci]
+        let preconfigured_client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .unwrap(); //#[allow_ci]
+
+        // Initialize ResilientClient with the pre-configured client.
+        let resilient_client = ResilientClient::new(
+            Some(preconfigured_client),
+            Duration::from_millis(10),
+            0,
+            &[StatusCode::OK],
+            None,
+        );
+
+        // Make a request. The test will pass only if the default header is sent correctly.
+        let response = resilient_client
+            .client
+            .get(format!("{}/test", &mock_server.uri()))
+            .send()
+            .await
+            .unwrap(); //#[allow_ci]
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_retry_on_server_error_then_success() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/submit"))
+            .and(header("Content-Type", "application/json"))
+            .respond_with(ResponseTemplate::new(503))
+            .up_to_n_times(2)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/submit"))
+            .and(header("Content-Type", "application/json"))
+            .respond_with(ResponseTemplate::new(202)) // The server will succeed with 202
+            .mount(&mock_server)
+            .await;
+
+        let client = ResilientClient::new(
+            None,
+            Duration::from_millis(10),
+            3,
+            &[StatusCode::ACCEPTED], // We tell the client that 202 is a success code
+            None,
+        );
+
+        let response = client
+            .send_json(
+                Method::POST,
+                &format!("{}/submit", &mock_server.uri()),
+                &json!({}),
+            )
+            .unwrap() //#[allow_ci]
+            .send()
+            .await;
+
+        assert!(response.is_ok());
+        assert_eq!(response.unwrap().status(), StatusCode::ACCEPTED); //#[allow_ci]
+        let received_requests =
+            mock_server.received_requests().await.unwrap(); //#[allow_ci]
+        assert_eq!(received_requests.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_stops_on_success_code() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/submit"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        let client = ResilientClient::new(
+            None,
+            Duration::from_millis(10),
+            3,
+            &[StatusCode::OK], // We tell the client that 200 is a success code
+            None,
+        );
+
+        let response = client
+            .send_json(
+                Method::POST,
+                &format!("{}/submit", &mock_server.uri()),
+                &json!({}),
+            )
+            .unwrap() //#[allow_ci]
+            .send()
+            .await;
+
+        assert!(response.is_ok());
+        assert_eq!(response.unwrap().status(), StatusCode::OK); //#[allow_ci]
+        let received_requests =
+            mock_server.received_requests().await.unwrap(); //#[allow_ci]
+        assert_eq!(received_requests.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_exhausts_retries() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/submit"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&mock_server)
+            .await;
+
+        let max_retries = 2;
+        let client = ResilientClient::new(
+            None,
+            Duration::from_millis(10),
+            max_retries,
+            &[StatusCode::OK],
+            None,
+        );
+
+        let response = client
+            .send_json(
+                Method::POST,
+                &format!("{}/submit", &mock_server.uri()),
+                &json!({}),
+            )
+            .unwrap() //#[allow_ci]
+            .send()
+            .await
+            .unwrap(); //#[allow_ci]
+
+        // The overall request is "successful" at the network level, but the status indicates an error.
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        // The server should have received 1 (original) + 2 (retries) = 3 requests.
+        let received_requests =
+            mock_server.received_requests().await.unwrap(); //#[allow_ci]
+        assert_eq!(received_requests.len(), (max_retries + 1) as usize);
+    }
+
+    /// A helper function to find a TCP port that is currently not in use.
+    fn find_free_port() -> u16 {
+        // Ask the OS for a free port by binding to port 0.
+        TcpListener::bind("127.0.0.1:0")
+            .expect("Could not bind to a free port")
+            .local_addr()
+            .expect("Could not get local address")
+            .port()
+    }
+
+    #[tokio::test]
+    async fn test_retries_on_network_error() {
+        // Verifies that the client retries when a network error occurs (e.g., connection refused).
+        // This specifically tests the `Err(_)` arm of the `handle` method.
+        let unreachable_url =
+            format!("http://127.0.0.1:{}", find_free_port());
+        let max_retries = 2;
+
+        let client = ResilientClient::new(
+            None,
+            Duration::from_millis(10),
+            max_retries,
+            &[StatusCode::OK],
+            None,
+        );
+
+        let response = client
+            .send_json(Method::GET, &unreachable_url, &json!({}))
+            .unwrap() //#[allow_ci]
+            .send()
+            .await;
+
+        // The request should fail because the server is unreachable.
+        assert!(
+            response.is_err(),
+            "Expected the request to fail with a network error"
+        );
+    }
+}


### PR DESCRIPTION
This pull request introduces a resilient HTTP client with an exponential backoff strategy to enhance the robustness of the Keylime push model agent. This new client is then integrated into the push-model agent's attestation process, making it more tolerant of transient network failures and temporary server-side errors.

1. Add Resilient HTTP Client with Exponential Backoff

The first commit adds a new, reusable module named resilient_client.

* New Module: Creates keylime/src/resilient_client.rs.
* Functionality: This module provides a ResilientClient that wraps reqwest. It uses the reqwest-retry and reqwest-middleware crates to automatically retry failed HTTP requests.
* Custom Retry Strategy: A custom retry strategy, StopOnSuccessStrategy, is implemented. This allows the client to intelligently stop retrying not only on failures but also when it receives a specific, configurable list of successful HTTP status codes (e.g., 200 OK, 202 Accepted).
* Configurability: The client is configurable with parameters for maximum retries, initial delay, and maximum delay, providing flexible control over the backoff behavior.
* Dependencies: Adds reqwest-middleware, reqwest-retry, and retry-policies to the project. **All these newly introduced crates (and used versions) exist on Fedora:**
    https://src.fedoraproject.org/rpms/rust-retry-policies
    https://src.fedoraproject.org/rpms/rust-reqwest-middleware
    https://src.fedoraproject.org/rpms/rust-reqwest-retry
  

2. Integrate Resilient Client into Push Attestation

The second commit applies the new ResilientClient to the agent's attestation workflow.

* Integration: The keylime-push-model-agent's AttestationClient is refactored to use the new ResilientClient instead of a standard reqwest::Client.
* Increased Robustness: HTTP calls for attestation negotiation and evidence submission will now automatically retry on connection errors or server-side statuses like 503 Service Unavailable.
* New Configuration: New configuration options have been added to the agent's config file (keylime.conf) to control the retry behavior:
   -  expbackoff_max_retries
   -  expbackoff_initial_delay
   -    expbackoff_max_delay
* Improved Reliability: This change makes the push-model agent significantly more reliable in environments where the verifier or registrar might be temporarily unavailable.