### PR TITLE
cargo: Bump retry-policies to version 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
- "retry-policies 0.3.0",
+ "retry-policies",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2234,22 +2234,11 @@ dependencies = [
  "parking_lot 0.11.2",
  "reqwest",
  "reqwest-middleware",
- "retry-policies 0.4.0",
+ "retry-policies",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
  "wasm-timer",
-]
-
-[[package]]
-name = "retry-policies"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "493b4243e32d6eedd29f9a398896e35c6943a123b55eec97dcaee98310d25810"
-dependencies = [
- "anyhow",
- "chrono",
- "rand 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ pretty_env_logger = "0.5"
 reqwest = {version = "0.12", default-features = false, features = ["json", "native-tls"]}
 reqwest-middleware = "0.4.2"
 reqwest-retry = "0.7.0"
-retry-policies = "0.3.0"
+retry-policies = "0.4.0"
 serde = "1.0.80"
 serde_derive = "1.0.80"
 serde_json = { version = "1.0", features = ["raw_value"] }


### PR DESCRIPTION
The `retry-policies` crate in Fedora uses the version 0.4.0