### PR TITLE
Add policy to handle Retry-After response headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,6 +1409,7 @@ dependencies = [
  "glob",
  "hex",
  "http 1.1.0",
+ "httpdate",
  "keylime-macros",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,9 +1098,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures = "0.3.6"
 glob = "0.3"
 hex = "0.4"
 http = "1.1.0"
-httpdate = "1.0.2"
+httpdate = "1.0.3"
 keylime = { version = "=0.2.8", path = "keylime" }
 keylime-macros = { version = "=0.2.8", path = "keylime-macros" }
 libc = "0.2.43"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ futures = "0.3.6"
 glob = "0.3"
 hex = "0.4"
 http = "1.1.0"
+httpdate = "1.0.2"
 keylime = { version = "=0.2.8", path = "keylime" }
 keylime-macros = { version = "=0.2.8", path = "keylime-macros" }
 libc = "0.2.43"

--- a/keylime/Cargo.toml
+++ b/keylime/Cargo.toml
@@ -18,6 +18,7 @@ config.workspace = true
 glob.workspace = true
 hex.workspace = true
 http.workspace = true
+httpdate.workspace = true
 libc.workspace = true
 keylime-macros.workspace = true
 log.workspace = true

--- a/keylime/src/resilient_client.rs
+++ b/keylime/src/resilient_client.rs
@@ -604,7 +604,7 @@ mod tests {
             .get_request(Method::GET, &format!("{}/test", &mock_server.uri()))
             .send()
             .await
-            .unwrap();
+            .unwrap(); //#[allow_ci]
         let elapsed = start_time.elapsed();
 
         // The total time should be at least 2 seconds due to the Retry-After header.
@@ -620,7 +620,7 @@ mod tests {
         let mock_server = MockServer::start().await;
         use chrono::Timelike;
         // Create a date string for 1 second in the future
-        let now_truncated = Utc::now().with_nanosecond(0).unwrap();
+        let now_truncated = Utc::now().with_nanosecond(0).unwrap(); //#[allow_ci]
         let retry_at = now_truncated + chrono::Duration::seconds(1);
         let http_date = httpdate::fmt_http_date(retry_at.into());
 
@@ -655,7 +655,7 @@ mod tests {
             .get_request(Method::GET, &format!("{}/test", &mock_server.uri()))
             .send()
             .await
-            .unwrap();
+            .unwrap(); //#[allow_ci]
         let elapsed = start_time.elapsed();
 
         assert!(
@@ -694,7 +694,7 @@ mod tests {
             .get_request(Method::GET, &format!("{}/test", &mock_server.uri()))
             .send()
             .await
-            .unwrap();
+            .unwrap(); //#[allow_ci]
         let elapsed = start_time.elapsed();
 
         // Should return 429 after max_retries
@@ -702,7 +702,7 @@ mod tests {
 
         // Should have made exactly max_retries + 1 requests (initial + retries)
         let received_requests =
-            mock_server.received_requests().await.unwrap();
+            mock_server.received_requests().await.unwrap(); //#[allow_ci]
         assert_eq!(received_requests.len(), (max_retries + 1) as usize);
 
         // Should have waited for max_retries seconds (each retry waits 1 second)
@@ -786,7 +786,7 @@ mod tests {
             .get_request(Method::GET, &format!("{}/test", &mock_server.uri()))
             .send()
             .await
-            .unwrap();
+            .unwrap(); //#[allow_ci]
         let elapsed = start_time.elapsed();
 
         // Should eventually succeed
@@ -794,7 +794,7 @@ mod tests {
 
         // Should have made 3 total requests (2 failures + 1 success)
         let received_requests =
-            mock_server.received_requests().await.unwrap();
+            mock_server.received_requests().await.unwrap(); //#[allow_ci]
         assert_eq!(received_requests.len(), 3);
 
         // Should have waited for ~2 seconds (for the two retries)


### PR DESCRIPTION
This pull request enhances the ResilientClient by adding support for the standard Retry-After HTTP response header.

Currently, our client relies solely on an exponential backoff strategy for all retryable errors. While effective, this approach is less precise when a server explicitly indicates how long we should wait before trying again (e.g., for rate limiting or temporary maintenance).

This change introduces a dedicated middleware that respects the Retry-After header, making our client a better HTTP citizen and improving its ability to recover from transient server-side issues efficiently.

Co-Authored-By: Gemini <noreply@google.com>
Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: Sergio Arroutbi <sarroutb@redhat.com>