### PR TITLE
Fix RSA2048 algorithm reporting in keylime agent

### DIFF
--- a/keylime-agent/src/agent_handler.rs
+++ b/keylime-agent/src/agent_handler.rs
@@ -109,7 +109,7 @@ mod tests {
         let result: JsonWrapper<AgentInfo> = test::read_body_json(resp).await;
         assert_eq!(result.results.agent_uuid.as_str(), "DEADBEEF");
         assert_eq!(result.results.tpm_hash_alg.as_str(), "sha256");
-        assert_eq!(result.results.tpm_enc_alg.as_str(), "rsa");
+        assert_eq!(result.results.tpm_enc_alg.as_str(), "rsa2048");
         assert_eq!(result.results.tpm_sign_alg.as_str(), "rsassa");
 
         // Explicitly drop QuoteData to cleanup keys

--- a/keylime-agent/src/quotes_handler.rs
+++ b/keylime-agent/src/quotes_handler.rs
@@ -385,7 +385,7 @@ mod tests {
         let result: JsonWrapper<KeylimeQuote> =
             test::read_body_json(resp).await;
         assert_eq!(result.results.hash_alg.as_str(), "sha256");
-        assert_eq!(result.results.enc_alg.as_str(), "rsa");
+        assert_eq!(result.results.enc_alg.as_str(), "rsa2048");
         assert_eq!(result.results.sign_alg.as_str(), "rsassa");
         assert!(
             pkey_pub_from_pem(&result.results.pubkey.unwrap()) //#[allow_ci]
@@ -431,7 +431,7 @@ mod tests {
         let result: JsonWrapper<KeylimeQuote> =
             test::read_body_json(resp).await;
         assert_eq!(result.results.hash_alg.as_str(), "sha256");
-        assert_eq!(result.results.enc_alg.as_str(), "rsa");
+        assert_eq!(result.results.enc_alg.as_str(), "rsa2048");
         assert_eq!(result.results.sign_alg.as_str(), "rsassa");
         assert!(
             pkey_pub_from_pem(&result.results.pubkey.unwrap()) //#[allow_ci]
@@ -493,7 +493,7 @@ mod tests {
         let result: JsonWrapper<KeylimeQuote> =
             test::read_body_json(resp).await;
         assert_eq!(result.results.hash_alg.as_str(), "sha256");
-        assert_eq!(result.results.enc_alg.as_str(), "rsa");
+        assert_eq!(result.results.enc_alg.as_str(), "rsa2048");
         assert_eq!(result.results.sign_alg.as_str(), "rsassa");
 
         if let Some(ima_mutex) = &quotedata.ima_ml_file {

--- a/keylime/src/algorithms.rs
+++ b/keylime/src/algorithms.rs
@@ -274,7 +274,7 @@ impl fmt::Display for EncryptionAlgorithm {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let value = match self {
             EncryptionAlgorithm::Rsa1024 => "rsa1024",
-            EncryptionAlgorithm::Rsa2048 => "rsa", /* for backwards compatibility */
+            EncryptionAlgorithm::Rsa2048 => "rsa2048",
             EncryptionAlgorithm::Rsa3072 => "rsa3072",
             EncryptionAlgorithm::Rsa4096 => "rsa4096",
             EncryptionAlgorithm::Ecc192 => "ecc192",

--- a/keylime/src/context_info.rs
+++ b/keylime/src/context_info.rs
@@ -631,7 +631,7 @@ mod tests {
         assert!(!context_info.get_public_key_as_base64().unwrap().is_empty()); //#[allow_ci]
         assert_eq!(context_info.get_key_class(), "asymmetric");
         assert_eq!(context_info.get_key_size(), 2048);
-        assert_eq!(context_info.get_key_algorithm(), "rsa");
+        assert_eq!(context_info.get_key_algorithm(), "rsa2048");
         let ek_handle = context_info.get_ek_handle();
         let ak_handle = context_info.get_ak_handle();
         assert!(context_info
@@ -740,7 +740,7 @@ mod tests {
         assert!(!context_info.get_public_key_as_base64().unwrap().is_empty()); //#[allow_ci]
         assert_eq!(context_info.get_key_class(), "asymmetric");
         assert_eq!(context_info.get_key_size(), 2048);
-        assert_eq!(context_info.get_key_algorithm(), "rsa");
+        assert_eq!(context_info.get_key_algorithm(), "rsa2048");
         assert!(!context_info.get_ak_key_class_str().is_empty());
         assert!(!context_info.get_ak_key_algorithm_str().is_empty());
         assert!(context_info.get_ak_key_size().is_ok());


### PR DESCRIPTION
Change EncryptionAlgorithm::Rsa2048 display from "rsa" to "rsa2048" to be consistent with other specific algorithm reporting (similar to ECC fix in f2979c438).