### PR TITLE
tpm: Hash qualifying data in TPM2_Certify for IAK-based AK certification

### DIFF
--- a/keylime-agent/src/api.rs
+++ b/keylime-agent/src/api.rs
@@ -188,6 +188,25 @@ fn configure_api_v2_5(cfg: &mut web::ServiceConfig) {
     )
 }
 
+/// Configure the endpoints supported by API version 2.6
+///
+/// Version 2.6 has the same agent-side endpoints as 2.5. The version bump
+/// reflects a protocol change: the agent now SHA-256 hashes the agent ID
+/// before using it as qualifying data in TPM2_Certify (IAK-based AK
+/// certification). This ensures the qualifying data fits within the
+/// TPM2B_DATA size limit on SHA-256-only TPMs (34 bytes). The certify
+/// operation is deferred until after API version negotiation so the agent
+/// can fall back to raw UUID bytes when the registrar only supports 2.5.
+fn configure_api_v2_6(cfg: &mut web::ServiceConfig) {
+    let version = Version::from_str("2.6").expect("Invalid API version");
+    _ = cfg.app_data(web::Data::new(version));
+    configure_base_endpoints(cfg);
+    _ = cfg.service(
+        web::scope("/agent")
+            .configure(agent_handler::configure_agent_endpoints),
+    )
+}
+
 /// Get a scope configured for the given API version
 pub(crate) fn get_api_scope(version: &str) -> Result<Scope, APIError> {
     match version {
@@ -201,6 +220,8 @@ pub(crate) fn get_api_scope(version: &str) -> Result<Scope, APIError> {
             .configure(configure_api_v2_4)),
         "2.5" => Ok(web::scope(format!("v{version}").as_ref())
             .configure(configure_api_v2_5)),
+        "2.6" => Ok(web::scope(format!("v{version}").as_ref())
+            .configure(configure_api_v2_6)),
         _ => Err(APIError::UnsupportedVersion(version.into())),
     }
 }

--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -87,7 +87,7 @@ use tss_esapi::{
     handles::KeyHandle,
     interface_types::algorithm::{AsymmetricAlgorithm, HashingAlgorithm},
     interface_types::resource_handles::Hierarchy,
-    structures::{Auth, Data, Digest, MaxBuffer, PublicBuffer},
+    structures::{Auth, Digest, MaxBuffer, PublicBuffer},
     traits::Marshall,
     Context,
 };
@@ -494,24 +494,6 @@ async fn main() -> Result<()> {
         None
     };
 
-    let (attest, signature) = if let Some(dev_id) = &mut device_id {
-        let qualifying_data = Data::try_from(agent_uuid.as_bytes())?;
-        let (attest, signature) =
-            dev_id.certify(qualifying_data, ak_handle, &mut ctx)?;
-
-        info!("AK certified with IAK.");
-
-        // // For debugging certify(), the following checks the generated signature
-        // let max_b = MaxBuffer::try_from(attest.clone().marshall()?)?;
-        // let (hashed_attest, _) = ctx.inner.hash(max_b, HashingAlgorithm::Sha256, Hierarchy::Endorsement,)?;
-        // println!("{:?}", hashed_attest);
-        // println!("{:?}", signature);
-        // println!("{:?}", ctx.inner.verify_signature(iak.as_ref().unwrap().handle, hashed_attest, signature.clone())?); //#[allow_ci]
-        (Some(attest), Some(signature))
-    } else {
-        (None, None)
-    };
-
     // Load or generate RSA key pair for secure transmission of u, v keys.
     // The u, v keys are two halves of the key used to decrypt the workload after
     // the Identity and Integrity Quotes sent by the agent are validated
@@ -645,8 +627,6 @@ async fn main() -> Result<()> {
         agent_uuid: agent_uuid.clone(),
         mtls_cert,
         device_id,
-        attest,
-        signature,
         ak_handle,
         retry_config: Some(get_retry_config(&config)),
     };

--- a/keylime-push-model-agent/src/registration.rs
+++ b/keylime-push-model-agent/src/registration.rs
@@ -109,8 +109,6 @@ pub async fn register_agent(
         agent_uuid,
         mtls_cert: None,
         device_id: None, // TODO: Check how to proceed with device ID
-        attest: None, // TODO: Check how to proceed with attestation, normally, no device ID means no attest
-        signature: None, // TODO: Normally, no device ID means no signature
         ak_handle: context_info.ak_handle,
         retry_config,
     };

--- a/keylime/src/agent_registration.rs
+++ b/keylime/src/agent_registration.rs
@@ -9,10 +9,12 @@ use crate::{
     tpm::{self},
 };
 use base64::{engine::general_purpose, Engine as _};
-use log::{error, info};
+use log::{error, info, warn};
 use openssl::x509::X509;
 use tss_esapi::{
-    handles::KeyHandle, structures::PublicBuffer, traits::Marshall,
+    handles::KeyHandle,
+    structures::{Data, PublicBuffer},
+    traits::Marshall,
 };
 
 #[derive(Debug)]
@@ -44,14 +46,12 @@ pub struct AgentRegistration {
     pub agent_uuid: String,
     pub mtls_cert: Option<X509>,
     pub device_id: Option<device_id::DeviceID>,
-    pub attest: Option<tss_esapi::structures::Attest>,
-    pub signature: Option<tss_esapi::structures::Signature>,
     pub ak_handle: KeyHandle,
     pub retry_config: Option<RetryConfig>,
 }
 
 pub async fn register_agent(
-    aa: AgentRegistration,
+    mut aa: AgentRegistration,
     ctx: &mut tpm::Context<'_>,
 ) -> Result<()> {
     let iak_pub;
@@ -59,6 +59,28 @@ pub async fn register_agent(
     let ak_pub = &PublicBuffer::try_from(aa.ak.public)?.marshall()?;
     let ek_pub =
         &PublicBuffer::try_from(aa.ek_result.public.clone())?.marshall()?;
+
+    let ac = &aa.agent_registration_config;
+
+    // Build the registrar client first so we can query its supported API
+    // versions before performing TPM operations that depend on that version.
+    // Uses HTTPS if CA certificate is provided, otherwise plain HTTP.
+    let mut builder = RegistrarClientBuilder::new()
+        .registrar_address(ac.registrar_ip.clone())
+        .registrar_port(ac.registrar_port)
+        .retry_config(aa.retry_config.clone());
+
+    if let Some(ca_cert) = &ac.registrar_ca_cert {
+        builder = builder.ca_certificate(ca_cert.clone());
+    }
+    if let Some(disable_tls) = ac.registrar_disable_tls {
+        builder = builder.disable_tls(disable_tls);
+    }
+    if let Some(timeout) = ac.registrar_timeout {
+        builder = builder.timeout(timeout);
+    }
+
+    let mut registrar_client = builder.build().await?;
 
     let mut ai_builder = AgentIdentityBuilder::new()
         .ak_pub(ak_pub)
@@ -81,15 +103,43 @@ pub async fn register_agent(
 
     // Set the IAK/IDevID related fields, if enabled
     if aa.agent_registration_config.enable_iak_idevid {
-        let (Some(dev_id), Some(attest), Some(signature)) =
-            (&aa.device_id, aa.attest, aa.signature)
-        else {
+        let Some(dev_id) = aa.device_id.as_mut() else {
             error!("IDevID and IAK are enabled but could not be generated");
             return Err(Error::ConfigurationGenericError(
                 "IDevID and IAK are enabled but could not be generated"
                     .to_string(),
             ));
         };
+
+        // Hash the agent UUID (SHA-256) when the registrar supports API 2.6+.
+        // This keeps qualifying data within the TPM2B_DATA size limit on
+        // SHA-256-only TPMs (34 bytes). For registrars that only support 2.5
+        // or earlier, fall back to the raw UUID bytes for backward compat.
+        let qualifying_data = if registrar_client.supports_api_version("2.6")
+        {
+            let hash = crypto::hash(
+                aa.agent_uuid.as_bytes(),
+                openssl::hash::MessageDigest::sha256(),
+            )?;
+            Data::try_from(hash.as_slice())?
+        } else {
+            let uuid_bytes = aa.agent_uuid.as_bytes();
+            if uuid_bytes.len() > 34 {
+                // TPM2B_DATA limit on SHA-256-only TPMs is 34 bytes.
+                // Raw UUID won't fit; the registrar must support 2.6+.
+                warn!(
+                        "Agent UUID is {} bytes (max 34 for pre-2.6 registrar); \
+                         registration will likely fail. Update the registrar to 2.6+.",
+                        uuid_bytes.len()
+                    );
+            }
+            Data::try_from(uuid_bytes)?
+        };
+
+        let (attest, signature) =
+            dev_id.certify(qualifying_data, aa.ak_handle, ctx)?;
+
+        info!("AK certified with IAK.");
 
         iak_pub =
             PublicBuffer::try_from(dev_id.iak_pubkey.clone())?.marshall()?;
@@ -114,28 +164,6 @@ pub async fn register_agent(
 
     // Build the Agent Identity
     let ai = ai_builder.build().await?;
-
-    let ac = &aa.agent_registration_config;
-
-    // Build the registrar client
-    // Uses HTTPS if CA certificate is provided, otherwise plain HTTP
-    let mut builder = RegistrarClientBuilder::new()
-        .registrar_address(ac.registrar_ip.clone())
-        .registrar_port(ac.registrar_port)
-        .retry_config(aa.retry_config.clone());
-
-    // Add TLS configuration if CA certificate is provided
-    if let Some(ca_cert) = &ac.registrar_ca_cert {
-        builder = builder.ca_certificate(ca_cert.clone());
-    }
-    if let Some(disable_tls) = ac.registrar_disable_tls {
-        builder = builder.disable_tls(disable_tls);
-    }
-    if let Some(timeout) = ac.registrar_timeout {
-        builder = builder.timeout(timeout);
-    }
-
-    let mut registrar_client = builder.build().await?;
 
     // Request keyblob material
     let keyblob = registrar_client.register_agent(&ai).await?;

--- a/keylime/src/config/base.rs
+++ b/keylime/src/config/base.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 
 pub static CONFIG_VERSION: &str = "2.0";
 pub static SUPPORTED_API_VERSIONS: &[&str] =
-    &["2.1", "2.2", "2.3", "2.4", "2.5"];
+    &["2.1", "2.2", "2.3", "2.4", "2.5", "2.6"];
 pub static DEFAULT_REGISTRAR_API_VERSIONS: &str = "default";
 
 pub static DEFAULT_CONFIG: &str = "/etc/keylime/agent.conf";

--- a/keylime/src/registrar_client.rs
+++ b/keylime/src/registrar_client.rs
@@ -400,6 +400,16 @@ struct Register<'a> {
 }
 
 impl RegistrarClient {
+    /// Check if the registrar supports the given API version.
+    ///
+    /// Returns `false` if the registrar did not advertise supported versions
+    /// (e.g., it does not expose a `/version` endpoint).
+    pub fn supports_api_version(&self, version: &str) -> bool {
+        self.supported_api_versions
+            .as_ref()
+            .is_some_and(|versions| versions.iter().any(|v| v == version))
+    }
+
     async fn try_register_agent(
         &self,
         ai: &AgentIdentity<'_>,

--- a/keylime/src/tpm.rs
+++ b/keylime/src/tpm.rs
@@ -3291,14 +3291,25 @@ pub mod tests {
             .expect("failed to create IAK")
             .handle;
 
-        let qualifying_data = "some_uuid".as_bytes();
+        // Use a realistic UUID string (36 bytes) — the exact input size that
+        // triggers TPM_RC_SIZE on SHA-256-only TPMs without the hash fix.
+        let agent_uuid = "d432fbb3-d2f1-4a97-9ef7-75bd81c00000";
+        let qualifying_data = crate::crypto::hash(
+            agent_uuid.as_bytes(),
+            openssl::hash::MessageDigest::sha256(),
+        )
+        .unwrap(); //#[allow_ci]
 
-        let r = ctx.certify_credential_with_iak(
-            Data::try_from(qualifying_data).unwrap(), //#[allow_ci]
-            ak_handle,
-            iak_handle,
+        let data = Data::try_from(qualifying_data.as_slice()).unwrap(); //#[allow_ci]
+        let (attest, _signature) = ctx
+            .certify_credential_with_iak(data, ak_handle, iak_handle)
+            .expect("certify_credential_with_iak failed");
+
+        assert_eq!(
+            attest.extra_data().value(),
+            qualifying_data.as_slice(),
+            "extra_data in Attest must equal the SHA-256 hash of the agent UUID"
         );
-        assert!(r.is_ok(), "Result: {r:?}");
 
         // Flush context to free TPM memory
         let r = ctx.flush_context(ek_handle.into());


### PR DESCRIPTION
tpm: Hash qualifying data in TPM2_Certify for IAK-based AK certification

## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [x] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
**Resolves:** https://github.com/keylime/rust-keylime/issues/1226
**See also:** https://github.com/keylime/keylime/issues/1892

## Change Description

### Concise Summary
Hash agent ID (SHA-256) before passing it as qualifying data to `TPM2_Certify`.

### Technical Details

When the agent certifies the AK with the IAK using `TPM2_Certify`, it passes the agent ID string directly as `qualifyingData` (`TPM2B_DATA`). The TPM 2.0 spec limits `TPM2B_DATA` to `sizeof(TPMT_HA)` bytes, which depends on the TPM's supported hash algorithms. On SHA-256-only TPMs (e.g., NVIDIA Grace Hopper aarch64), this limit is 34 bytes — smaller than a standard UUID string (36 bytes). Since Keylime supports arbitrary strings as agent IDs, the qualifying data can be even longer.

This PR hashes the agent ID with SHA-256 before using it as qualifying data, producing a fixed 32-byte value that fits within `TPM2B_DATA` on any TPM. The qualifying data is arbitrary per the TPM 2.0 spec (Part 3, Section 18.2) — hashing it is fully compliant.

**Changes:**

- **Hash agent ID in `main.rs`**: Use `keylime::crypto::hash` with `MessageDigest::sha256()` to hash the agent ID before passing it to `TPM2_Certify`. No new dependencies — uses the existing `openssl` crate via the keylime crypto module.

- **Update test in `tpm.rs`**: `test_certify_credential_with_iak` now hashes the qualifying data to match the production code path.

- **Bump pull-mode API version to 2.6** in `config/base.rs`.

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

Documentation updates are included in the companion Python PR.

## Verification Process
1. Run `cargo fmt && cargo clippy --all-targets` — no new warnings
2. Run `cargo test` — existing tests pass
3. Integration test with swtpm:
   - Verify that a new agent (2.6) registers successfully with the updated registrar
   - Verify that registration works with agent IDs longer than 34 bytes (e.g., non-UUID strings)

## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context

- **Deployment ordering**: The companion Python PR (https://github.com/keylime/keylime/issues/1892) **must be merged first**. It adds backward-compatible "try both" support to the registrar, accepting both hashed (new agents) and raw (old agents) qualifying data. If this Rust PR is merged first, agents on SHA-256-only TPMs with long agent IDs will send hashed qualifying data to a registrar that cannot verify it.
- No new dependencies were added. The hash is computed using the existing `keylime::crypto::hash` function backed by `openssl`.

> This PR was created with the assistance of Claude Opus 4.6 (Anthropic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for API version 2.6.

* **Updates**
  * Agent registration now computes IAK/IDevID attestations at registration time and selects qualifying data based on registrar API version (SHA-256 for 2.6+).

* **Tests / CI**
  * Unit tests adjusted for the new qualifying-data behavior; e2e scenario now pins upstream source/branch used by CI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/keylime/rust-keylime/pull/1239)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->