### PR TITLE
Align exp.backoff to current configuration format

### DIFF
--- a/keylime-push-model-agent/src/main.rs
+++ b/keylime-push-model-agent/src/main.rs
@@ -145,11 +145,13 @@ async fn run(args: &Args) -> Result<()> {
         ca_certificate: &args.ca_certificate,
         client_certificate: &args.certificate,
         ima_log_path: Some(config.ima_ml_path.as_str()),
-        initial_delay_ms: config.expbackoff_initial_delay.unwrap_or(1000),
+        initial_delay_ms: config
+            .exponential_backoff_initial_delay
+            .unwrap_or(1000),
         insecure: args.insecure,
         key: &args.key,
-        max_delay_ms: config.expbackoff_max_delay,
-        max_retries: config.expbackoff_max_retries.unwrap_or(5),
+        max_delay_ms: config.exponential_backoff_max_delay,
+        max_retries: config.exponential_backoff_max_retries.unwrap_or(5),
         timeout: args.timeout,
         uefi_log_path: Some(config.measuredboot_ml_path.as_str()),
         url: &negotiations_request_url,

--- a/keylime-push-model-agent/src/registration.rs
+++ b/keylime-push-model-agent/src/registration.rs
@@ -25,16 +25,20 @@ pub async fn check_registration<T: PushModelConfigTrait>(
 fn get_retry_config<T: PushModelConfigTrait>(
     config: &T,
 ) -> Option<RetryConfig> {
-    if config.expbackoff_max_retries().is_none()
-        && config.expbackoff_initial_delay().is_none()
-        && config.expbackoff_max_delay().is_none()
+    if config.exponential_backoff_max_retries().is_none()
+        && config.exponential_backoff_initial_delay().is_none()
+        && config.exponential_backoff_max_delay().is_none()
     {
         None
     } else {
         Some(RetryConfig {
-            max_retries: config.expbackoff_max_retries().unwrap_or(0),
-            initial_delay_ms: config.expbackoff_initial_delay().unwrap_or(0),
-            max_delay_ms: *config.expbackoff_max_delay(),
+            max_retries: config
+                .exponential_backoff_max_retries()
+                .unwrap_or(0),
+            initial_delay_ms: config
+                .exponential_backoff_initial_delay()
+                .unwrap_or(0),
+            max_delay_ms: *config.exponential_backoff_max_delay(),
         })
     }
 }
@@ -125,9 +129,9 @@ mod tests {
             agent_data_path: "".to_string(),
             disabled_signing_algorithms: vec![],
         };
-        config.expbackoff_initial_delay = None;
-        config.expbackoff_max_retries = None;
-        config.expbackoff_max_delay = None;
+        config.exponential_backoff_initial_delay = None;
+        config.exponential_backoff_max_retries = None;
+        config.exponential_backoff_max_delay = None;
 
         let mut context_info = ContextInfo::new_from_str(alg_config)
             .expect("Failed to create context info from string");

--- a/keylime/src/config/base.rs
+++ b/keylime/src/config/base.rs
@@ -114,9 +114,9 @@ pub struct AgentConfig {
     pub api_versions: String,
     pub disabled_signing_algorithms: Vec<String>,
     pub ek_handle: String,
-    pub expbackoff_max_delay: Option<u64>,
-    pub expbackoff_max_retries: Option<u32>,
-    pub expbackoff_initial_delay: Option<u64>,
+    pub exponential_backoff_max_delay: Option<u64>,
+    pub exponential_backoff_max_retries: Option<u32>,
+    pub exponential_backoff_initial_delay: Option<u64>,
     pub enable_iak_idevid: bool,
     pub iak_cert: String,
     pub iak_handle: String,
@@ -272,9 +272,13 @@ impl Default for AgentConfig {
             enable_revocation_notifications:
                 DEFAULT_ENABLE_REVOCATION_NOTIFICATIONS,
             enc_keyname: DEFAULT_ENC_KEYNAME.to_string(),
-            expbackoff_max_delay: Some(DEFAULT_EXP_BACKOFF_MAX_DELAY as u64),
-            expbackoff_max_retries: Some(DEFAULT_EXP_BACKOFF_MAX_RETRIES),
-            expbackoff_initial_delay: Some(
+            exponential_backoff_max_delay: Some(
+                DEFAULT_EXP_BACKOFF_MAX_DELAY as u64,
+            ),
+            exponential_backoff_max_retries: Some(
+                DEFAULT_EXP_BACKOFF_MAX_RETRIES,
+            ),
+            exponential_backoff_initial_delay: Some(
                 DEFAULT_EXP_BACKOFF_INITIAL_DELAY as u64,
             ),
             extract_payload_zip: DEFAULT_EXTRACT_PAYLOAD_ZIP,

--- a/keylime/src/config/push_model.rs
+++ b/keylime/src/config/push_model.rs
@@ -37,9 +37,9 @@ pub struct PushModelConfig {
     contact_ip: String,
     contact_port: u32,
     disabled_signing_algorithms: Vec<String>,
-    expbackoff_max_delay: Option<u64>,
-    expbackoff_max_retries: Option<u32>,
-    expbackoff_initial_delay: Option<u64>,
+    exponential_backoff_max_delay: Option<u64>,
+    exponential_backoff_max_retries: Option<u32>,
+    exponential_backoff_initial_delay: Option<u64>,
     enable_iak_idevid: bool,
     #[transform(using = override_default_ek_handle, error = OverrideError)]
     ek_handle: String,


### PR DESCRIPTION
The primary reason for this change is to improve code clarity and consistency. Using the full word `exponential_backoff` instead of the abbreviation expbackoff makes the configuration options easier to understand for new developers and aligns them with the naming conventions used elsewhere in the Keylime codebase. This change has no impact on functionality. To address this, renaming of three configuration variables is performed across the codebase to be more descriptive and consistent:

- `expbackoff_initial_delay` is now `exponential_backoff_initial_delay`
- `expbackoff_max_retries` is now `exponential_backoff_max_retries`
- `expbackoff_max_delay` is now `exponential_backoff_max_delay`

This renaming has been applied consistently in all the places where these parameters are defined or used:

* Configuration Structs (keylime/src/config/base.rs & push_model.rs): The field names in the main AgentConfig struct and the PushModelConfig view have been updated to reflect the new names.

* Agent Logic (keylime-push-model-agent/src/main.rs & registration.rs): All code that accesses these configuration values, either through direct struct access or via getter methods, has been updated to use the new, more descriptive names.