### PR TITLE
Make compilation to fail on warnings

### DIFF
--- a/.github/workflows/compile-no-warnings.yml
+++ b/.github/workflows/compile-no-warnings.yml
@@ -1,0 +1,28 @@
+---
+name: Rust
+
+"on":
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  basic-compilation:
+    name: Compilation with no warnings
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/keylime/keylime-ci:latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check compilation (no warnings)
+        run: RUSTFLAGS="-D warnings" cargo build
+      - name: Check test compilation (no warnings)
+        run: RUSTFLAGS="-D warnings" cargo test
+      - name: Check clippy errors (no warnings included)
+        run: cargo clippy --all-features --all-targets  -- -D clippy::all -D warnings
+      - name: Check clippy test errors (no warnings included)
+        run: cargo clippy --all-features --all-targets --tests -- -D clippy::all -D warnings

--- a/.github/workflows/compile-no-warnings.yml
+++ b/.github/workflows/compile-no-warnings.yml
@@ -1,5 +1,5 @@
 ---
-name: Rust
+name: No-Warnings Compilation
 
 "on":
   push:
@@ -21,8 +21,6 @@ jobs:
       - name: Check compilation (no warnings)
         run: RUSTFLAGS="-D warnings" cargo build
       - name: Check test compilation (no warnings)
-        run: RUSTFLAGS="-D warnings" cargo test
+        run: RUSTFLAGS="-D warnings" cargo test --no-run
       - name: Check clippy errors (no warnings included)
         run: cargo clippy --all-features --all-targets  -- -D clippy::all -D warnings
-      - name: Check clippy test errors (no warnings included)
-        run: cargo clippy --all-features --all-targets --tests -- -D clippy::all -D warnings

--- a/.github/workflows/compile-no-warnings.yml
+++ b/.github/workflows/compile-no-warnings.yml
@@ -15,7 +15,8 @@ jobs:
     name: Compilation with no warnings
     runs-on: ubuntu-latest
     container:
-      image: quay.io/keylime/keylime-ci:latest
+      # To refresh: skopeo inspect --no-tags docker://quay.io/keylime/keylime-ci:latest | jq -r '.Digest'
+      image: quay.io/keylime/keylime-ci@sha256:973f36045d0dd0b1a219dd88f06625c65a77f267842ee23d955e0c095ef09ff2
     steps:
       - uses: actions/checkout@v6
       - name: Set git safe.directory for the working directory

--- a/.github/workflows/compile-no-warnings.yml
+++ b/.github/workflows/compile-no-warnings.yml
@@ -18,6 +18,8 @@ jobs:
       image: quay.io/keylime/keylime-ci:latest
     steps:
       - uses: actions/checkout@v6
+      - name: Set git safe.directory for the working directory
+        run: git config --system --add safe.directory "$PWD"
       - name: Check compilation (no warnings)
         run: RUSTFLAGS="-D warnings" cargo build
       - name: Check test compilation (no warnings)

--- a/.github/workflows/compile-no-warnings.yml
+++ b/.github/workflows/compile-no-warnings.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Check test compilation (no warnings)
         run: RUSTFLAGS="-D warnings" cargo test --no-run
       - name: Check clippy errors (no warnings included)
-        run: cargo clippy --all-features --all-targets  -- -D clippy::all -D warnings
+        run: cargo clippy --all-features --all-targets -- -D clippy::all -D warnings

--- a/.github/workflows/compile-no-warnings.yml
+++ b/.github/workflows/compile-no-warnings.yml
@@ -18,7 +18,7 @@ jobs:
       # To refresh: skopeo inspect --no-tags docker://quay.io/keylime/keylime-ci:latest | jq -r '.Digest'
       image: quay.io/keylime/keylime-ci@sha256:973f36045d0dd0b1a219dd88f06625c65a77f267842ee23d955e0c095ef09ff2
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set git safe.directory for the working directory
         run: git config --system --add safe.directory "$PWD"
       - name: Check compilation (no warnings)

--- a/keylime/src/context_info.rs
+++ b/keylime/src/context_info.rs
@@ -790,7 +790,6 @@ impl ContextInfo {
 mod uefi_log_tests {
     use super::base64_standard;
     use super::*;
-    use base64::Engine as _;
 
     /// Cached bytes are preferred over the on-disk file.
     ///


### PR DESCRIPTION
The new workflow runs on every push and pull request to the master branch and performs the following checks:

* cargo build: Compiles the main application.
* cargo test: Compiles the test suite.

Both steps are executed with the `RUSTFLAGS="-D warnings"` environment variable. This flag instructs the Rust compiler to treat all warnings as fatal errors, which will cause the build to fail if any warnings are present. This helps prevent latent bugs and ensures the code base remains clean.

These are some reasons to enforce a "No Warnings" Policy:
1. Future-Proofing Code: A warning in the current version of a compiler might become a hard error in a future version. Code that compiles with warnings today may fail to compile tomorrow after a simple rustup update, causing unexpected build failures. Enforcing a "no warnings" policy ensures your code is robust against compiler updates.

2. Preventing Latent Bugs: Many warnings are not just stylistic suggestions; they often point to subtle logical flaws, potential null pointer dereferences, race conditions, or undefined behavior. A classic example is an "unused variable" warning, which can indicate that a necessary calculation was performed but its result was never used.

3. Improving Code Readability and Reducing Noise: When a build produces dozens of warnings, developers become desensitized to them. This "warning fatigue" can cause them to miss a new, critical warning that appears among the noise. A clean, warning-free build ensures that any new message from the compiler gets immediate attention.

4. Maintaining a Culture of Quality: A strict "no warnings" policy sets a high standard for the team. It encourages developers to write clean, precise, and intentional code, fostering a culture where quality is not negotiable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow that runs on pushes and pull requests to the main branch to build the project, run tests, and perform lint checks.
  * Runs in a pinned, reproducible CI environment to ensure consistent results.
  * Compiler and linter warnings are treated as failures, enforcing stricter code quality and preventing merges with warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/keylime/rust-keylime/pull/1104)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->