### PR TITLE
Fix agent handling of 403 Forbidden registration responses

### DIFF
--- a/keylime/src/config/testing.rs
+++ b/keylime/src/config/testing.rs
@@ -256,6 +256,10 @@ impl Drop for TestConfigGuard {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    // Mutex to ensure tests that modify global TESTING_CONFIG_OVERRIDE run serially
+    static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_get_testing_config() {
@@ -288,6 +292,9 @@ mod tests {
 
     #[test]
     fn test_testing_config_override() {
+        // Acquire mutex to prevent concurrent access to global state
+        let _lock = TEST_MUTEX.lock().unwrap(); //#[allow_ci]
+
         // Clear any existing override
         clear_testing_config_override();
 
@@ -330,6 +337,9 @@ mod tests {
 
     #[test]
     fn test_testconfig_guard_automatic_cleanup() {
+        // Acquire mutex to prevent concurrent access to global state
+        let _lock = TEST_MUTEX.lock().unwrap(); //#[allow_ci]
+
         // Clear any existing override
         clear_testing_config_override();
 


### PR DESCRIPTION
The agent was incorrectly interpreting 403 Forbidden responses from the registrar as API version incompatibility errors. This caused two problems:

1. The agent would try all enabled API versions, even though 403 indicates a permanent security rejection (e.g., TPM identity mismatch during re-registration)

2. The agent would continue running after registration failure, making it appear operational when it was not properly registered

This issue became apparent with the Python keylime registrar security fix for CVE-2025-13609 (duplicate UUID vulnerability), which returns 403 Forbidden when an agent attempts to re-register with a different TPM identity.

The agent will now correctly fail fast when the registrar rejects registration for security reasons, allowing proper error detection in tests and production deployments.

Related: keylime/keylime#1820 (Python registrar UUID spoofing fix)