### PR TITLE
Fix boot time retrieval

### DIFF
--- a/keylime/src/boot_time.rs
+++ b/keylime/src/boot_time.rs
@@ -1,0 +1,43 @@
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+/// Returns the system boot time as a `DateTime<Utc>` object by reading /proc/stat.
+pub fn get_boot_time() -> Result<DateTime<Utc>> {
+    let file = File::open("/proc/stat")?;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.starts_with("btime") {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 2 {
+                let timestamp = parts[1].parse::<i64>()?;
+                let boot_datetime = DateTime::from_timestamp(timestamp, 0)
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "Invalid or out-of-range Unix timestamp: {}",
+                            timestamp
+                        )
+                    })?;
+
+                return Ok(boot_datetime);
+            }
+        }
+    }
+
+    Err(anyhow!("btime field not found in /proc/stat"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_boot_time() {
+        let boot_time1 = get_boot_time().unwrap(); //#[allow_ci]
+        let boot_time2 = get_boot_time().unwrap(); //#[allow_ci]
+        assert_eq!(boot_time1, boot_time2);
+    }
+}

--- a/keylime/src/lib.rs
+++ b/keylime/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent_data;
 pub mod agent_identity;
 pub mod agent_registration;
 pub mod algorithms;
+pub mod boot_time;
 pub mod cert;
 pub mod config;
 pub mod context_info;


### PR DESCRIPTION
This patch correctly implements boot time retrieval for the Rust agent, replacing the temporary use of the current time with the actual system boot time.

* New boot_time.rs Module: A new module was created to contain the logic for getting the system boot time. It works by parsing the btime field from the /proc/stat file, which is the standard method on Linux.

* Updated Agent Payload: The agent no longer sends the current time (chrono::Utc::now()) as the boot_time. Instead, it now calls the new get_boot_time() function to provide the true boot time in its capabilities report.

* Error Handling: If reading the boot time fails, the agent now logs an error and defaults to the Unix epoch (1970-01-01), ensuring the program doesn't crash.