### PR TITLE
docker: update rust to 1.81 for distroless Dockerfile

### DIFF
--- a/docker/release/Dockerfile.distroless
+++ b/docker/release/Dockerfile.distroless
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # the builder stage which uses the official rust base image (based on Debian 11) to build the keylime agent
-FROM rust:1.70-bullseye AS builder
+FROM rust:1.81-bullseye AS builder
 
 # we are using the "generate-bindings" feature for the tss-esapi crate which requires clang/llvm
 RUN apt-get update && apt-get install -y --no-install-recommends clang llvm


### PR DESCRIPTION
When building the keylime_agent docker image, the process fails with the following error:

```text
[...]
------
 > [builder 12/14] RUN make RELEASE=1 TARGETDIR=target target/release/keylime_agent:
0.164 Package systemd was not found in the pkg-config search path. 0.164 Perhaps you should add the directory containing `systemd.pc' 0.164 to the PKG_CONFIG_PATH environment variable
0.164 No package 'systemd' found
0.164 cargo build --target-dir="target" --release
0.305 error: failed to parse lock file at: /src/rust-keylime/Cargo.lock 0.305
0.305 Caused by:
0.305   lock file version `4` was found, but this version of Cargo does not understand this lock file, perhaps Cargo needs to be updated?
0.305 make: *** [GNUmakefile:27: target/release/keylime_agent] Error 101
------
Dockerfile.distroless:26
--------------------
  24 |     COPY . /src/rust-keylime/
  25 |     WORKDIR /src/rust-keylime
  26 | >>> RUN make RELEASE=1 TARGETDIR=target target/release/keylime_agent
  27 |
  28 |     # truly just for debugging purposes for the assembly stage
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c make RELEASE=1 TARGETDIR=target target/release/keylime_agent" did not complete successfully: exit code: 2
Error response from daemon: No such image: keylime_agent:latest-distroless
```

Update the rust docker image to 1.81-bullseye.