### PR TITLE
Remove disabled_signing_algorithms configuration

### DIFF
--- a/keylime-push-model-agent/src/context_info_handler.rs
+++ b/keylime-push-model-agent/src/context_info_handler.rs
@@ -26,11 +26,6 @@ pub fn init_context_info(avoid_tpm: bool) -> Result<()> {
                     tpm_hash_alg: config.tpm_hash_alg().to_string(),
                     tpm_signing_alg: config.tpm_signing_alg().to_string(),
                     agent_data_path: config.agent_data_path().to_string(),
-                    disabled_signing_algorithms: config
-                        .disabled_signing_algorithms()
-                        .iter()
-                        .map(|e| e.to_string())
-                        .collect(),
                 })
                 .map_err(|e| e.to_string())?;
 

--- a/keylime-push-model-agent/src/registration.rs
+++ b/keylime-push-model-agent/src/registration.rs
@@ -126,7 +126,6 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: "".to_string(),
-            disabled_signing_algorithms: vec![],
         };
         config.exponential_backoff_initial_delay = None;
         config.exponential_backoff_max_retries = None;

--- a/keylime-push-model-agent/src/state_machine.rs
+++ b/keylime-push-model-agent/src/state_machine.rs
@@ -412,7 +412,6 @@ mod tpm_tests {
                 tpm_hash_alg: keylime::algorithms::HashAlgorithm::Sha256,
                 tpm_signing_alg: keylime::algorithms::SignAlgorithm::RsaSsa,
                 agent_data_path: "".to_string(),
-                disabled_signing_algorithms: vec![],
             },
         ) {
             Ok(ctx) => ctx,
@@ -653,7 +652,6 @@ mod tpm_tests {
                 tpm_hash_alg: keylime::algorithms::HashAlgorithm::Sha256,
                 tpm_signing_alg: keylime::algorithms::SignAlgorithm::RsaSsa,
                 agent_data_path: "".to_string(),
-                disabled_signing_algorithms: vec![],
             })
             .expect("This test requires TPM access with proper permissions");
         let _ = registration::check_registration(Some(context_info.clone()))

--- a/keylime-push-model-agent/src/struct_filler.rs
+++ b/keylime-push-model-agent/src/struct_filler.rs
@@ -341,7 +341,6 @@ mod tests {
                 tpm_hash_alg: "sha256".to_string(),
                 tpm_signing_alg: "rsassa".to_string(),
                 agent_data_path: "".to_string(),
-                disabled_signing_algorithms: vec![],
             },
         );
 
@@ -371,7 +370,6 @@ mod tests {
                 tpm_hash_alg: "sha256".to_string(),
                 tpm_signing_alg: "rsassa".to_string(),
                 agent_data_path: "".to_string(),
-                disabled_signing_algorithms: vec![],
             },
         );
 
@@ -444,7 +442,6 @@ mod tests {
                 tpm_hash_alg: "sha256".to_string(),
                 tpm_signing_alg: "rsassa".to_string(),
                 agent_data_path: "".to_string(),
-                disabled_signing_algorithms: vec![],
             },
         );
 
@@ -475,7 +472,6 @@ mod tests {
                 tpm_hash_alg: "sha256".to_string(),
                 tpm_signing_alg: "rsassa".to_string(),
                 agent_data_path: "".to_string(),
-                disabled_signing_algorithms: vec![],
             },
         );
 
@@ -565,7 +561,6 @@ mod tests {
                 tpm_hash_alg: "sha256".to_string(),
                 tpm_signing_alg: "rsassa".to_string(),
                 agent_data_path: "".to_string(),
-                disabled_signing_algorithms: vec![],
             },
         );
 
@@ -648,7 +643,6 @@ mod tests {
                 tpm_hash_alg: "sha256".to_string(),
                 tpm_signing_alg: "rsassa".to_string(),
                 agent_data_path: "".to_string(),
-                disabled_signing_algorithms: vec![],
             },
         );
 
@@ -684,7 +678,6 @@ mod tests {
                 tpm_hash_alg: "sha256".to_string(),
                 tpm_signing_alg: "rsassa".to_string(),
                 agent_data_path: "".to_string(),
-                disabled_signing_algorithms: vec![],
             },
         );
 
@@ -734,7 +727,6 @@ mod tests {
                 tpm_hash_alg: "sha256".to_string(),
                 tpm_signing_alg: "rsassa".to_string(),
                 agent_data_path: "".to_string(),
-                disabled_signing_algorithms: vec![],
             },
         );
 

--- a/keylime/src/config/base.rs
+++ b/keylime/src/config/base.rs
@@ -84,7 +84,6 @@ pub static DEFAULT_SERVER_KEY_PASSWORD: &str = "";
 pub static DEFAULT_TRUSTED_CLIENT_CA: &str = "cv_ca/cacert.crt";
 
 // Push attestation agent option defaults
-pub const DEFAULT_DISABLED_SIGNING_ALGORITHMS: &[&str] = &["ecschnorr"];
 pub const DEFAULT_IMA_ML_DIRECTORY_PATH: &str = "/sys/kernel/security/ima";
 pub const DEFAULT_IMA_ML_COUNT_FILE: &str =
     "/sys/kernel/security/ima/measurements";
@@ -108,7 +107,6 @@ pub static DEFAULT_VERIFIER_URL: &str = "https://localhost:8881";
 pub struct AgentConfig {
     pub agent_data_path: String,
     pub api_versions: String,
-    pub disabled_signing_algorithms: Vec<String>,
     pub ek_handle: String,
     pub exponential_backoff_max_delay: Option<u64>,
     pub exponential_backoff_max_retries: Option<u32>,
@@ -261,10 +259,6 @@ impl Default for AgentConfig {
             contact_ip: DEFAULT_CONTACT_IP.to_string(),
             contact_port: DEFAULT_CONTACT_PORT,
             dec_payload_file: DEFAULT_DEC_PAYLOAD_FILE.to_string(),
-            disabled_signing_algorithms: DEFAULT_DISABLED_SIGNING_ALGORITHMS
-                .iter()
-                .map(|s| s.to_string())
-                .collect(),
             ek_handle: DEFAULT_EK_HANDLE.to_string(),
             enable_agent_mtls: DEFAULT_ENABLE_AGENT_MTLS,
             enable_iak_idevid: DEFAULT_ENABLE_IAK_IDEVID,

--- a/keylime/src/config/push_model.rs
+++ b/keylime/src/config/push_model.rs
@@ -36,7 +36,6 @@ pub struct PushModelConfig {
     certification_keys_server_identifier: String,
     contact_ip: String,
     contact_port: u32,
-    disabled_signing_algorithms: Vec<String>,
     exponential_backoff_max_delay: Option<u64>,
     exponential_backoff_max_retries: Option<u32>,
     exponential_backoff_initial_delay: Option<u64>,

--- a/keylime/src/config/testing.rs
+++ b/keylime/src/config/testing.rs
@@ -67,11 +67,6 @@ fn apply_config_overrides(
             "ima_ml_path" => config.ima_ml_path = value,
             "agent_data_path" => config.agent_data_path = value,
             "api_versions" => config.api_versions = value,
-            "disabled_signing_algorithms" => {
-                // Parse as comma-separated list
-                config.disabled_signing_algorithms =
-                    value.split(',').map(|s| s.trim().to_string()).collect();
-            }
             "ek_handle" => config.ek_handle = value,
             "exponential_backoff_max_delay" => {
                 config.exponential_backoff_max_delay = value.parse().ok();
@@ -324,16 +319,11 @@ mod tests {
 
         overrides.insert("ip".to_string(), "192.168.1.1".to_string());
         overrides.insert("enable_iak_idevid".to_string(), "true".to_string());
-        overrides.insert(
-            "disabled_signing_algorithms".to_string(),
-            "rsa,ecdsa".to_string(),
-        );
 
         apply_config_overrides(&mut config, overrides);
 
         assert_eq!(config.ip, "192.168.1.1");
         assert!(config.enable_iak_idevid);
-        assert_eq!(config.disabled_signing_algorithms, vec!["rsa", "ecdsa"]);
     }
 
     #[test]

--- a/keylime/src/context_info.rs
+++ b/keylime/src/context_info.rs
@@ -80,7 +80,6 @@ pub struct AlgorithmConfiguration {
     pub tpm_hash_alg: algorithms::HashAlgorithm,
     pub tpm_signing_alg: algorithms::SignAlgorithm,
     pub agent_data_path: String,
-    pub disabled_signing_algorithms: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -89,7 +88,6 @@ pub struct AlgorithmConfigurationString {
     pub tpm_hash_alg: String,
     pub tpm_signing_alg: String,
     pub agent_data_path: String,
-    pub disabled_signing_algorithms: Vec<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -103,7 +101,6 @@ pub struct ContextInfo {
     pub ek_handle: KeyHandle,
     pub ak: tpm::AKResult,
     pub ak_handle: KeyHandle,
-    pub disabled_signing_algorithms: Vec<String>,
 }
 
 impl ContextInfo {
@@ -124,9 +121,6 @@ impl ContextInfo {
             tpm_hash_alg,
             tpm_signing_alg,
             agent_data_path: config.agent_data_path,
-            disabled_signing_algorithms: config
-                .disabled_signing_algorithms
-                .clone(),
         })
     }
 
@@ -236,9 +230,6 @@ impl ContextInfo {
             ek_handle,
             ak,
             ak_handle,
-            disabled_signing_algorithms: config
-                .disabled_signing_algorithms
-                .clone(),
         })
     }
 
@@ -284,14 +275,9 @@ impl ContextInfo {
     pub fn get_supported_signing_schemes(
         &mut self,
     ) -> Result<Vec<String>, ContextInfoError> {
-        let mut supported_algs = self
+        Ok(self
             .tpm_context
-            .get_supported_signing_algorithms_as_strings()?;
-        let disabled_signing_algorithms =
-            self.disabled_signing_algorithms.clone();
-        supported_algs
-            .retain(|alg| !disabled_signing_algorithms.contains(alg));
-        Ok(supported_algs)
+            .get_supported_signing_algorithms_as_strings()?)
     }
 
     pub fn get_key_algorithm(&self) -> String {
@@ -624,7 +610,6 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: "".to_string(),
-            disabled_signing_algorithms: vec![],
         };
         let mut context_info = ContextInfo::new_from_str(config)
             .expect("Failed to create context from string");
@@ -640,7 +625,6 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: "".to_string(), // Don't use persistence for this test
-            disabled_signing_algorithms: vec![],
         };
         let mut context_info = ContextInfo::new_from_str(config)
             .expect("Failed to create context from string");
@@ -674,7 +658,6 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: data_path.to_str().unwrap().to_string(), //#[allow_ci]
-            disabled_signing_algorithms: vec![],
         };
 
         // First run: should create and store the AK
@@ -710,7 +693,6 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: "".to_string(),
-            disabled_signing_algorithms: vec![],
         };
         let r = ContextInfo::new_from_str(config);
         assert!(r.is_err());
@@ -725,7 +707,6 @@ mod tests {
             tpm_hash_alg: "bad-hash".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: "".to_string(),
-            disabled_signing_algorithms: vec![],
         };
         let r = ContextInfo::new_from_str(config);
         assert!(r.is_err());
@@ -739,7 +720,6 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "bad-signing-alg".to_string(),
             agent_data_path: "".to_string(),
-            disabled_signing_algorithms: vec![],
         };
         let r = ContextInfo::new_from_str(config);
         assert!(r.is_err());
@@ -753,7 +733,6 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: "".to_string(),
-            disabled_signing_algorithms: vec![],
         };
         let mut context_info = ContextInfo::new_from_str(config)
             .expect("Failed to create context from string");
@@ -782,7 +761,6 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: data_path.to_str().unwrap().to_string(), //#[allow_ci]
-            disabled_signing_algorithms: vec![],
         };
         let ak_name_1 = {
             let mut context_info_1 =
@@ -799,7 +777,6 @@ mod tests {
             tpm_hash_alg: "sha384".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: data_path.to_str().unwrap().to_string(), //#[allow_ci]
-            disabled_signing_algorithms: vec![],
         };
         let ak_name_2 = {
             let mut context_info_2 =
@@ -829,7 +806,6 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: data_path.to_str().unwrap().to_string(), //#[allow_ci]
-            disabled_signing_algorithms: vec![],
         };
 
         // The creation should not fail, but gracefully create a new key.
@@ -853,7 +829,6 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: "".to_string(),
-            disabled_signing_algorithms: vec![],
         };
         let context_result = ContextInfo::new_from_str(config);
         assert!(context_result.is_ok());
@@ -908,7 +883,6 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: "".to_string(),
-            disabled_signing_algorithms: vec![],
         };
 
         let context_result = ContextInfo::new_from_str(config);
@@ -944,7 +918,6 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: "".to_string(),
-            disabled_signing_algorithms: vec![],
         };
 
         let context_result = ContextInfo::new_from_str(config);
@@ -983,7 +956,6 @@ mod tests {
             tpm_hash_alg: "sha256".to_string(),
             tpm_signing_alg: "rsassa".to_string(),
             agent_data_path: "".to_string(),
-            disabled_signing_algorithms: vec![],
         };
 
         let context_result = ContextInfo::new_from_str(config);


### PR DESCRIPTION
- Changes made:

  - Configuration removal: Removed disabled_signing_algorithms field from AgentConfig and PushModelConfig structs
  - Default cleanup: Removed DEFAULT_DISABLED_SIGNING_ALGORITHMS constant and its default value ["ecschnorr"]
  - Algorithm context updates: Removed disabled_signing_algorithms from AlgorithmConfiguration, AlgorithmConfigurationString, and ContextInfo structs
  - Logic simplification: Updated get_supported_signing_schemes() to return all TPM-supported signing algorithms without filtering
  - Test updates: Removed disabled_signing_algorithms field initialization from all test cases across multiple modules
  - Configuration parsing: Removed handling of disabled_signing_algorithms from config override functionality

- Impact:

  - Signing algorithm support is now determined solely by TPM capabilities rather than configuration filtering
  - Simplifies configuration management by removing an unnecessary configuration option
  - All previously disabled algorithms (like ecschnorr) will now be available if supported by the TPM