### PR TITLE
docker: Include keylime_push_model_agent binary

### DIFF
--- a/docker/release/Dockerfile.distroless
+++ b/docker/release/Dockerfile.distroless
@@ -59,6 +59,7 @@ COPY --from=builder \
 
 # now copy the agent from the builder
 COPY --from=builder /src/rust-keylime/target/release/keylime_agent /bin/keylime_agent
+COPY --from=builder /src/rust-keylime/target/release/keylime_push_model_agent /bin/keylime_push_model_agent
 COPY --from=builder /src/rust-keylime/keylime-agent.conf /etc/keylime/agent.conf
 ENTRYPOINT ["/bin/keylime_agent"]
 

--- a/docker/release/Dockerfile.fedora
+++ b/docker/release/Dockerfile.fedora
@@ -48,6 +48,7 @@ RUN microdnf makecache && \
 
 # now copy the agent from the builder
 COPY --from=builder /src/rust-keylime/target/release/keylime_agent /bin/keylime_agent
+COPY --from=builder /src/rust-keylime/target/release/keylime_push_model_agent /bin/keylime_push_model_agent
 COPY --from=builder /src/rust-keylime/keylime-agent.conf /etc/keylime/agent.conf
 ENTRYPOINT ["/bin/keylime_agent"]
 

--- a/docker/release/Dockerfile.wolfi
+++ b/docker/release/Dockerfile.wolfi
@@ -77,6 +77,7 @@ COPY --from=builder \
 
 # now copy the agent from the builder
 COPY --from=builder /src/rust-keylime/target/release/keylime_agent /bin/keylime_agent
+COPY --from=builder /src/rust-keylime/target/release/keylime_push_model_agent /bin/keylime_push_model_agent
 COPY --from=builder /src/rust-keylime/keylime-agent.conf /etc/keylime/agent.conf
 ENTRYPOINT ["/bin/keylime_agent"]
 


### PR DESCRIPTION
Include /bin/keylime_push_model_agent binary in the built docker image.