### PR TITLE
Fix body sending by allowing serializing strings 

### DIFF
--- a/keylime-push-model-agent/src/attestation.rs
+++ b/keylime-push-model-agent/src/attestation.rs
@@ -82,7 +82,7 @@ impl AttestationClient {
 
         let response = self
             .client
-            .get_json_request(
+            .get_json_request_from_struct(
                 reqwest::Method::POST,
                 config.url,
                 &req,
@@ -391,12 +391,9 @@ mod tests {
 
         let single_serialized_body = sample_evidence_struct.to_string();
 
-        let expected_incorrect_body =
-            serde_json::to_string(&single_serialized_body).unwrap();
-
         Mock::given(method("PATCH"))
             .and(path("/evidence"))
-            .and(body_string(expected_incorrect_body))
+            .and(body_string(single_serialized_body.clone()))
             .respond_with(ResponseTemplate::new(202))
             .mount(&mock_server)
             .await;

--- a/keylime/src/registrar_client.rs
+++ b/keylime/src/registrar_client.rs
@@ -367,7 +367,12 @@ impl RegistrarClient {
 
         let resp = match self.resilient_client {
             Some(ref client) => client
-                .get_json_request(reqwest::Method::POST, &addr, &data, None)
+                .get_json_request_from_struct(
+                    reqwest::Method::POST,
+                    &addr,
+                    &data,
+                    None,
+                )
                 .map_err(RegistrarClientError::Serde)?
                 .send()
                 .await


### PR DESCRIPTION
This patch refactors the resilient_client to fix a JSON double-encoding bug that caused the verifier to reject requests.

The root cause of the "malformed parameters" error from Verifier was that the `get_json_request` function was being called with a String that already contained JSON. The function would then re-serialize this string, wrapping it in an extra layer of quotes and escaping its contents, leading to a double-encoded payload.

This PR resolves the issue by improving the client's API to be more explicit and prevent this error by design.

* keylime/src/resilient_client.rs:

The original `get_json_request` function has been refactored. Its signature is changed to accept a pre-serialized string slice (json_string: &str) and it now uses this string directly as the request body without further serialization.

A new function, get_json_request_from_struct<T: Serialize>, has been introduced. This function now contains the original logic: it takes a serializable Rust struct, converts it to a JSON string, and then calls the new get_json_request to build the request.

* keylime-push-model-agent/src/attestation.rs & keylime/src/registrar_client.rs:

All call sites have been updated to use the new, more descriptive get_json_request_from_struct function, clarifying the intent to serialize a struct.

A test case in the push-model agent was also corrected to assert against the properly single-encoded JSON body.