### PR TITLE
Persist the payload key to avoid failing attestation on restart

### DIFF
--- a/keylime-agent.conf
+++ b/keylime-agent.conf
@@ -87,6 +87,28 @@ server_key = "default"
 # environment variable.
 server_key_password = ""
 
+# The name of the file containing the payload encryption private key.
+# This private key is used to decrypt U and V keys sent by the verifier/tenant
+# for secure payload transmission.
+# A new RSA 2048 private key is generated in case it is not found.
+# If an existing key is provided, it MUST be RSA 2048, otherwise the agent will
+# fail to start.
+# If set as "default", the "payload-private.pem" value is used.
+# If a relative path is set, it will be considered relative from the keylime_dir.
+# If an absolute path is set, it is used without change.
+#
+# To override payload_key, set KEYLIME_AGENT_PAYLOAD_KEY environment variable.
+payload_key = "default"
+
+# Set the password used to encrypt the payload private key file.
+# This password will also be used to protect the generated private key used for
+# payload encryption.
+# If left empty, the private key will not be encrypted.
+#
+# To override payload_key_password, set KEYLIME_AGENT_PAYLOAD_KEY_PASSWORD
+# environment variable.
+payload_key_password = ""
+
 # The name of the file containing the X509 certificate used as the Keylime agent
 # server TLS certificate.
 # This certificate must be self signed.

--- a/keylime/src/config/base.rs
+++ b/keylime/src/config/base.rs
@@ -80,6 +80,8 @@ pub static DEFAULT_SECURE_SIZE: &str = "1m";
 pub static DEFAULT_SERVER_CERT: &str = "server-cert.crt";
 pub static DEFAULT_SERVER_KEY: &str = "server-private.pem";
 pub static DEFAULT_SERVER_KEY_PASSWORD: &str = "";
+pub static DEFAULT_PAYLOAD_KEY: &str = "payload-private.pem";
+pub static DEFAULT_PAYLOAD_KEY_PASSWORD: &str = "";
 // The DEFAULT_TRUSTED_CLIENT_CA is relative from KEYLIME_DIR
 pub static DEFAULT_TRUSTED_CLIENT_CA: &str = "cv_ca/cacert.crt";
 
@@ -157,6 +159,8 @@ pub struct AgentConfig {
     pub server_cert: String,
     pub server_key: String,
     pub server_key_password: String,
+    pub payload_key: String,
+    pub payload_key_password: String,
 
     // Push attestation options
     pub certification_keys_server_identifier: String,
@@ -307,6 +311,8 @@ impl Default for AgentConfig {
             server_cert: "default".to_string(),
             server_key: "default".to_string(),
             server_key_password: DEFAULT_SERVER_KEY_PASSWORD.to_string(),
+            payload_key: "default".to_string(),
+            payload_key_password: DEFAULT_PAYLOAD_KEY_PASSWORD.to_string(),
             tpm_encryption_alg: DEFAULT_TPM_ENCRYPTION_ALG.to_string(),
             tpm_hash_alg: DEFAULT_TPM_HASH_ALG.to_string(),
             tpm_ownerpassword: DEFAULT_TPM_OWNERPASSWORD.to_string(),
@@ -412,6 +418,14 @@ pub(crate) fn config_translate_keywords(
         &config.server_cert,
         keylime_dir,
         DEFAULT_SERVER_CERT,
+        false,
+    );
+
+    let payload_key = config_get_file_path(
+        "payload_key",
+        &config.payload_key,
+        keylime_dir,
+        DEFAULT_PAYLOAD_KEY,
         false,
     );
 
@@ -612,6 +626,7 @@ pub(crate) fn config_translate_keywords(
         revocation_cert,
         server_cert,
         server_key,
+        payload_key,
         trusted_client_ca,
         uuid,
         ..config.clone()

--- a/keylime/src/config/env.rs
+++ b/keylime/src/config/env.rs
@@ -145,6 +145,11 @@ mod test {
                 "KEYLIME_AGENT_SERVER_KEY_PASSWORD",
                 "override_server_key_password",
             ),
+            ("KEYLIME_AGENT_PAYLOAD_KEY", "override_payload_key"),
+            (
+                "KEYLIME_AGENT_PAYLOAD_KEY_PASSWORD",
+                "override_payload_key_password",
+            ),
             (
                 "KEYLIME_AGENT_TPM_ENCRYPTION_ALG",
                 "override_tpm_encryption_alg",

--- a/keylime/src/config/testing.rs
+++ b/keylime/src/config/testing.rs
@@ -150,6 +150,8 @@ fn apply_config_overrides(
             "server_cert" => config.server_cert = value,
             "server_key" => config.server_key = value,
             "server_key_password" => config.server_key_password = value,
+            "payload_key" => config.payload_key = value,
+            "payload_key_password" => config.payload_key_password = value,
             // Push attestation options
             "certification_keys_server_identifier" => {
                 config.certification_keys_server_identifier = value


### PR DESCRIPTION
Previously, when the agent was restarted while being monitored by the verifier, it would fail attestation because the PCR#16 would be extended with the new ephemeral payload public key.

With this change, the payload key is persisted, making the agent to reuse the previously generated payload key instead of generating a new ephemeral key on restart.

Resolves: #1136
