### PR TITLE
tpm: Add method to extract signing scheme and hash algorithm from AK

### DIFF
--- a/keylime-push-model-agent/src/struct_filler.rs
+++ b/keylime-push-model-agent/src/struct_filler.rs
@@ -382,6 +382,8 @@ fn get_attestation_request_from_code() -> structures::AttestationRequest {
                                     key_size: 2048,
                                     server_identifier: "ak".to_string(),
                                     public: "VGhpcyBpcyBhIHRlc3QgZm9yIGEgYmFzZTY0IGVuY29kZWQgZm9ybWF0IHN0cmluZw==".to_string(),
+                                    allowable_hash_algorithms: None,
+                                    allowable_signature_schemes: None,
                                 },
                             ],
                         },

--- a/keylime/src/context_info.rs
+++ b/keylime/src/context_info.rs
@@ -363,9 +363,16 @@ impl ContextInfo {
     }
 
     pub fn get_ak_certification_data(
-        &self,
+        &mut self,
     ) -> Result<CertificationKey, ContextInfoError> {
+        // TODO Receive the configuration instead of reading it again
         let config = AgentConfig::new()?;
+
+        // Extract the AK's actual signing scheme and hash algorithm
+        let (ak_signing_scheme, ak_hash_algorithm) = self
+            .tpm_context
+            .extract_ak_scheme_and_hash(self.ak_handle)?;
+
         Ok(CertificationKey {
             key_class: self.get_ak_key_class_str(),
             key_algorithm: self.get_ak_key_algorithm_str(),
@@ -375,6 +382,8 @@ impl ContextInfo {
                 .to_string(),
             local_identifier: self.get_ak_local_identifier_str()?,
             public: self.get_ak_public_key_as_base64()?,
+            allowable_hash_algorithms: Some(vec![ak_hash_algorithm]),
+            allowable_signature_schemes: Some(vec![ak_signing_scheme]),
         })
     }
 

--- a/keylime/src/structures/capabilities_negotiation.rs
+++ b/keylime/src/structures/capabilities_negotiation.rs
@@ -188,6 +188,10 @@ pub struct CertificationKey {
     pub server_identifier: String,
     pub local_identifier: String,
     pub public: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowable_hash_algorithms: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowable_signature_schemes: Option<Vec<String>>,
 }
 
 // Define the structure for the AttestationResponse:
@@ -321,6 +325,8 @@ mod tests {
                                         key_size: 2048,
                                         server_identifier: "ak".to_string(),
                                         public: "OTgtMjkzODQ1LTg5MjMtNDk1OGlrYXNkamZnO2Frc2pka2ZqYXM7a2RqZjtramJrY3hqejk4MS0zMjQ5MDhpLWpmZDth".to_string(),
+                                        allowable_hash_algorithms: None,
+                                        allowable_signature_schemes: None,
                                     },
                                 ],
                             },
@@ -496,6 +502,8 @@ mod tests {
                                         local_identifier: "att_local_identifier".to_string(),
                                         key_algorithm: "rsa".to_string(),
                                         public: "OTgtMjkzODQ1LTg5MjMtNDk1OGlrYXNkamZnO2Frc2pka2ZqYXM7a2RqZjtramJrY3hqejk4MS0zMjQ5MDhpLWpmZDth".to_string(),
+                                        allowable_hash_algorithms: None,
+                                        allowable_signature_schemes: None,
                                     },
                                 ],
                             },
@@ -822,6 +830,8 @@ mod tests {
                                     local_identifier: "att_local_identifier".to_string(),
                                     key_algorithm: "rsa".to_string(),
                                     public: "OTgtMjkzODQ1LTg5MjMtNDk1OGlrYXNkamZnO2Frc2pka2ZqYXM7a2RqZjtramJrY3hqejk4MS0zMjQ5MDhpLWpmZDth".to_string(),
+                                    allowable_hash_algorithms: None,
+                                    allowable_signature_schemes: None,
                                 }),
                             }))),
                         },
@@ -915,6 +925,8 @@ mod tests {
                                     local_identifier: "att_local_identifier".to_string(),
                                     key_algorithm: "rsa".to_string(),
                                     public: "OTgtMjkzODQ1LTg5MjMtNDk1OGlrYXNkamZnO2Frc2pka2ZqYXM7a2RqZjtramJrY3hqejk4MS0zMjQ5MDhpLWpmZDth".to_string(),
+                                    allowable_hash_algorithms: None,
+                                    allowable_signature_schemes: None,
                                 }),
                             }))),
                         },

--- a/keylime/src/structures/evidence_handling.rs
+++ b/keylime/src/structures/evidence_handling.rs
@@ -708,6 +708,8 @@ mod tests {
                                     local_identifier: "att_local_identifier".to_string(),
                                     key_algorithm: "rsa".to_string(),
                                     public: "OTgtMjkzODQ1LTg5MjMtNDk1OGlrYXNkamZnO2Frc2pka2ZqYXM7a2RqZjtramJrY3hqejk4MS0zMjQ5MDhpLWpmZDth".to_string(),
+                                    allowable_hash_algorithms: None,
+                                    allowable_signature_schemes: None,
                                 }),
                             }))),
                             data: EvidenceData::TpmQuoteData {
@@ -750,6 +752,8 @@ mod tests {
                                     local_identifier: "att_local_identifier".to_string(),
                                     key_algorithm: "rsa".to_string(),
                                     public: "OTgtMjkzODQ1LTg5MjMtNDk1OGlrYXNkamZnO2Frc2pka2ZqYXM7a2RqZjtramJrY3hqejk4MS0zMjQ5MDhpLWpmZDth".to_string(),
+                                    allowable_hash_algorithms: None,
+                                    allowable_signature_schemes: None,
                                 }),
                             }))),
                             data: EvidenceData::UefiLog {


### PR DESCRIPTION
The signing scheme and hash algorithm that the AK can use is set and locked during its generation.  This means that an AK cannot be used to generate signatures using a different scheme.

This adds a method to extract the signing scheme and hash algorithm set during the AK generation from the TPM for the given AK.

The push attestation agent prototype is modified to generate a quote using the extracted signing scheme and hash algorithm.