### PR TITLE
Fix ECC algorithm selection and reporting for keylime agent

### DIFF
--- a/keylime/src/algorithms.rs
+++ b/keylime/src/algorithms.rs
@@ -279,7 +279,7 @@ impl fmt::Display for EncryptionAlgorithm {
             EncryptionAlgorithm::Rsa4096 => "rsa4096",
             EncryptionAlgorithm::Ecc192 => "ecc192",
             EncryptionAlgorithm::Ecc224 => "ecc224",
-            EncryptionAlgorithm::Ecc256 => "ecc", /* for backwards compatibility */
+            EncryptionAlgorithm::Ecc256 => "ecc256",
             EncryptionAlgorithm::Ecc384 => "ecc384",
             EncryptionAlgorithm::Ecc521 => "ecc521",
             EncryptionAlgorithm::EccSm2 => "ecc_sm2",

--- a/keylime/src/tpm.rs
+++ b/keylime/src/tpm.rs
@@ -31,7 +31,7 @@ use tss_esapi::{
     abstraction::{
         ak, ek, nv,
         pcr::{read_all, PcrData},
-        DefaultKey,
+        AsymmetricAlgorithmSelection, DefaultKey,
     },
     attributes::{
         object::ObjectAttributesBuilder, session::SessionAttributesBuilder,
@@ -773,7 +773,7 @@ impl Context<'_> {
             &mut self.inner.lock().unwrap(), //#[allow_ci]
             handle,
             hash_alg.into(),
-            key_alg.into(),
+            Into::<AsymmetricAlgorithmSelection>::into(key_alg),
             sign_alg.into(),
             None,
             DefaultKey,


### PR DESCRIPTION
- Use AsymmetricAlgorithmSelection instead of AsymmetricAlgorithm to allow ecc521 to properly map to P-521 curve instead of defaulting to P-256
- Change ECC256 algorithm display from generic "ecc" to specific "ecc256"

These changes are required for enabling ECC attestation with the NIST curves.