### PR TITLE
config: Use the singleton pattern to avoid reading the files multiple times

### DIFF
--- a/keylime-agent/src/keys_handler.rs
+++ b/keylime-agent/src/keys_handler.rs
@@ -881,7 +881,7 @@ mod tests {
     async fn test_u_or_v_key(key_len: usize, payload: Option<&[u8]>) {
         // Create temporary working directory and secure mount
         let temp_workdir = tempfile::tempdir().unwrap(); //#[allow_ci]
-        let test_config = get_testing_config(temp_workdir.path());
+        let test_config = get_testing_config(temp_workdir.path(), None);
 
         let (mut fixture, mutex) = QuoteData::fixture().await.unwrap(); //#[allow_ci]
 

--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -956,7 +956,7 @@ mod testing {
             let work_dir =
                 Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
 
-            let test_config = get_testing_config(&work_dir);
+            let test_config = get_testing_config(&work_dir, None);
             let mut ctx = tpm::Context::new()?;
 
             let tpm_encryption_alg =

--- a/keylime-agent/src/payloads.rs
+++ b/keylime-agent/src/payloads.rs
@@ -415,7 +415,7 @@ echo hello > test-output
     #[test]
     fn test_setup_unzipped() {
         let temp_workdir = tempfile::tempdir().unwrap(); //#[allow_ci]
-        let test_config = get_testing_config(temp_workdir.path());
+        let test_config = get_testing_config(temp_workdir.path(), None);
         let secure_mount =
             PathBuf::from(&temp_workdir.path().join("tmpfs-dev"));
         fs::create_dir(&secure_mount).unwrap(); //#[allow_ci]
@@ -448,7 +448,7 @@ echo hello > test-output
     #[test]
     fn test_unzip_payload() {
         let temp_workdir = tempfile::tempdir().unwrap(); //#[allow_ci]
-        let test_config = get_testing_config(temp_workdir.path());
+        let test_config = get_testing_config(temp_workdir.path(), None);
         let payload_path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("test-data")
             .join("payload.zip");
@@ -481,7 +481,7 @@ echo hello > test-output
             .lock()
             .await;
         let temp_workdir = tempfile::tempdir().unwrap(); //#[allow_ci]
-        let test_config = get_testing_config(temp_workdir.path());
+        let test_config = get_testing_config(temp_workdir.path(), None);
         let secure_mount =
             PathBuf::from(&temp_workdir.path().join("tmpfs-dev"));
         fs::create_dir(&secure_mount).unwrap(); //#[allow_ci]
@@ -531,7 +531,7 @@ echo hello > test-output
         use crate::{config::DEFAULT_PAYLOAD_SCRIPT, secure_mount};
 
         let temp_workdir = tempfile::tempdir().unwrap(); //#[allow_ci]
-        let test_config = get_testing_config(temp_workdir.path());
+        let test_config = get_testing_config(temp_workdir.path(), None);
         let secure_mount =
             PathBuf::from(&temp_workdir.path().join("tmpfs-dev"));
         fs::create_dir(&secure_mount).unwrap(); //#[allow_ci]

--- a/keylime-agent/src/revocation.rs
+++ b/keylime-agent/src/revocation.rs
@@ -525,7 +525,7 @@ mod tests {
     fn revocation_scripts_ok() {
         let work_dir = tempfile::tempdir()
             .expect("failed to create temporary directory");
-        let test_config = get_testing_config(work_dir.path());
+        let test_config = get_testing_config(work_dir.path(), None);
         let json_file = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/tests/unzipped/test_ok.json"
@@ -566,7 +566,7 @@ mod tests {
     fn revocation_scripts_err() {
         let work_dir = tempfile::tempdir()
             .expect("failed to create temporary directory");
-        let test_config = get_testing_config(work_dir.path());
+        let test_config = get_testing_config(work_dir.path(), None);
         let json_file = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/tests/unzipped/test_err.json"
@@ -596,7 +596,7 @@ mod tests {
     fn revocation_scripts_from_config() {
         let work_dir = tempfile::tempdir()
             .expect("failed to create temporary directory");
-        let test_config = get_testing_config(work_dir.path());
+        let test_config = get_testing_config(work_dir.path(), None);
         let json_file = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/tests/unzipped/test_ok.json"
@@ -764,7 +764,7 @@ mod tests {
     fn test_process_revocation() {
         let work_dir = tempfile::tempdir()
             .expect("failed to create temporary directory");
-        let test_config = get_testing_config(work_dir.path());
+        let test_config = get_testing_config(work_dir.path(), None);
 
         let sig_path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("test-data/revocation.sig");

--- a/keylime-push-model-agent/Cargo.toml
+++ b/keylime-push-model-agent/Cargo.toml
@@ -35,7 +35,7 @@ wiremock = {version = "0.6"}
 [features]
 # The features enabled by default
 default = []
-testing = []
+testing = ["keylime/testing"]
 legacy-python-actions = []
 
 [package.metadata.deb]

--- a/keylime-push-model-agent/src/context_info_handler.rs
+++ b/keylime-push-model-agent/src/context_info_handler.rs
@@ -88,7 +88,7 @@ mod tests {
         // Use temporary directory instead of assuming /var/lib/keylime exists
         let _mutex = testing::lock_tests().await;
         let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
-        let config = get_testing_config(tmpdir.path());
+        let config = get_testing_config(tmpdir.path(), None);
 
         const AVOID_TPM: bool = true;
         let init_res = init_context_info(&config, AVOID_TPM);
@@ -107,7 +107,7 @@ mod tests {
         // Use temporary directory instead of assuming /var/lib/keylime exists
         let _mutex = testing::lock_tests().await;
         let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
-        let config = get_testing_config(tmpdir.path());
+        let config = get_testing_config(tmpdir.path(), None);
 
         const DONT_AVOID_TPM: bool = false;
         let init_res = init_context_info(&config, DONT_AVOID_TPM);

--- a/keylime-push-model-agent/src/context_info_handler.rs
+++ b/keylime-push-model-agent/src/context_info_handler.rs
@@ -90,8 +90,8 @@ mod tests {
         let config = get_testing_config(tmpdir.path(), None);
 
         const AVOID_TPM: bool = true;
-        // Set testing configuration override
-        keylime::config::set_testing_config_override(config);
+        // Create guard that will automatically clear override when dropped
+        let _guard = keylime::config::TestConfigGuard::new(config);
 
         let init_res = init_context_info(AVOID_TPM);
         assert!(init_res.is_ok());
@@ -101,9 +101,6 @@ mod tests {
             context_res.unwrap().is_none(),
             "Context should be None when TPM is avoided"
         );
-
-        // Clear testing configuration override
-        keylime::config::clear_testing_config_override();
     }
 
     #[tokio::test]
@@ -114,8 +111,8 @@ mod tests {
         let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
         let config = get_testing_config(tmpdir.path(), None);
 
-        // Set testing configuration override
-        keylime::config::set_testing_config_override(config);
+        // Create guard that will automatically clear override when dropped
+        let _guard = keylime::config::TestConfigGuard::new(config);
 
         const DONT_AVOID_TPM: bool = false;
         let init_res = init_context_info(DONT_AVOID_TPM);
@@ -129,8 +126,5 @@ mod tests {
         );
         let mut context_info = context_info_handler.unwrap(); //#[allow_ci]
         context_info.flush_context().unwrap(); //#[allow_ci]
-
-        // Clear testing configuration override
-        keylime::config::clear_testing_config_override();
     }
 }

--- a/keylime-push-model-agent/src/main.rs
+++ b/keylime-push-model-agent/src/main.rs
@@ -2,7 +2,7 @@
 // Copyright 2025 Keylime Authors
 use anyhow::Result;
 use clap::Parser;
-use keylime::config::{AgentConfig, PushModelConfigTrait};
+use keylime::config::PushModelConfigTrait;
 use log::{debug, error, info};
 mod attestation;
 mod auth;
@@ -121,9 +121,9 @@ async fn run(args: &Args) -> Result<()> {
     debug!("Certificate file: {}", args.certificate);
     debug!("Key file: {}", args.key);
     debug!("Insecure: {}", args.insecure.unwrap_or(false));
-    let config = AgentConfig::new()?;
+    let config = keylime::config::get_config();
     let avoid_tpm = get_avoid_tpm_from_args(args);
-    context_info_handler::init_context_info(&config, avoid_tpm)?;
+    context_info_handler::init_context_info(avoid_tpm)?;
     debug!("Avoid TPM: {avoid_tpm}");
     let ctx_info = match context_info_handler::get_context_info(avoid_tpm) {
         Ok(Some(context_info)) => Some(context_info),
@@ -175,7 +175,6 @@ async fn run(args: &Args) -> Result<()> {
     let attestation_client =
         attestation::AttestationClient::new(&neg_config)?;
     let mut state_machine = state_machine::StateMachine::new(
-        &config,
         attestation_client,
         neg_config,
         ctx_info,

--- a/keylime-push-model-agent/src/registration.rs
+++ b/keylime-push-model-agent/src/registration.rs
@@ -112,7 +112,7 @@ mod tests {
     async fn test_avoid_registration() {
         let _mutex = testing::lock_tests().await;
         let tmpdir = tempfile::tempdir().expect("failed to create tempdir");
-        let config = get_testing_config(tmpdir.path());
+        let config = get_testing_config(tmpdir.path(), None);
         let result = check_registration(&config, None).await;
         assert!(result.is_ok());
     }
@@ -121,7 +121,7 @@ mod tests {
     async fn test_register_agent() {
         let _mutex = testing::lock_tests().await;
         let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
-        let mut config = get_testing_config(tmpdir.path());
+        let mut config = get_testing_config(tmpdir.path(), None);
         let alg_config = AlgorithmConfigurationString {
             tpm_encryption_alg: "rsa".to_string(),
             tpm_hash_alg: "sha256".to_string(),

--- a/keylime-push-model-agent/src/registration.rs
+++ b/keylime-push-model-agent/src/registration.rs
@@ -132,16 +132,13 @@ mod tests {
         config.exponential_backoff_max_retries = None;
         config.exponential_backoff_max_delay = None;
 
-        // Set testing configuration override for this test
-        keylime::config::set_testing_config_override(config);
+        // Create guard that will automatically clear override when dropped
+        let _guard = keylime::config::TestConfigGuard::new(config);
 
         let mut context_info = ContextInfo::new_from_str(alg_config)
             .expect("Failed to create context info from string");
         let result = register_agent(&mut context_info).await;
         assert!(result.is_err());
         assert!(context_info.flush_context().is_ok());
-
-        // Clear testing configuration override
-        keylime::config::clear_testing_config_override();
     }
 }

--- a/keylime-push-model-agent/src/struct_filler.rs
+++ b/keylime-push-model-agent/src/struct_filler.rs
@@ -2,7 +2,7 @@
 // Copyright 2025 Keylime Authors
 use async_trait::async_trait;
 use keylime::algorithms::HashAlgorithm;
-use keylime::config::{AgentConfig, PushModelConfigTrait};
+use keylime::config::PushModelConfigTrait;
 use keylime::context_info::ContextInfo;
 use keylime::ima::ImaLog;
 use keylime::structures;
@@ -65,10 +65,7 @@ pub struct FillerFromHardware<'a> {
 
 impl<'a> FillerFromHardware<'a> {
     pub fn new(tpm_context_info: &'a mut ContextInfo) -> Self {
-        // TODO: Change this to avoid loading the configuration multiple times
-        // TODO: Modify here to avoid panic on failure
-        let config =
-            AgentConfig::new().expect("failed to load configuration");
+        let config = keylime::config::get_config();
         let ml_path = config.measuredboot_ml_path();
         let uefi_log_handler = uefi_log_handler::UefiLogHandler::new(ml_path);
         match uefi_log_handler {
@@ -85,15 +82,11 @@ impl<'a> FillerFromHardware<'a> {
             }
         }
     }
-    // TODO: Change this function to use the attestation request appropriately
-    // Add self to the function signature to use the tpm_context
+
     fn get_attestation_request_final(
         &mut self,
     ) -> structures::AttestationRequest {
-        // TODO: Change this to avoid loading the configuration multiple times
-        // TODO Modify this to not panic on failure
-        let config =
-            AgentConfig::new().expect("failed to load configuration");
+        let config = keylime::config::get_config();
 
         // Get all supported hash algorithms from the TPM
         let supported_algorithms = self
@@ -644,6 +637,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "testing")]
     async fn test_filler_from_hardware_new_with_uefi_error() {
         use keylime::config::{
             clear_testing_config_override, get_testing_config,

--- a/keylime-push-model-agent/src/struct_filler.rs
+++ b/keylime-push-model-agent/src/struct_filler.rs
@@ -639,10 +639,7 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "testing")]
     async fn test_filler_from_hardware_new_with_uefi_error() {
-        use keylime::config::{
-            clear_testing_config_override, get_testing_config,
-            set_testing_config_override,
-        };
+        use keylime::config::{get_testing_config, TestConfigGuard};
 
         let _mutex = testing::lock_tests().await;
         let context_info_result = context_info::ContextInfo::new_from_str(
@@ -668,14 +665,12 @@ mod tests {
             let test_config =
                 get_testing_config(temp_dir.path(), Some(overrides));
 
-            // Set the testing configuration override
-            set_testing_config_override(test_config);
+            // Create guard that will automatically clear override when dropped
+            let _guard = TestConfigGuard::new(test_config);
 
             let filler = FillerFromHardware::new(&mut ctx);
             assert!(filler.uefi_log_handler.is_none());
 
-            // Clear the testing configuration override
-            clear_testing_config_override();
             assert!(ctx.flush_context().is_ok());
         }
     }

--- a/keylime/src/agent_data.rs
+++ b/keylime/src/agent_data.rs
@@ -79,7 +79,7 @@ mod test {
 
         let tempdir =
             tempfile::tempdir().expect("failed to create temporary dir");
-        let config = config::get_testing_config(tempdir.path());
+        let config = config::get_testing_config(tempdir.path(), None);
 
         let mut ctx = tpm::Context::new().unwrap(); //#[allow_ci]
 
@@ -138,7 +138,7 @@ mod test {
         let _mutex = tpm::testing::lock_tests().await;
         let tempdir =
             tempfile::tempdir().expect("failed to create temporary dir");
-        let config = config::get_testing_config(tempdir.path());
+        let config = config::get_testing_config(tempdir.path(), None);
 
         let mut ctx = tpm::Context::new().unwrap(); //#[allow_ci]
 

--- a/keylime/src/config/env.rs
+++ b/keylime/src/config/env.rs
@@ -61,7 +61,7 @@ mod test {
         // Get the configuration using a temporary directory as `keylime_dir`
         let tempdir =
             tempfile::tempdir().expect("failed to create temporary dir");
-        let default = get_testing_config(tempdir.path());
+        let default = get_testing_config(tempdir.path(), None);
 
         let env_config = EnvConfig::new().unwrap(); //#[allow_ci]
 
@@ -166,7 +166,7 @@ mod test {
         // Get the configuration using a temporary directory as `keylime_dir`
         let tempdir =
             tempfile::tempdir().expect("failed to create temporary dir");
-        let default = get_testing_config(tempdir.path());
+        let default = get_testing_config(tempdir.path(), None);
 
         // For possible variable
         for (c, v) in override_map.into_iter() {

--- a/keylime/src/config/error.rs
+++ b/keylime/src/config/error.rs
@@ -78,4 +78,8 @@ pub enum KeylimeConfigError {
     // Error from serde crate
     #[error("Serde error")]
     Serde(#[from] serde_json::Error),
+
+    // Configuration singleton already initialized
+    #[error("Configuration singleton already initialized")]
+    SingletonAlreadyInitialized,
 }

--- a/keylime/src/config/mod.rs
+++ b/keylime/src/config/mod.rs
@@ -3,6 +3,7 @@ mod env;
 mod error;
 mod file_config;
 mod push_model;
+mod singleton;
 #[cfg(feature = "testing")]
 mod testing;
 
@@ -11,5 +12,6 @@ pub use env::*;
 pub use error::*;
 pub use file_config::*;
 pub use push_model::*;
+pub use singleton::{get_config, initialize_config, is_initialized};
 #[cfg(feature = "testing")]
 pub use testing::*;

--- a/keylime/src/config/mod.rs
+++ b/keylime/src/config/mod.rs
@@ -3,9 +3,13 @@ mod env;
 mod error;
 mod file_config;
 mod push_model;
+#[cfg(feature = "testing")]
+mod testing;
 
 pub use base::*;
 pub use env::*;
 pub use error::*;
 pub use file_config::*;
 pub use push_model::*;
+#[cfg(feature = "testing")]
+pub use testing::*;

--- a/keylime/src/config/push_model.rs
+++ b/keylime/src/config/push_model.rs
@@ -70,7 +70,7 @@ mod tests {
     #[test]
     fn test_push_model_trait() {
         let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
-        let config = get_testing_config(tmpdir.path());
+        let config = get_testing_config(tmpdir.path(), None);
         assert_eq!(
             config.certification_keys_server_identifier(),
             DEFAULT_CERTIFICATION_KEYS_SERVER_IDENTIFIER

--- a/keylime/src/config/singleton.rs
+++ b/keylime/src/config/singleton.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Keylime Authors
+
+use super::{AgentConfig, KeylimeConfigError};
+use std::sync::OnceLock;
+
+static GLOBAL_CONFIG: OnceLock<AgentConfig> = OnceLock::new();
+
+/// Initialize the global configuration singleton (optional explicit initialization)
+///
+/// This function can be called at application startup to explicitly initialize
+/// the configuration. If not called, the configuration will be automatically
+/// initialized on first access via `get_config()`.
+///
+/// # Errors
+///
+/// Returns `KeylimeConfigError::SingletonAlreadyInitialized` if called after
+/// the configuration has already been initialized (either explicitly or automatically).
+/// Returns any configuration loading error if the configuration cannot be loaded.
+pub fn initialize_config() -> Result<(), KeylimeConfigError> {
+    let config = AgentConfig::new()?;
+    GLOBAL_CONFIG
+        .set(config)
+        .map_err(|_| KeylimeConfigError::SingletonAlreadyInitialized)?;
+    Ok(())
+}
+
+/// Get reference to the configuration (factory method)
+///
+/// This is the main factory method for accessing the configuration.
+/// Returns the global singleton reference. If the configuration has not been
+/// initialized yet, it will be automatically initialized.
+///
+/// # Panics
+///
+/// Panics if configuration loading fails during automatic initialization.
+pub fn get_config() -> &'static AgentConfig {
+    #[cfg(feature = "testing")]
+    {
+        // In testing mode, check for testing override first
+        use crate::config::testing::TESTING_CONFIG_OVERRIDE;
+        use std::sync::Mutex;
+
+        let mutex = TESTING_CONFIG_OVERRIDE.get_or_init(|| Mutex::new(None));
+        if let Ok(guard) = mutex.lock() {
+            if let Some(ref testing_config) = *guard {
+                // If there's a testing override, we need to use Box::leak to get a static reference
+                let leaked_config =
+                    Box::leak(Box::new(testing_config.clone()));
+                return leaked_config;
+            }
+        }
+    }
+
+    // Use normal singleton - AgentConfig::new() already handles testing overrides
+    GLOBAL_CONFIG.get_or_init(|| {
+        AgentConfig::new().expect("Failed to load configuration")
+    })
+}
+
+/// Check if configuration has been initialized
+///
+/// This can be used for defensive programming or in tests to verify initialization state.
+pub fn is_initialized() -> bool {
+    GLOBAL_CONFIG.get().is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PushModelConfigTrait;
+
+    #[test]
+    fn test_lazy_initialization() {
+        // Test that get_config() works with automatic initialization
+        let config = get_config();
+
+        // Verify we got a valid configuration
+        assert!(!config.uuid().is_empty(), "Config should have a valid UUID");
+        assert!(
+            !config.keylime_dir.is_empty(),
+            "Config should have a keylime directory"
+        );
+
+        // After first access, should be initialized
+        assert!(
+            is_initialized(),
+            "Config should be initialized after first access"
+        );
+
+        // Subsequent calls should return the same instance
+        let config2 = get_config();
+        assert_eq!(
+            config.uuid(),
+            config2.uuid(),
+            "Should return same config instance"
+        );
+    }
+}

--- a/keylime/src/config/testing.rs
+++ b/keylime/src/config/testing.rs
@@ -14,8 +14,9 @@ use std::{
 };
 
 // Global storage for testing configuration override
-static TESTING_CONFIG_OVERRIDE: OnceLock<Mutex<Option<AgentConfig>>> =
-    OnceLock::new();
+pub(crate) static TESTING_CONFIG_OVERRIDE: OnceLock<
+    Mutex<Option<AgentConfig>>,
+> = OnceLock::new();
 
 /// Create a configuration based on a temporary directory
 ///
@@ -165,7 +166,7 @@ fn apply_config_overrides(
             }
             "verifier_url" => config.verifier_url = value,
             _ => {
-                log::warn!("Unknown configuration override key: {}", key);
+                log::warn!("Unknown configuration override key: {key}");
             }
         }
     }
@@ -264,7 +265,7 @@ mod tests {
         // Verify override is returned
         let retrieved = get_testing_config_override();
         assert!(retrieved.is_some());
-        let retrieved_config = retrieved.unwrap();
+        let retrieved_config = retrieved.expect("failed to retrieve config");
         assert_eq!(retrieved_config.ip, "test.example.com");
         assert_eq!(retrieved_config.port, 12345);
 

--- a/keylime/src/config/testing.rs
+++ b/keylime/src/config/testing.rs
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Keylime Authors
+
+//! Testing utilities for configuration management
+//!
+//! This module provides utilities for creating and managing test configurations,
+//! including the ability to override configuration values during test execution.
+
+use crate::config::{base::config_translate_keywords, AgentConfig};
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{Mutex, OnceLock},
+};
+
+// Global storage for testing configuration override
+static TESTING_CONFIG_OVERRIDE: OnceLock<Mutex<Option<AgentConfig>>> =
+    OnceLock::new();
+
+/// Create a configuration based on a temporary directory
+///
+/// # Arguments
+///
+/// * `tempdir`: Path to be used as the keylime directory in the generated configuration
+/// * `overrides`: HashMap of configuration option names to values to override in the configuration
+///
+/// # Returns
+///
+/// A `AgentConfig` structure using the given path as the `keylime_dir` option and any provided overrides
+pub fn get_testing_config(
+    tempdir: &Path,
+    overrides: Option<HashMap<String, String>>,
+) -> AgentConfig {
+    let mut config = AgentConfig {
+        keylime_dir: tempdir.display().to_string(),
+        ..AgentConfig::default()
+    };
+
+    // Apply any overrides if provided
+    if let Some(overrides) = overrides {
+        apply_config_overrides(&mut config, overrides);
+    }
+
+    // It is expected that the translation of keywords will not fail
+    config_translate_keywords(&config).expect("failed to translate keywords")
+}
+
+/// Apply configuration overrides to an AgentConfig instance
+///
+/// # Arguments
+///
+/// * `config`: Mutable reference to the AgentConfig to modify
+/// * `overrides`: HashMap of configuration option names to values to override
+fn apply_config_overrides(
+    config: &mut AgentConfig,
+    overrides: HashMap<String, String>,
+) {
+    use crate::config::{
+        DEFAULT_CONTACT_PORT, DEFAULT_PORT, DEFAULT_REGISTRAR_PORT,
+        DEFAULT_REVOCATION_NOTIFICATION_PORT,
+    };
+
+    for (key, value) in overrides {
+        match key.as_str() {
+            "measuredboot_ml_path" => config.measuredboot_ml_path = value,
+            "ima_ml_path" => config.ima_ml_path = value,
+            "agent_data_path" => config.agent_data_path = value,
+            "api_versions" => config.api_versions = value,
+            "disabled_signing_algorithms" => {
+                // Parse as comma-separated list
+                config.disabled_signing_algorithms =
+                    value.split(',').map(|s| s.trim().to_string()).collect();
+            }
+            "ek_handle" => config.ek_handle = value,
+            "exponential_backoff_max_delay" => {
+                config.exponential_backoff_max_delay = value.parse().ok();
+            }
+            "exponential_backoff_max_retries" => {
+                config.exponential_backoff_max_retries = value.parse().ok();
+            }
+            "exponential_backoff_initial_delay" => {
+                config.exponential_backoff_initial_delay = value.parse().ok();
+            }
+            "enable_iak_idevid" => {
+                config.enable_iak_idevid = value.parse().unwrap_or(false);
+            }
+            "iak_cert" => config.iak_cert = value,
+            "iak_handle" => config.iak_handle = value,
+            "iak_idevid_asymmetric_alg" => {
+                config.iak_idevid_asymmetric_alg = value
+            }
+            "iak_idevid_name_alg" => config.iak_idevid_name_alg = value,
+            "iak_idevid_template" => config.iak_idevid_template = value,
+            "iak_password" => config.iak_password = value,
+            "idevid_cert" => config.idevid_cert = value,
+            "idevid_handle" => config.idevid_handle = value,
+            "idevid_password" => config.idevid_password = value,
+            "ip" => config.ip = value,
+            "port" => {
+                config.port = value.parse().unwrap_or(DEFAULT_PORT);
+            }
+            "registrar_ip" => config.registrar_ip = value,
+            "registrar_port" => {
+                config.registrar_port =
+                    value.parse().unwrap_or(DEFAULT_REGISTRAR_PORT);
+            }
+            "run_as" => config.run_as = value,
+            "tpm_encryption_alg" => config.tpm_encryption_alg = value,
+            "tpm_hash_alg" => config.tpm_hash_alg = value,
+            "tpm_ownerpassword" => config.tpm_ownerpassword = value,
+            "tpm_signing_alg" => config.tpm_signing_alg = value,
+            "trusted_client_ca" => config.trusted_client_ca = value,
+            "uuid" => config.uuid = value,
+            "version" => config.version = value,
+            // Pull attestation options
+            "allow_payload_revocation_actions" => {
+                config.allow_payload_revocation_actions =
+                    value.parse().unwrap_or(false);
+            }
+            "contact_ip" => config.contact_ip = value,
+            "contact_port" => {
+                config.contact_port =
+                    value.parse().unwrap_or(DEFAULT_CONTACT_PORT);
+            }
+            "dec_payload_file" => config.dec_payload_file = value,
+            "enable_agent_mtls" => {
+                config.enable_agent_mtls = value.parse().unwrap_or(true);
+            }
+            "enable_insecure_payload" => {
+                config.enable_insecure_payload =
+                    value.parse().unwrap_or(false);
+            }
+            "enable_revocation_notifications" => {
+                config.enable_revocation_notifications =
+                    value.parse().unwrap_or(false);
+            }
+            "enc_keyname" => config.enc_keyname = value,
+            "extract_payload_zip" => {
+                config.extract_payload_zip = value.parse().unwrap_or(true);
+            }
+            "payload_script" => config.payload_script = value,
+            "revocation_actions" => config.revocation_actions = value,
+            "revocation_actions_dir" => config.revocation_actions_dir = value,
+            "revocation_cert" => config.revocation_cert = value,
+            "revocation_notification_ip" => {
+                config.revocation_notification_ip = value
+            }
+            "revocation_notification_port" => {
+                config.revocation_notification_port = value
+                    .parse()
+                    .unwrap_or(DEFAULT_REVOCATION_NOTIFICATION_PORT);
+            }
+            "secure_size" => config.secure_size = value,
+            "server_cert" => config.server_cert = value,
+            "server_key" => config.server_key = value,
+            "server_key_password" => config.server_key_password = value,
+            // Push attestation options
+            "certification_keys_server_identifier" => {
+                config.certification_keys_server_identifier = value
+            }
+            "ima_ml_count_file" => config.ima_ml_count_file = value,
+            "registrar_api_versions" => config.registrar_api_versions = value,
+            "uefi_logs_evidence_version" => {
+                config.uefi_logs_evidence_version = value
+            }
+            "verifier_url" => config.verifier_url = value,
+            _ => {
+                log::warn!("Unknown configuration override key: {}", key);
+            }
+        }
+    }
+}
+
+/// Set a testing configuration override that will be returned by AgentConfig::new()
+/// during test execution. This allows tests to override specific configuration values
+/// without affecting the actual configuration files.
+///
+/// # Arguments
+///
+/// * `config`: The configuration to use as override during testing
+pub fn set_testing_config_override(config: AgentConfig) {
+    let mutex = TESTING_CONFIG_OVERRIDE.get_or_init(|| Mutex::new(None));
+    if let Ok(mut guard) = mutex.lock() {
+        *guard = Some(config);
+    }
+}
+
+/// Clear the testing configuration override, restoring normal configuration loading behavior
+pub fn clear_testing_config_override() {
+    let mutex = TESTING_CONFIG_OVERRIDE.get_or_init(|| Mutex::new(None));
+    if let Ok(mut guard) = mutex.lock() {
+        *guard = None;
+    }
+}
+
+/// Check if there is a testing configuration override and return it if available
+///
+/// This function is called from AgentConfig::new() to check if there's a testing
+/// configuration that should be used instead of loading from files.
+///
+/// # Returns
+///
+/// * `Some(AgentConfig)` if a testing override is set
+/// * `None` if no testing override is active
+pub fn get_testing_config_override() -> Option<AgentConfig> {
+    let mutex = TESTING_CONFIG_OVERRIDE.get_or_init(|| Mutex::new(None));
+    if let Ok(guard) = mutex.lock() {
+        guard.clone()
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_get_testing_config() {
+        let dir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+
+        // Get the config and check that the value is correct
+        let config = get_testing_config(dir.path(), None);
+        assert_eq!(config.keylime_dir, dir.path().display().to_string());
+    }
+
+    #[test]
+    fn test_get_testing_config_with_overrides() {
+        let dir = tempfile::tempdir()
+            .expect("failed to create temporary directory");
+
+        let mut overrides = HashMap::new();
+        overrides.insert("ip".to_string(), "192.168.1.100".to_string());
+        overrides.insert("port".to_string(), "9999".to_string());
+        overrides
+            .insert("ima_ml_path".to_string(), "/custom/path".to_string());
+
+        let config = get_testing_config(dir.path(), Some(overrides));
+
+        assert_eq!(config.keylime_dir, dir.path().display().to_string());
+        assert_eq!(config.ip, "192.168.1.100");
+        assert_eq!(config.port, 9999);
+        assert_eq!(config.ima_ml_path, "/custom/path");
+    }
+
+    #[test]
+    fn test_testing_config_override() {
+        // Clear any existing override
+        clear_testing_config_override();
+
+        // Verify no override is set
+        assert!(get_testing_config_override().is_none());
+
+        // Set an override
+        let test_config = AgentConfig {
+            ip: "test.example.com".to_string(),
+            port: 12345,
+            ..AgentConfig::default()
+        };
+        set_testing_config_override(test_config.clone());
+
+        // Verify override is returned
+        let retrieved = get_testing_config_override();
+        assert!(retrieved.is_some());
+        let retrieved_config = retrieved.unwrap();
+        assert_eq!(retrieved_config.ip, "test.example.com");
+        assert_eq!(retrieved_config.port, 12345);
+
+        // Clear override
+        clear_testing_config_override();
+        assert!(get_testing_config_override().is_none());
+    }
+
+    #[test]
+    fn test_apply_config_overrides() {
+        let mut config = AgentConfig::default();
+        let mut overrides = HashMap::new();
+
+        overrides.insert("ip".to_string(), "192.168.1.1".to_string());
+        overrides.insert("enable_iak_idevid".to_string(), "true".to_string());
+        overrides.insert(
+            "disabled_signing_algorithms".to_string(),
+            "rsa,ecdsa".to_string(),
+        );
+
+        apply_config_overrides(&mut config, overrides);
+
+        assert_eq!(config.ip, "192.168.1.1");
+        assert!(config.enable_iak_idevid);
+        assert_eq!(config.disabled_signing_algorithms, vec!["rsa", "ecdsa"]);
+    }
+}

--- a/keylime/tests/config_singleton_integration.rs
+++ b/keylime/tests/config_singleton_integration.rs
@@ -1,0 +1,43 @@
+use keylime::config::{get_config, initialize_config, PushModelConfigTrait};
+
+#[test]
+fn test_configuration_singleton_behavior() {
+    // Test that multiple calls to get_config() return the same reference
+    let config1 = get_config();
+    let config2 = get_config();
+
+    // Verify they return the same configuration
+    assert_eq!(
+        config1.uuid(),
+        config2.uuid(),
+        "Multiple get_config() calls should return same configuration"
+    );
+
+    // Test that explicit initialization fails after auto-initialization
+    let result = initialize_config();
+    assert!(
+        result.is_err(),
+        "Explicit initialization should fail after auto-initialization"
+    );
+}
+
+#[test]
+fn test_config_singleton_properties() {
+    // Test that we can access configuration properties efficiently through the singleton
+    let config = get_config();
+
+    // Test that we can access configuration properties
+    assert!(!config.uuid().is_empty(), "UUID should not be empty");
+    assert!(
+        !config.keylime_dir.is_empty(),
+        "Keylime dir should not be empty"
+    );
+
+    // Test multiple accesses return consistent values
+    let uuid1 = config.uuid();
+    let uuid2 = get_config().uuid();
+    assert_eq!(
+        uuid1, uuid2,
+        "Multiple UUID accesses should return same value"
+    );
+}


### PR DESCRIPTION
This makes use of the singleton pattern to avoid re-reading the configuration files multiple times. Also, by providing a global way to obtain a reference to the configuration options (via the `get_config()` method), there is no need to pass the configuration structure through multiple layers, simplifying the API.

The configuration is basically immutable after loaded and processed, which means that it is basically read-only throughout the execution of the agent. Since no changes are expected to the configuration options after it is first loaded, there is no need to protect it against concurrent accesses. Using only references to the configuration options instead of creating copies via `clone()` improves the performance and reduces the memory usage.

For testing, it is necessary to have a mechanism that allows overriding the configuration options. This mechanism is more complex when the tests are executed in parallel under the same process, since the configuration is loaded only once for all tests. To override the options, a special caching mechanism was created to allow the configuration override to be applied throughout the test case execution. The tests using the configuration override **cannot** be executed in parallel because they could affect each other, being the recommended way to use the mutex mechanism used to isolate test cases that use the TPM (from `keylime::tpm::testing`). In addition, it is necessary to cleanup the override configuration if it is set.