### PR TITLE
Use simple algorithm specifiers in certification_keys object

### DIFF
--- a/keylime/src/algorithms.rs
+++ b/keylime/src/algorithms.rs
@@ -185,6 +185,23 @@ pub fn get_key_size(tpm_encryption_alg: &EncryptionAlgorithm) -> usize {
     }
 }
 
+pub fn get_key_algorithm_family(
+    tpm_encryption_alg: &EncryptionAlgorithm,
+) -> &'static str {
+    match tpm_encryption_alg {
+        EncryptionAlgorithm::Rsa1024
+        | EncryptionAlgorithm::Rsa2048
+        | EncryptionAlgorithm::Rsa3072
+        | EncryptionAlgorithm::Rsa4096 => "rsa",
+        EncryptionAlgorithm::Ecc192
+        | EncryptionAlgorithm::Ecc224
+        | EncryptionAlgorithm::Ecc256
+        | EncryptionAlgorithm::Ecc384
+        | EncryptionAlgorithm::Ecc521
+        | EncryptionAlgorithm::EccSm2 => "ecc",
+    }
+}
+
 impl From<EncryptionAlgorithm> for AsymmetricAlgorithm {
     fn from(enc_alg: EncryptionAlgorithm) -> Self {
         match enc_alg {
@@ -484,6 +501,29 @@ mod tests {
             );
         }
     } // test_get_key_size
+
+    #[test]
+    fn test_get_key_algorithm_family() {
+        let algorithms = [
+            (EncryptionAlgorithm::Rsa1024, "rsa"),
+            (EncryptionAlgorithm::Rsa2048, "rsa"),
+            (EncryptionAlgorithm::Rsa3072, "rsa"),
+            (EncryptionAlgorithm::Rsa4096, "rsa"),
+            (EncryptionAlgorithm::Ecc192, "ecc"),
+            (EncryptionAlgorithm::Ecc224, "ecc"),
+            (EncryptionAlgorithm::Ecc256, "ecc"),
+            (EncryptionAlgorithm::Ecc384, "ecc"),
+            (EncryptionAlgorithm::Ecc521, "ecc"),
+            (EncryptionAlgorithm::EccSm2, "ecc"),
+        ];
+        for (alg, expected_family) in algorithms {
+            let family = get_key_algorithm_family(&alg);
+            assert_eq!(
+                family, expected_family,
+                "Algorithm family mismatch for {alg}"
+            );
+        }
+    } // test_get_key_algorithm_family
 
     #[test]
     fn test_get_ecc_curve_key_size() {

--- a/keylime/src/context_info.rs
+++ b/keylime/src/context_info.rs
@@ -281,7 +281,8 @@ impl ContextInfo {
     }
 
     pub fn get_key_algorithm(&self) -> String {
-        self.tpm_encryption_alg.to_string()
+        algorithms::get_key_algorithm_family(&self.tpm_encryption_alg)
+            .to_string()
     }
 
     pub fn get_ek_handle(&self) -> KeyHandle {
@@ -301,7 +302,8 @@ impl ContextInfo {
     }
 
     pub fn get_ak_key_algorithm_str(&self) -> String {
-        self.tpm_encryption_alg.to_string()
+        algorithms::get_key_algorithm_family(&self.tpm_encryption_alg)
+            .to_string()
     }
 
     pub fn get_ak_public_enum_ref(&self) -> &TssPublic {
@@ -631,7 +633,7 @@ mod tests {
         assert!(!context_info.get_public_key_as_base64().unwrap().is_empty()); //#[allow_ci]
         assert_eq!(context_info.get_key_class(), "asymmetric");
         assert_eq!(context_info.get_key_size(), 2048);
-        assert_eq!(context_info.get_key_algorithm(), "rsa2048");
+        assert_eq!(context_info.get_key_algorithm(), "rsa");
         let ek_handle = context_info.get_ek_handle();
         let ak_handle = context_info.get_ak_handle();
         assert!(context_info
@@ -740,7 +742,7 @@ mod tests {
         assert!(!context_info.get_public_key_as_base64().unwrap().is_empty()); //#[allow_ci]
         assert_eq!(context_info.get_key_class(), "asymmetric");
         assert_eq!(context_info.get_key_size(), 2048);
-        assert_eq!(context_info.get_key_algorithm(), "rsa2048");
+        assert_eq!(context_info.get_key_algorithm(), "rsa");
         assert!(!context_info.get_ak_key_class_str().is_empty());
         assert!(!context_info.get_ak_key_algorithm_str().is_empty());
         assert!(context_info.get_ak_key_size().is_ok());


### PR DESCRIPTION
Update key_algorithm reporting in the certification_keys object to use simple specifiers ("rsa" or "ecc") instead of full algorithm names ("rsa2048", "ecc256", etc.) to comply with the push model protocol specification.

This is not an issue for algorithm identification because the certification_keys object also includes the key_size field, allowing complete identification of the exact algorithm in use.