### PR TITLE
tests: Enable more TPM tests in CI

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -67,6 +67,7 @@
        - /functional/tpm_policy-sanity-on-localhost
        - /functional/use-multiple-ima-sign-verification-keys
        - /functional/webhook-certificate-on-localhost
+       - /functional/agent-registration-with-non-default-tpm-algorithms/.*
        - /regression/cve-2023-38200
        - /regression/cve-2023-38201
        - /regression/CVE-2023-3674


### PR DESCRIPTION
Enable following e2e tests in CI:
  agent-registration-with-non-default-tpm-algorithms/ecc256-ecschnorr
  agent-registration-with-non-default-tpm-algorithms/ecc384-ecschnorr
  agent-registration-with-non-default-tpm-algorithms/rsa2048-rsassa
  agent-registration-with-non-default-tpm-algorithms/rsa3072-rsapss