### PR TITLE
fix: Remove unused base64::Engine import in context_info tests

### DIFF
--- a/keylime/src/context_info.rs
+++ b/keylime/src/context_info.rs
@@ -790,8 +790,6 @@ impl ContextInfo {
 mod uefi_log_tests {
     use super::base64_standard;
     use super::*;
-    use base64::Engine as _;
-
     /// Cached bytes are preferred over the on-disk file.
     ///
     /// RED without the commit: `uefi_log_content` had no `cached_uefi_bytes`


### PR DESCRIPTION
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (non-breaking change that improves code quality or structure)
- [ ] Tests (adding or updating tests)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Related Issues

None

## Change Description

### Concise Summary

Remove unused `use base64::Engine as _;` import in the `uefi_log_tests` module, fixing a compiler warning.

### Technical Details

The `base64::Engine` trait was imported but never used in the `uefi_log_tests` module in `keylime/src/context_info.rs`. This produced a warning during compilation:

```
warning: unused import: `base64::Engine`
   --> keylime/src/context_info.rs:793:9
```

The import was simply removed since no code in the test module requires it directly (the `base64_standard` helper imported from the parent module already handles encoding/decoding).

## Documentation Updates Required

- [ ] README.md
- [ ] Configuration documentation
- [ ] API documentation
- [ ] Man pages
- [ ] Other:

No documentation changes needed.

## Verification Process

1. Run `cargo clippy --all-targets` — no warnings produced
2. Run `cargo fmt --check` — no formatting issues
3. Run `cargo test` — all tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have signed all my commits
- [ ] I have updated the CHANGELOG
- [x] All new and existing tests pass

## Additional Context

> [!NOTE]
> This PR was created with the assistance of AI (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added gated unit tests for UEFI log handling verifying cached vs. on-disk behavior, correct base64 encoding of log content, and that cached content is used even if the on-disk log path is missing.
  * Cleaned up redundant test imports for clearer test code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->