### PR TITLE
push-model: implement continuous attestation with configurable intervals

### DIFF
--- a/keylime-push-model-agent/src/attestation.rs
+++ b/keylime-push-model-agent/src/attestation.rs
@@ -14,6 +14,16 @@ pub struct ResponseInformation {
     pub body: String,
 }
 
+impl Default for ResponseInformation {
+    fn default() -> Self {
+        Self {
+            status_code: StatusCode::OK,
+            headers: HeaderMap::new(),
+            body: String::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct NegotiationConfig<'a> {
     pub avoid_tpm: bool,


### PR DESCRIPTION
After the first successful attestation, the agent now waits for a
configurable interval before repeating the attestation process by
returning to the Negotiating state, creating a continuous attestation
loop.

The interval between the attestations is currently fixed, but in the
future, the verifier will provide this information in its response to
the attestation, so we can parse it from there and use it instead.

Currently, the interval between sending the measurements is defined
as 60s, but can be configured with the --attestation-interval-seconds
switch.