### PR TITLE
workflows: Add test to check if RPM patches still apply

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,0 +1,25 @@
+---
+name: rpm-test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  fedora:
+    name: Check that Fedora RPM patches still apply
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check that Fedora patches apply
+        run: for p in rpm/fedora/*.patch; do patch -p1 < "$p"; done
+  centos:
+    runs-on: ubuntu-latest
+    name: Check that CentOS RPM patches still apply
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check that CentOS patches apply
+        run: for p in rpm/centos/*.patch; do patch -p1 < "$p"; done


### PR DESCRIPTION
The tests simply try to patch the current code with the patches for both Fedora and CentOS. This is a sanity check to prevent changes changes that would make the patches incompatible to be introduced without properly updating the patches.