### PR TITLE
fix push-mode: cache UEFI event log bytes at startup to avoid post-privilege-drop failures

### DIFF
--- a/keylime-push-model-agent/src/attestation.rs
+++ b/keylime-push-model-agent/src/attestation.rs
@@ -284,6 +284,7 @@ mod tests {
             ima_ml_file: None,
             ima_ml: Mutex::new(MeasurementList::new()),
             measuredboot_ml_file: None,
+            measuredboot_ml_bytes: None,
         }
     }
 

--- a/keylime-push-model-agent/src/main.rs
+++ b/keylime-push-model-agent/src/main.rs
@@ -547,6 +547,7 @@ mod tests {
                     keylime::ima::MeasurementList::new(),
                 ),
                 measuredboot_ml_file: None,
+                measuredboot_ml_bytes: None,
             };
         let res = run(&args, privileged_resources);
         assert!(res.await.is_err());

--- a/keylime-push-model-agent/src/privileged_resources.rs
+++ b/keylime-push-model-agent/src/privileged_resources.rs
@@ -19,6 +19,7 @@ use anyhow::Result;
 use keylime::ima::MeasurementList;
 use log::{info, warn};
 use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use std::sync::Mutex;
 
@@ -48,7 +49,16 @@ pub struct PrivilegedResources {
     /// This file requires root access to `/sys/kernel/security/tpm0/`.
     /// If the file doesn't exist or can't be opened, this will be None
     /// and measured boot attestation will be unavailable.
+    /// Still used by `UefiLogHandler::from_file()` for event parsing.
     pub measuredboot_ml_file: Option<Mutex<File>>,
+
+    /// Cached raw bytes of the measured boot (UEFI) event log, read
+    /// once at startup with root privileges.  The UEFI event log only
+    /// contains boot-time events (up to ExitBootServices) so the
+    /// cached content is always valid for this boot.  Used by
+    /// `generate_uefi_log_evidence()` to avoid re-opening the
+    /// securityfs file after privilege drop.
+    pub measuredboot_ml_bytes: Option<Vec<u8>>,
 }
 
 impl PrivilegedResources {
@@ -104,41 +114,71 @@ impl PrivilegedResources {
             None
         };
 
-        // Open measured boot log (requires root for /sys/kernel/security/tpm0/)
+        // Open the measured boot log once, read its bytes into a cache, then
+        // seek back to the start so the same handle can be reused by
+        // UefiLogHandler::from_file.  Opening only once eliminates the TOCTOU
+        // race.  The byte cache is always populated when the file is
+        // readable; the file handle may be None if the seek-back fails
+        // (unlikely on securityfs seq_files, but harmless).
         let measuredboot_ml_path =
             Path::new(config.measuredboot_ml_path.as_str());
-        let measuredboot_ml_file = if measuredboot_ml_path.exists() {
-            match File::open(measuredboot_ml_path) {
-                Ok(file) => {
-                    info!(
-                        "Opened measured boot log: {}",
-                        measuredboot_ml_path.display()
-                    );
-                    Some(Mutex::new(file))
+        let (measuredboot_ml_file, measuredboot_ml_bytes) =
+            if measuredboot_ml_path.exists() {
+                let open_and_cache =
+                    || -> std::io::Result<(File, Vec<u8>)> {
+                        let mut file = File::open(measuredboot_ml_path)?;
+                        let mut bytes = Vec::new();
+                        file.read_to_end(&mut bytes)?;
+                        Ok((file, bytes))
+                    };
+                match open_and_cache() {
+                    Ok((mut file, bytes)) => {
+                        let file_handle = match file.seek(SeekFrom::Start(0))
+                        {
+                            Ok(_) => Some(Mutex::new(file)),
+                            Err(e) => {
+                                warn!(
+                                        "Measured boot log rewind failed: {} - {}; \
+                                         using cached bytes only",
+                                        measuredboot_ml_path.display(),
+                                        e
+                                    );
+                                None
+                            }
+                        };
+                        info!(
+                            "Opened and cached measured boot log: {} ({} bytes)",
+                            measuredboot_ml_path.display(),
+                            bytes.len()
+                        );
+                        (file_handle, Some(bytes))
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Measured boot measurement list not accessible: {} - {}",
+                            measuredboot_ml_path.display(),
+                            e
+                        );
+                        warn!(
+                            "Measured boot attestation will be unavailable"
+                        );
+                        (None, None)
+                    }
                 }
-                Err(e) => {
-                    warn!(
-                        "Measured boot measurement list not accessible: {} - {}",
-                        measuredboot_ml_path.display(),
-                        e
-                    );
-                    warn!("Measured boot attestation will be unavailable");
-                    None
-                }
-            }
-        } else {
-            warn!(
-                "Measured boot measurement list not available: {}",
-                measuredboot_ml_path.display()
-            );
-            warn!("Measured boot attestation will be unavailable");
-            None
-        };
+            } else {
+                warn!(
+                    "Measured boot measurement list not available: {}",
+                    measuredboot_ml_path.display()
+                );
+                warn!("Measured boot attestation will be unavailable");
+                (None, None)
+            };
 
         Ok(PrivilegedResources {
             ima_ml_file,
             ima_ml: Mutex::new(MeasurementList::new()),
             measuredboot_ml_file,
+            measuredboot_ml_bytes,
         })
     }
 }
@@ -164,6 +204,10 @@ mod tests {
 
         assert!(resources.ima_ml_file.is_none());
         assert!(resources.measuredboot_ml_file.is_none());
+        assert!(
+            resources.measuredboot_ml_bytes.is_none(),
+            "bytes cache should be None when the file doesn't exist"
+        );
         // IMA MeasurementList should always be initialized
         assert!(resources.ima_ml.lock().is_ok());
     }
@@ -198,6 +242,11 @@ mod tests {
 
         assert!(resources.ima_ml_file.is_some());
         assert!(resources.measuredboot_ml_file.is_some());
+        assert_eq!(
+            resources.measuredboot_ml_bytes.as_deref(),
+            Some(b"test uefi data" as &[u8]),
+            "bytes cache should contain the file contents"
+        );
         assert!(resources.ima_ml.lock().is_ok());
     }
 
@@ -221,6 +270,8 @@ mod tests {
 
         assert!(resources.ima_ml_file.is_some());
         assert!(resources.measuredboot_ml_file.is_none());
+        assert!(resources.measuredboot_ml_bytes.is_none(),
+            "bytes cache should be None when measuredboot_ml_path doesn't exist");
         assert!(resources.ima_ml.lock().is_ok());
     }
 }

--- a/keylime-push-model-agent/src/state_machine.rs
+++ b/keylime-push-model-agent/src/state_machine.rs
@@ -437,6 +437,7 @@ mod tpm_tests {
             ima_ml_file: None,
             ima_ml: Mutex::new(MeasurementList::new()),
             measuredboot_ml_file: None,
+            measuredboot_ml_bytes: None,
         }
     }
 
@@ -783,6 +784,7 @@ mod tests {
             ima_ml_file: None,
             ima_ml: Mutex::new(MeasurementList::new()),
             measuredboot_ml_file: None,
+            measuredboot_ml_bytes: None,
         }
     }
 

--- a/keylime-push-model-agent/src/struct_filler.rs
+++ b/keylime-push-model-agent/src/struct_filler.rs
@@ -312,6 +312,7 @@ impl<'a> FillerFromHardware<'a> {
                 &evidence_requests,
                 Some(&self.privileged_resources.ima_ml),
                 self.privileged_resources.ima_ml_file.as_ref(),
+                self.privileged_resources.measuredboot_ml_bytes.as_deref(),
             )
             .await
         {
@@ -445,6 +446,7 @@ mod tests {
             ima_ml_file: None,
             ima_ml: Mutex::new(MeasurementList::new()),
             measuredboot_ml_file: None,
+            measuredboot_ml_bytes: None,
         }
     }
 

--- a/keylime/src/context_info.rs
+++ b/keylime/src/context_info.rs
@@ -103,6 +103,33 @@ pub struct ContextInfo {
     pub ak_handle: KeyHandle,
 }
 
+/// Select and return the base64-encoded UEFI event log content.
+///
+/// This is the pure, allocation-only core of
+/// [`ContextInfo::generate_uefi_log_evidence`]: it does not touch the TPM
+/// and can be called (and tested) without a [`ContextInfo`].
+///
+/// # Source priority
+/// 1. `cached_uefi_bytes` – encoded directly, no file I/O.
+/// 2. `log_path` – file read from disk.
+/// 3. Both `None` – returns an empty string.
+fn uefi_log_content(
+    log_path: Option<&str>,
+    cached_uefi_bytes: Option<&[u8]>,
+) -> Result<String, ContextInfoError> {
+    if let Some(bytes) = cached_uefi_bytes {
+        Ok(base64_standard.encode(bytes))
+    } else if let Some(path) = log_path {
+        UefiLogHandler::read_raw_base64(path).map_err(|e| {
+            ContextInfoError::Keylime(format!(
+                "Failed to read UEFI log: {e:?}"
+            ))
+        })
+    } else {
+        Ok(String::new())
+    }
+}
+
 impl ContextInfo {
     pub fn new_from_str(
         config: AlgorithmConfigurationString,
@@ -679,33 +706,31 @@ impl ContextInfo {
         })
     }
 
+    /// Generate a UEFI event-log evidence entry; see [`uefi_log_content`] for
+    /// source-priority details.
     pub async fn generate_uefi_log_evidence(
         &mut self,
         log_path: Option<&str>,
+        cached_uefi_bytes: Option<&[u8]>,
     ) -> Result<EvidenceData, ContextInfoError> {
-        let content = if let Some(uefi_log_path) = log_path {
-            // Read raw bytes directly without parsing/reconstructing
-            // to match pull-model agent behavior
-            UefiLogHandler::read_raw_base64(uefi_log_path).map_err(|e| {
-                ContextInfoError::Keylime(format!(
-                    "Failed to read UEFI log: {e:?}",
-                ))
-            })?
-        } else {
-            String::new()
-        };
-
         Ok(EvidenceData::UefiLog {
-            entries: Some(content),
+            entries: Some(uefi_log_content(log_path, cached_uefi_bytes)?),
             meta: None,
         })
     }
 
+    /// Collect evidence for all requested subjects in one pass.
+    ///
+    /// `cached_uefi_bytes` is forwarded to every
+    /// [`generate_uefi_log_evidence`](Self::generate_uefi_log_evidence) call
+    /// so that the push-model agent can supply bytes that were captured with
+    /// root privileges before the privilege drop.
     pub async fn collect_evidences(
         &mut self,
         evidence_requests: &[EvidenceRequest],
         ima_ml: Option<&std::sync::Mutex<crate::ima::MeasurementList>>,
         ima_file: Option<&std::sync::Mutex<std::fs::File>>,
+        cached_uefi_bytes: Option<&[u8]>,
     ) -> Result<Vec<EvidenceData>, ContextInfoError> {
         let mut evidence_results = Vec::new();
 
@@ -747,7 +772,10 @@ impl ContextInfo {
                 }
                 EvidenceRequest::UefiLog { log_path, .. } => {
                     let evidence = self
-                        .generate_uefi_log_evidence(log_path.as_deref())
+                        .generate_uefi_log_evidence(
+                            log_path.as_deref(),
+                            cached_uefi_bytes,
+                        )
                         .await?;
                     evidence_results.push(evidence);
                 }
@@ -755,6 +783,55 @@ impl ContextInfo {
         }
 
         Ok(evidence_results)
+    }
+}
+
+#[cfg(test)]
+mod uefi_log_tests {
+    use super::base64_standard;
+    use super::*;
+    use base64::Engine as _;
+
+    /// Cached bytes are preferred over the on-disk file.
+    ///
+    /// RED without the commit: `uefi_log_content` had no `cached_uefi_bytes`
+    /// branch, so it read the real log file whose content differs from the
+    /// cache bytes below.
+    #[test]
+    fn test_cache_preferred_over_file() {
+        let cache = b"hello from cache";
+        let expected = base64_standard.encode(cache);
+
+        // log_path points at a real file; if the cache is ignored the
+        // returned content would be the file's bytes, not `expected`.
+        let result =
+            uefi_log_content(Some("test-data/uefi_log.bin"), Some(cache));
+        assert_eq!(result.unwrap(), expected); //#[allow_ci]
+    }
+
+    /// Without a cache the file is read and correctly base64-encoded.
+    #[test]
+    fn test_file_fallback() {
+        let expected_bytes =
+            std::fs::read("test-data/uefi_log.bin").expect("fixture missing");
+        let expected = base64_standard.encode(&expected_bytes);
+
+        let result = uefi_log_content(Some("test-data/uefi_log.bin"), None);
+        assert_eq!(result.unwrap(), expected); //#[allow_ci]
+    }
+
+    /// Cache is used even when log_path does not exist on disk.
+    ///
+    /// RED without the commit: without caching, opening a nonexistent path
+    /// returns an error and the assertion on `Ok` fails.
+    #[test]
+    fn test_cache_used_when_path_nonexistent() {
+        let cache = b"cached uefi payload";
+        let expected = base64_standard.encode(cache);
+
+        let result =
+            uefi_log_content(Some("/nonexistent/uefi_log.bin"), Some(cache));
+        assert_eq!(result.unwrap(), expected); //#[allow_ci]
     }
 }
 
@@ -1020,7 +1097,7 @@ mod tests {
         ];
         let mut context_info = context_result.unwrap(); //#[allow_ci]
         let result = context_info
-            .collect_evidences(&evidence_requests, None, None)
+            .collect_evidences(&evidence_requests, None, None, None)
             .await;
         assert!(result.is_ok());
         let evidence_results = result.unwrap(); //#[allow_ci]
@@ -1065,7 +1142,7 @@ mod tests {
         }];
 
         let result = context_info
-            .collect_evidences(&evidence_requests, None, None)
+            .collect_evidences(&evidence_requests, None, None, None)
             .await;
         assert!(result.is_err());
         assert!(matches!(
@@ -1102,7 +1179,7 @@ mod tests {
         }];
 
         let result = context_info
-            .collect_evidences(&evidence_requests, None, None)
+            .collect_evidences(&evidence_requests, None, None, None)
             .await;
         assert!(result.is_err());
         assert!(matches!(
@@ -1159,7 +1236,7 @@ mod tests {
             },
         ];
         let result = context_info
-            .collect_evidences(&evidence_requests, None, None)
+            .collect_evidences(&evidence_requests, None, None, None)
             .await;
         assert!(result.is_ok());
         context_info.flush_context().unwrap(); //#[allow_ci]
@@ -1208,6 +1285,55 @@ mod tests {
             context_info.resolve_agent_id("  custom-with-spaces  "),
             "custom-with-spaces"
         );
+
+        context_info.flush_context().unwrap(); //#[allow_ci]
+    }
+
+    /// Verify that `collect_evidences` forwards `cached_uefi_bytes` all the
+    /// way through to `generate_uefi_log_evidence` rather than falling back to
+    /// an on-disk read.
+    ///
+    /// We submit a single `UefiLog` request with a non-existent `log_path` so
+    /// the test would fail (I/O error) if the cache were ignored.
+    #[tokio::test]
+    async fn test_collect_evidences_uses_cached_uefi_bytes() {
+        use crate::structures::{EvidenceData, EvidenceRequest};
+        use base64::Engine;
+
+        let _mutex = testing::lock_tests().await;
+        let config = AlgorithmConfigurationString {
+            tpm_encryption_alg: "rsa".to_string(),
+            tpm_hash_alg: "sha256".to_string(),
+            tpm_signing_alg: "rsassa".to_string(),
+            agent_data_path: "".to_string(),
+        };
+        let mut context_info = ContextInfo::new_from_str(config)
+            .expect("Failed to create ContextInfo"); //#[allow_ci]
+
+        let cached_bytes: &[u8] = b"synthetic uefi log payload";
+        let expected =
+            base64::engine::general_purpose::STANDARD.encode(cached_bytes);
+
+        let requests = vec![EvidenceRequest::UefiLog {
+            format: None,
+            log_path: Some("/nonexistent/uefi_log.bin".to_string()),
+        }];
+
+        let evidences = context_info
+            .collect_evidences(&requests, None, None, Some(cached_bytes))
+            .await
+            .expect("collect_evidences failed"); //#[allow_ci]
+
+        assert_eq!(evidences.len(), 1);
+        if let EvidenceData::UefiLog { entries, .. } = &evidences[0] {
+            assert_eq!(
+                entries.as_deref(),
+                Some(expected.as_str()),
+                "collect_evidences must forward cached_uefi_bytes"
+            );
+        } else {
+            panic!("Expected EvidenceData::UefiLog"); //#[allow_ci]
+        }
 
         context_info.flush_context().unwrap(); //#[allow_ci]
     }


### PR DESCRIPTION
generate_uefi_log_evidence() was re-opening the securityfs UEFI event log by path on each attestation, which fails with PermissionDenied after run_as drops privileges in the push-model agent.

So we read and cache the raw event log bytes at startup, while still privileged. Since the UEFI event log only contains boot-time events (up to ExitBootServices), the cached bytes should stay valid for as long as the agent runs (and longer; until reboot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evidence collection now prefers in-memory cached measured-boot and UEFI log data, falling back to on-disk reads when cache is absent.

* **Tests**
  * Added and updated tests for cache precedence, file-fallback behavior, and missing-path scenarios; test helpers updated to include the new cached fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->