### PR TITLE
docs: add documentation on FQDN hostnames

### DIFF
--- a/keylime-agent.conf
+++ b/keylime-agent.conf
@@ -3,6 +3,10 @@
 # 'KEYLIME_AGENT_' prefix followed by the option to be set in upper case.
 # For example, to override the 'registrar_ip' option, set the
 # KEYLIME_AGENT_REGISTRAR_IP environment variable.
+#
+# Note: Configuration options named with '_ip' suffix (ip, contact_ip, registrar_ip,
+# revocation_notification_ip) accept both IP addresses (IPv4/IPv6) and fully qualified
+# domain names (FQDNs). The '_ip' suffix is maintained for backward compatibility.
 
 #=============================================================================
 [agent]
@@ -31,14 +35,16 @@ api_versions = "default"
 # To override, set KEYLIME_AGENT_UUID environment variable.
 uuid = "d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
 
-# The binding IP address and port for the agent server
+# The binding IP address or hostname (FQDN) and port for the agent server
+# Supports IPv4, IPv6, or fully qualified domain names
 #
 # To override ip, set KEYLIME_AGENT_IP environment variable.
 # To override port, set KEYLIME_AGENT_PORT environment variable.
 ip = "127.0.0.1"
 port = 9002
 
-# Address and port where the verifier and tenant can connect to reach the agent.
+# Address (IP or hostname/FQDN) and port where the verifier and tenant can connect to reach the agent.
+# Supports IPv4, IPv6, or fully qualified domain names
 # These keys are optional.
 #
 # To override contact_ip, set KEYLIME_AGENT_CONTACT_IP environment variable.
@@ -46,7 +52,8 @@ port = 9002
 contact_ip = "127.0.0.1"
 contact_port = 9002
 
-# The address and port of registrar server which agent communicate with
+# The address (IP or hostname/FQDN) and port of registrar server which agent communicate with
+# Supports IPv4, IPv6, or fully qualified domain names
 #
 # To override registrar_ip, set KEYLIME_AGENT_REGISTRAR_IP environment variable.
 # To override registrar_port, set KEYLIME_AGENT_REGISTRAR_PORT environment
@@ -175,8 +182,9 @@ enable_revocation_notifications = false
 # environment variable.
 revocation_actions_dir = "/usr/libexec/keylime"
 
-# Revocation IP & Port used by the agent to receive revocation
+# Revocation IP address or hostname (FQDN) & Port used by the agent to receive revocation
 # notifications from the verifier via zeromq.
+# Supports IPv4, IPv6, or fully qualified domain names
 # This is optional and used only when 'enable_revocation_notifications' is 'true'.
 #
 # To override revocation_notification_ip, set


### PR DESCRIPTION
Last year, support for FQDN hostnames instead of only IP addresses were added in https://github.com/keylime/rust-keylime/pull/866. In that PR, no documentation changes were made. Variable names are still for compatibility reasons ending with `_ip`, which might be confusing. This commit adds relevant documentation what the fields accept in the config file inline help.