### PR TITLE
FSM: Fix compilation warnings detected by clippy

### DIFF
--- a/keylime-push-model-agent/src/state_machine.rs
+++ b/keylime-push-model-agent/src/state_machine.rs
@@ -369,13 +369,13 @@ mod tpm_tests {
     }
 
     /// Helper function to create TPM test configuration.
-    fn create_tpm_test_config<'a>(
-        url: &'a str,
+    fn create_tpm_test_config(
+        url: &str,
         timeout: u64,
         max_retries: u32,
         initial_delay_ms: u64,
         max_delay_ms: Option<u64>,
-    ) -> NegotiationConfig<'a> {
+    ) -> NegotiationConfig<'_> {
         NegotiationConfig {
             avoid_tpm: true,
             ca_certificate: "",
@@ -728,13 +728,13 @@ mod tests {
     use crate::attestation::{AttestationClient, NegotiationConfig};
 
     // Helper function to create test configuration.
-    fn create_test_config<'a>(
-        url: &'a str,
+    fn create_test_config(
+        url: &str,
         timeout: u64,
         max_retries: u32,
         initial_delay_ms: u64,
         max_delay_ms: Option<u64>,
-    ) -> NegotiationConfig<'a> {
+    ) -> NegotiationConfig<'_> {
         NegotiationConfig {
             avoid_tpm: true,
             ca_certificate: "",


### PR DESCRIPTION
This PR resolves a clippy::needless_lifetimes warning found in the create_test_config test helper function.

The explicit 'a lifetime annotation was unnecessary, as Rust's lifetime elision rules can correctly infer the lifetime of the input &str and the returned NegotiationConfig.

The function signature has been updated to remove the explicit lifetime, making the code more idiomatic.