### PR TITLE
Fix payload key upgrade regression by falling back to mTLS key

### DIFF
--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -118,6 +118,118 @@ fn get_retry_config(config: &config::AgentConfig) -> RetryConfig {
     }
 }
 
+/// On upgrade from a pre-key-separation agent, the payload key file does not
+/// exist yet. If the mTLS server key is RSA, copy it as the payload key so
+/// that PCR 16 stays consistent with what the verifier has cached.
+///
+/// Returns `Ok(())` when the copy succeeds or when a copy is not needed
+/// (key already exists, server key missing, or server key is not RSA).
+/// Returns `Err` if the server key is a valid RSA key but writing the
+/// payload key file fails — continuing in that state could leave a
+/// corrupt or insecure file behind.
+fn ensure_payload_key(
+    payload_key_path: &Path,
+    payload_key_password: &str,
+    server_key_path: &Path,
+    server_key_password: &str,
+) -> std::result::Result<(), Error> {
+    if payload_key_path.exists() {
+        return Ok(());
+    }
+    if !server_key_path.exists() {
+        return Ok(());
+    }
+
+    match crypto::load_key_pair(server_key_path, Some(server_key_password)) {
+        Ok((_, priv_key))
+            if priv_key.id() == Id::RSA && priv_key.bits() >= 2048 =>
+        {
+            crypto::write_key_pair(
+                &priv_key,
+                payload_key_path,
+                Some(payload_key_password),
+            )
+            .map_err(|e| {
+                if matches!(e, crypto::CryptoError::IOSetPermissionError(_)) {
+                    // The key was written successfully but chmod failed.
+                    // Remove the file so the next startup retries the copy
+                    // rather than loading a key with insecure permissions.
+                    // The file did not exist before this call (checked above),
+                    // so removal cannot delete pre-existing user data.
+                    match fs::remove_file(payload_key_path) {
+                        Ok(()) => {
+                            error!(
+                                "Wrote mTLS key to {} but failed to set \
+                                 file permissions: {e}. The file has been \
+                                 removed; the copy will be retried on next \
+                                 startup.",
+                                payload_key_path.display()
+                            );
+                        }
+                        Err(rm_err) => {
+                            error!(
+                                "Wrote mTLS key to {} but failed to set \
+                                 file permissions: {e}. Cleanup also failed: \
+                                 {rm_err}. Remove the file manually before \
+                                 restarting the agent to prevent loading a key \
+                                 with insecure permissions.",
+                                payload_key_path.display()
+                            );
+                        }
+                    }
+                } else {
+                    error!(
+                        "Failed to write mTLS key to {}: {e}. \
+                         If a partial file was left behind, remove \
+                         it manually before restarting the agent.",
+                        payload_key_path.display()
+                    );
+                }
+                Error::Crypto(e)
+            })?;
+
+            warn!(
+                "Payload key not found; wrote mTLS key from {} to {} \
+                 for backward compatibility. The same RSA key will \
+                 be used for both mTLS and payload encryption.",
+                server_key_path.display(),
+                payload_key_path.display()
+            );
+            if !server_key_password.is_empty()
+                && payload_key_password.is_empty()
+            {
+                warn!(
+                    "The mTLS key was encrypted at rest but the \
+                     payload key copy at {} is unencrypted. To \
+                     encrypt it, re-encrypt the file manually and \
+                     set 'payload_key_password' in the agent \
+                     configuration.",
+                    payload_key_path.display()
+                );
+            }
+        }
+        Ok(_) => {
+            warn!(
+                "mTLS key {} is not a supported RSA key (at least 2048 \
+                 bits); a new RSA payload key will be generated, which \
+                 will change PCR 16 and may cause attestation failures \
+                 until the agent is re-enrolled.",
+                server_key_path.display()
+            );
+        }
+        Err(e) => {
+            warn!(
+                "Failed to load mTLS key {}: {e}. \
+                 A new payload key will be generated, which will change \
+                 PCR 16 and may cause attestation failures until the \
+                 agent is re-enrolled.",
+                server_key_path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
 // This data is passed in to the actix httpserver threads that
 // handle quotes.
 #[derive(Debug)]
@@ -500,6 +612,13 @@ async fn main() -> Result<()> {
     // by the Tenant and Cloud Verifier, respectively.
     // The payload key is always persistent, stored at the configured path.
     let key_path = Path::new(&config.payload_key);
+    ensure_payload_key(
+        key_path,
+        config.payload_key_password.as_ref(),
+        Path::new(&config.server_key),
+        config.server_key_password.as_ref(),
+    )?;
+
     let (payload_pub_key, payload_priv_key) = crypto::load_or_generate_key(
         key_path,
         Some(config.payload_key_password.as_ref()),
@@ -1204,5 +1323,202 @@ mod tests {
             retry_config.max_delay_ms,
             Some(config::DEFAULT_EXP_BACKOFF_MAX_DELAY as u64)
         );
+    }
+
+    mod ensure_payload_key_tests {
+        use super::*;
+        use openssl::ec::{EcGroup, EcKey};
+        use openssl::nid::Nid;
+        use openssl::pkey::PKey;
+        use openssl::rsa::Rsa;
+        use tempfile::TempDir;
+
+        type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+        fn write_rsa_key(
+            path: &Path,
+            bits: u32,
+            password: &str,
+        ) -> Result<()> {
+            let rsa = Rsa::generate(bits)?;
+            let key = PKey::from_rsa(rsa)?;
+            crypto::write_key_pair(&key, path, Some(password))?;
+            Ok(())
+        }
+
+        fn write_ec_key(path: &Path, password: &str) -> Result<()> {
+            let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)?;
+            let ec = EcKey::generate(&group)?;
+            let key = PKey::from_ec_key(ec)?;
+            crypto::write_key_pair(&key, path, Some(password))?;
+            Ok(())
+        }
+
+        #[test]
+        fn copies_rsa2048_server_key_as_payload_key() -> Result<()> {
+            let dir = TempDir::new()?;
+            let server = dir.path().join("server-private.pem");
+            let payload = dir.path().join("payload-private.pem");
+
+            write_rsa_key(&server, 2048, "")?;
+
+            ensure_payload_key(&payload, "", &server, "")?;
+
+            assert!(payload.exists());
+            let (_, loaded) = crypto::load_key_pair(&payload, Some(""))?;
+            assert_eq!(loaded.id(), Id::RSA);
+            assert_eq!(loaded.bits(), 2048);
+            Ok(())
+        }
+
+        #[test]
+        fn copies_rsa4096_server_key_as_payload_key() -> Result<()> {
+            let dir = TempDir::new()?;
+            let server = dir.path().join("server-private.pem");
+            let payload = dir.path().join("payload-private.pem");
+
+            write_rsa_key(&server, 4096, "")?;
+
+            ensure_payload_key(&payload, "", &server, "")?;
+
+            assert!(payload.exists());
+            let (_, loaded) = crypto::load_key_pair(&payload, Some(""))?;
+            assert_eq!(loaded.id(), Id::RSA);
+            assert_eq!(loaded.bits(), 4096);
+            Ok(())
+        }
+
+        #[test]
+        fn skips_when_payload_key_already_exists() -> Result<()> {
+            let dir = TempDir::new()?;
+            let server = dir.path().join("server-private.pem");
+            let payload = dir.path().join("payload-private.pem");
+
+            write_rsa_key(&server, 2048, "")?;
+            write_rsa_key(&payload, 2048, "")?;
+
+            let before = fs::read(&payload)?;
+            ensure_payload_key(&payload, "", &server, "")?;
+            let after = fs::read(&payload)?;
+
+            assert_eq!(before, after);
+            Ok(())
+        }
+
+        #[test]
+        fn skips_when_no_server_key() -> Result<()> {
+            let dir = TempDir::new()?;
+            let server = dir.path().join("server-private.pem");
+            let payload = dir.path().join("payload-private.pem");
+
+            ensure_payload_key(&payload, "", &server, "")?;
+
+            assert!(!payload.exists());
+            Ok(())
+        }
+
+        #[test]
+        fn skips_non_rsa_server_key() -> Result<()> {
+            let dir = TempDir::new()?;
+            let server = dir.path().join("server-private.pem");
+            let payload = dir.path().join("payload-private.pem");
+
+            write_ec_key(&server, "")?;
+
+            ensure_payload_key(&payload, "", &server, "")?;
+
+            assert!(!payload.exists());
+            Ok(())
+        }
+
+        #[test]
+        fn skips_rsa_key_below_minimum_size() -> Result<()> {
+            let dir = TempDir::new()?;
+            let server = dir.path().join("server-private.pem");
+            let payload = dir.path().join("payload-private.pem");
+
+            write_rsa_key(&server, 1024, "")?;
+
+            ensure_payload_key(&payload, "", &server, "")?;
+
+            assert!(!payload.exists());
+            Ok(())
+        }
+
+        #[test]
+        fn preserves_key_material_on_copy() -> Result<()> {
+            let dir = TempDir::new()?;
+            let server = dir.path().join("server-private.pem");
+            let payload = dir.path().join("payload-private.pem");
+
+            write_rsa_key(&server, 2048, "")?;
+            let (_, original) = crypto::load_key_pair(&server, Some(""))?;
+
+            ensure_payload_key(&payload, "", &server, "")?;
+
+            let (_, copied) = crypto::load_key_pair(&payload, Some(""))?;
+            assert_eq!(
+                original.private_key_to_pem_pkcs8()?,
+                copied.private_key_to_pem_pkcs8()?,
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn handles_password_mismatch_gracefully() -> Result<()> {
+            let dir = TempDir::new()?;
+            let server = dir.path().join("server-private.pem");
+            let payload = dir.path().join("payload-private.pem");
+
+            write_rsa_key(&server, 2048, "server-pass")?;
+
+            ensure_payload_key(&payload, "payload-pass", &server, "wrong")?;
+
+            assert!(!payload.exists());
+            Ok(())
+        }
+
+        #[test]
+        fn copies_with_different_passwords() -> Result<()> {
+            let dir = TempDir::new()?;
+            let server = dir.path().join("server-private.pem");
+            let payload = dir.path().join("payload-private.pem");
+
+            write_rsa_key(&server, 2048, "server-pass")?;
+            let (_, original) =
+                crypto::load_key_pair(&server, Some("server-pass"))?;
+
+            ensure_payload_key(
+                &payload,
+                "payload-pass",
+                &server,
+                "server-pass",
+            )?;
+
+            let (_, copied) =
+                crypto::load_key_pair(&payload, Some("payload-pass"))?;
+            assert_eq!(
+                original.private_key_to_pem_pkcs8()?,
+                copied.private_key_to_pem_pkcs8()?,
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn returns_err_when_write_fails() -> Result<()> {
+            let dir = TempDir::new()?;
+            let server = dir.path().join("server-private.pem");
+            // Nonexistent parent directory forces FSCreateError in write_key_pair.
+            let payload = dir
+                .path()
+                .join("nonexistent-subdir")
+                .join("payload-private.pem");
+
+            write_rsa_key(&server, 2048, "")?;
+
+            assert!(ensure_payload_key(&payload, "", &server, "").is_err());
+            assert!(!payload.exists());
+            Ok(())
+        }
     }
 }

--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -66,7 +66,7 @@ use keylime::{
 };
 use log::*;
 use openssl::{
-    pkey::{PKey, Private, Public},
+    pkey::{Id, PKey, Private, Public},
     x509::X509,
 };
 use std::{
@@ -504,7 +504,7 @@ async fn main() -> Result<()> {
         key_path,
         Some(config.payload_key_password.as_ref()),
         keylime::algorithms::EncryptionAlgorithm::Rsa2048,
-        true, // Validate that loaded keys are RSA 2048
+        false, // Don't validate key size (accept any RSA for backward compatibility)
     )
     .map_err(|e| {
         error!(
@@ -516,6 +516,25 @@ async fn main() -> Result<()> {
             key_path.display()
         )))
     })?;
+
+    if payload_priv_key.id() != Id::RSA || payload_priv_key.bits() < 2048 {
+        error!(
+            "Payload key {} must be an RSA key of at least 2048 bits, \
+             found {:?} with {} bits",
+            key_path.display(),
+            payload_priv_key.id(),
+            payload_priv_key.bits()
+        );
+        return Err(Error::Configuration(
+            config::KeylimeConfigError::Generic(format!(
+                "Payload key {} must be an RSA key of at least 2048 \
+                 bits, found {:?} with {} bits",
+                key_path.display(),
+                payload_priv_key.id(),
+                payload_priv_key.bits()
+            )),
+        ));
+    }
 
     // Load or generate mTLS key pair (separate from payload keys)
     // The mTLS key is always persistent, stored at the configured path.


### PR DESCRIPTION
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Tests (adding or updating tests)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Related Issues

Resolves #1262

## Change Description

### Concise Summary

On upgrade from a pre-key-separation agent version, the new agent generates a
fresh payload key (`payload-private.pem`) because the file doesn't exist. This
causes PCR 16 to be extended with the hash of the new key, while the verifier
still has the old key cached — resulting in `pcr_validation.invalid_pcr_16`.

This PR adds fallback logic: on startup, if `payload-private.pem` is missing
but `server-private.pem` exists and contains an RSA key, it is copied as the
payload key. This preserves PCR 16 consistency during rolling upgrades.

### Technical Details

**Motivation:** Before commits 2091359 and bec5d94, a single RSA key
(`server-private.pem`) was used for both mTLS and payload encryption. After the
key separation, upgrading the agent creates a new payload key that doesn't match
what the verifier expects. The verifier only updates its cached public key after
a successful quote, so the mismatch creates a permanent failure loop.

**Approach:** The fallback runs before the existing `load_or_generate_key()`
call in `main()`. It checks whether the payload key file is missing, and if so,
attempts to copy the mTLS server key if it is RSA. If the server key is not RSA
(e.g. ECC from a fresh install), a new RSA key is generated as before.

**Security:** RSA-OAEP is CCA2-secure, the key only wraps random symmetric key
halves, and this is exactly what the old agent did before the key separation.
There is no security regression. File permissions are set to 0o600 on the
copied file.

**Scenarios handled:**
- Fresh install (no key files): generates separate keys — no change
- Upgrade (RSA `server-private.pem` exists): copies to `payload-private.pem` with warning
- Upgrade (ECC `server-private.pem`): skips fallback, generates new RSA payload key
- Both files already exist: no fallback logic triggers
- Server key unreadable: logs warning, falls through to generate new key

## Documentation Updates Required

- [ ] `docs/` directory
- [ ] README.md
- [ ] Wiki
- [x] No documentation changes needed

## Verification Process

1. **Environment:** Any system with keylime agent and verifier configured
2. **Procedure:**
   - Install pre-separation agent (e.g. 0.2.2) with working attestation
   - Upgrade agent to this version
   - Verify agent continues attesting without re-enrollment
3. **Expected results:**
   - Warning logged about copying mTLS key as payload key
   - PCR 16 validation passes (same key as before)
   - `payload-private.pem` created with 0o600 permissions

## Checklist

- [x] Code follows the project's style guidelines
- [ ] Tests have been added/updated
- [ ] Documentation has been updated (if applicable)
- [x] Commit messages follow project conventions
- [ ] CHANGELOG has been updated
- [x] All tests pass locally

## Additional Context

> [!NOTE]
> This PR was co-authored with AI assistance (Claude Opus 4.6).

This is a targeted upgrade-compatibility fix. The fallback is only relevant
during the transition from pre-separation to post-separation agent versions.
Once all deployments have been upgraded past this point, the fallback code path
will never trigger (since `payload-private.pem` will always exist).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payload-key upgrades by reusing a compatible RSA 2048-bit-or-larger mTLS key when no payload key exists.
  * Prevents overwriting existing payload keys and provides clearer errors for unsupported, undersized, password-protected, or failed key operations.
  * Preserves key material during successful reuse.

* **Tests**
  * Added coverage for reuse conditions, skipped upgrades, password handling, key preservation, and copy failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->