### PR TITLE
Accept evidence handling structures null entries

### DIFF
--- a/keylime/src/context_info.rs
+++ b/keylime/src/context_info.rs
@@ -522,7 +522,7 @@ impl ContextInfo {
         let entry_count = entries.lines().count();
         Ok(EvidenceData::ImaLog {
             entry_count,
-            entries,
+            entries: Some(entries),
             meta: None,
         })
     }
@@ -551,7 +551,7 @@ impl ContextInfo {
         };
 
         Ok(EvidenceData::UefiLog {
-            entries: content,
+            entries: Some(content),
             meta: None,
         })
     }


### PR DESCRIPTION
Update ImaLog and UefiLog structures to handle null entries field:
- Change entries field from String to Option<String> in both structures
- Update serialization/deserialization logic to handle null values
- Modify entry count calculation for ImaLog to handle None entries
- Add comprehensive tests for null entries scenarios
- Update context_info.rs to wrap entries in Some() when creating evidence

This change improves robustness when handling evidence data that may null entry fields, which can occur in certain attestation scenarios.