### PR TITLE
tpm: Avoid running code example during documentation tests

### DIFF
--- a/keylime/src/tpm.rs
+++ b/keylime/src/tpm.rs
@@ -1877,7 +1877,7 @@ impl Context<'_> {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// use keylime::tpm::Context;
     /// use keylime::algorithms::{EncryptionAlgorithm, HashAlgorithm, SignAlgorithm};
     /// use tss_esapi::handles::ObjectHandle;


### PR DESCRIPTION
Annotate code example to avoid executing it during documentation tests. This is particularly important for tests that depend on the presence of TPM.