### PR TITLE
Fix exponential backoff (10secs, 4xx accepted)

### DIFF
--- a/keylime/src/config/base.rs
+++ b/keylime/src/config/base.rs
@@ -99,9 +99,9 @@ pub const DEFAULT_UEFI_LOGS_BINARY_FILE_PATH: &str =
     "/sys/kernel/security/tpm0/binary_bios_measurements";
 
 // Default values for exponential backoff
-pub const DEFAULT_EXP_BACKOFF_INITIAL_DELAY: u32 = 2000; // 2 seconds
+pub const DEFAULT_EXP_BACKOFF_INITIAL_DELAY: u32 = 10000; // 10 seconds
 pub const DEFAULT_EXP_BACKOFF_MAX_RETRIES: u32 = 5;
-pub const DEFAULT_EXP_BACKOFF_MAX_DELAY: u32 = 60000; // 60 seconds
+pub const DEFAULT_EXP_BACKOFF_MAX_DELAY: u32 = 300000; // 300 seconds
 
 // TODO These should be temporary
 pub const DEFAULT_CERTIFICATION_KEYS_SERVER_IDENTIFIER: &str = "ak";


### PR DESCRIPTION
This patch introduces two key refinements to the agent's exponential
backoff and retry logic, making it more patient and aligned with
standard network practices.

* Increased Default Backoff Timings (config/base.rs)
The default values for the exponential backoff have been
significantly increased:

  - Initial Delay: Changed from 2 seconds to 10 seconds. This makes
the agent wait longer before the first retry, which is more suitable for
services that might be slow to initialize.

  - Maximum Delay: Changed from 60 seconds to 300 seconds (5
minutes). This allows the delay between retries to grow larger,
accommodating longer-term service disruptions.

* Smarter Retry Strategy (resilient_client.rs)
The core logic in the custom StopOnSuccessStrategy has been improved
to be more intelligent about when to retry.

  - Before: The strategy would retry on any non-success status code,
including 4xx client errors (like 404 Not Found), which are typically
not temporary.

  - After: The strategy now delegates the decision for non-success
codes to reqwest-retry's built-in default_on_request_success function.
This default logic is smarter:

* It will retry on 5xx server errors (e.g., 503 Service Unavailable).

* It will NOT retry on most 4xx client errors (e.g., 404 Not
Found, 403 Forbidden), as these indicate a problem with the request
itself, not a temporary server issue.

* Similarly, the handling of network errors is now delegated to
default_on_request_failure, ensuring consistent and robust behavior.
