### PR TITLE
fix: Remove redundant references in formatting macros for Rust 1.97+

### DIFF
--- a/keylime-agent/src/main.rs
+++ b/keylime-agent/src/main.rs
@@ -366,7 +366,7 @@ async fn main() -> Result<()> {
     {
         let message = "The agent mTLS is disabled and 'payload_script' is not empty. To allow the agent to run, 'enable_insecure_payload' has to be set to 'True'".to_string();
 
-        error!("Configuration error: {}", &message);
+        error!("Configuration error: {}", message);
         return Err(Error::Configuration(
             config::KeylimeConfigError::Generic(message),
         ));
@@ -396,7 +396,7 @@ async fn main() -> Result<()> {
         if let Err(e) = permissions::run_as(user_group) {
             let message = "The user running the Keylime agent should be set in keylime-agent.conf, using the parameter `run_as`, with the format `user:group`".to_string();
 
-            error!("Configuration error: {}", &message);
+            error!("Configuration error: {}", message);
             return Err(Error::Configuration(
                 config::KeylimeConfigError::Generic(message),
             ));
@@ -410,10 +410,7 @@ async fn main() -> Result<()> {
         .map(|s| s.to_string())
         .collect::<Vec<_>>();
 
-    info!(
-        "Starting server with API versions: {}",
-        &config.api_versions
-    );
+    info!("Starting server with API versions: {}", config.api_versions);
 
     let mut ctx = tpm::Context::new()?;
 

--- a/keylime-agent/src/payloads.rs
+++ b/keylime-agent/src/payloads.rs
@@ -143,7 +143,7 @@ fn run(dir: &Path, script: &str) -> Result<()> {
     {
         return Err(Error::Other(format!(
             "unable to set {:?} as executable",
-            &script_path
+            script_path
         )));
     }
 
@@ -159,12 +159,12 @@ fn run(dir: &Path, script: &str) -> Result<()> {
         .status()
     {
         Ok(_) => {
-            info!("{:?} ran successfully", &script_path);
+            info!("{:?} ran successfully", script_path);
             Ok(())
         }
         Err(e) => Err(Error::Other(format!(
             "{:?} failed during run: {}",
-            &script_path, e
+            script_path, e
         ))),
     }
 }

--- a/keylime-agent/src/revocation.rs
+++ b/keylime-agent/src/revocation.rs
@@ -64,7 +64,7 @@ fn lookup_action(
     if !py_action.set_extension("py") {
         return Err(Error::Other(format!(
             "unable to set action {} extension",
-            &action
+            action
         )));
     }
 
@@ -655,7 +655,7 @@ mod tests {
             if #[cfg(feature = "legacy-python-actions")] {
                 // Test local python action
                 let expected =
-                    format!("{}", &actions_dir.join("shim.py").display(),);
+                    format!("{}", actions_dir.join("shim.py").display(),);
 
                 assert_eq!(
                     lookup_action(
@@ -673,7 +673,7 @@ mod tests {
         // Test local non-python action
         let expected = format!(
             "{}",
-            &actions_dir.join("local_action_hello_shell.sh").display()
+            actions_dir.join("local_action_hello_shell.sh").display()
         );
 
         assert_eq!(
@@ -691,7 +691,7 @@ mod tests {
             if #[cfg(feature = "legacy-python-actions")] {
                 // Test payload python action
                 let expected =
-                    format!("{}", &actions_dir.join("shim.py").display(),);
+                    format!("{}", actions_dir.join("shim.py").display(),);
 
                 assert_eq!(
                     lookup_action(
@@ -709,7 +709,7 @@ mod tests {
         // Test payload non-python action
         let expected = format!(
             "{}",
-            &payload_dir.join("local_action_payload_shell.sh").display()
+            payload_dir.join("local_action_payload_shell.sh").display()
         );
 
         assert_eq!(

--- a/keylime/src/agent_registration.rs
+++ b/keylime/src/agent_registration.rs
@@ -168,7 +168,7 @@ pub async fn register_agent(
     // Request keyblob material
     let keyblob = registrar_client.register_agent(&ai).await?;
 
-    info!("SUCCESS: Agent {} registered", &aa.agent_uuid);
+    info!("SUCCESS: Agent {} registered", aa.agent_uuid);
 
     let key = ctx.activate_credential(
         keyblob,
@@ -188,6 +188,6 @@ pub async fn register_agent(
 
     registrar_client.activate_agent(&ai, &auth_tag).await?;
 
-    info!("SUCCESS: Agent {} activated", &aa.agent_uuid);
+    info!("SUCCESS: Agent {} activated", aa.agent_uuid);
     Ok(())
 }

--- a/keylime/src/config/base.rs
+++ b/keylime/src/config/base.rs
@@ -726,15 +726,15 @@ fn get_uuid(agent_uuid_config: &str) -> String {
         }
         "generate" => {
             let agent_uuid = Uuid::new_v4();
-            info!("Generated a new UUID: {}", &agent_uuid);
+            info!("Generated a new UUID: {}", agent_uuid);
             agent_uuid.to_string()
         }
         uuid_config => match Uuid::parse_str(uuid_config) {
             Ok(uuid_config) => uuid_config.to_string(),
             Err(_) => {
-                warn!("Misformatted UUID: {}", &uuid_config);
+                warn!("Misformatted UUID: {}", uuid_config);
                 let agent_uuid = Uuid::new_v4();
-                info!("Using generated UUID: {}", &agent_uuid);
+                info!("Using generated UUID: {}", agent_uuid);
                 agent_uuid.to_string()
             }
         },

--- a/keylime/src/registrar_client.rs
+++ b/keylime/src/registrar_client.rs
@@ -441,7 +441,7 @@ impl RegistrarClient {
 
         info!(
             "Requesting agent registration from {} for {}",
-            &addr, &ai.uuid
+            addr, ai.uuid
         );
 
         let resp = self
@@ -596,10 +596,7 @@ impl RegistrarClient {
             "{scheme}://{registrar_ip}:{registrar_port}/v{api_version}/agents/{uuid}",
         );
 
-        info!(
-            "Requesting agent activation from {} for {}",
-            &addr, &ai.uuid
-        );
+        info!("Requesting agent activation from {} for {}", addr, ai.uuid);
 
         let resp = self
             .resilient_client

--- a/keylime/src/resilient_client.rs
+++ b/keylime/src/resilient_client.rs
@@ -635,7 +635,7 @@ mod tests {
         // Make a request. The test will pass only if the default header is sent correctly.
         let response = resilient_client
             .client
-            .get(format!("{}/test", &mock_server.uri()))
+            .get(format!("{}/test", mock_server.uri()))
             .send()
             .await
             .unwrap(); //#[allow_ci]
@@ -663,7 +663,7 @@ mod tests {
         let response = client
             .get_json_request_from_struct(
                 Method::POST,
-                &format!("{}/submit", &mock_server.uri()),
+                &format!("{}/submit", mock_server.uri()),
                 &json!({}),
                 Some("application/vnd.api+json".to_string()),
             )
@@ -704,7 +704,7 @@ mod tests {
         let response = client
             .get_json_request_from_struct(
                 Method::POST,
-                &format!("{}/submit", &mock_server.uri()),
+                &format!("{}/submit", mock_server.uri()),
                 &json!({}),
                 None,
             )
@@ -740,7 +740,7 @@ mod tests {
         let response = client
             .get_json_request_from_struct(
                 Method::POST,
-                &format!("{}/submit", &mock_server.uri()),
+                &format!("{}/submit", mock_server.uri()),
                 &json!({}),
                 None,
             )
@@ -777,7 +777,7 @@ mod tests {
         let response = client
             .get_json_request_from_struct(
                 Method::POST,
-                &format!("{}/submit", &mock_server.uri()),
+                &format!("{}/submit", mock_server.uri()),
                 &json!({}),
                 None,
             )
@@ -860,7 +860,7 @@ mod tests {
         let response = client
             .get_request(
                 Method::GET,
-                &format!("{}/health", &mock_server.uri()),
+                &format!("{}/health", mock_server.uri()),
             )
             .send()
             .await;
@@ -906,7 +906,7 @@ mod tests {
 
         let start_time = std::time::Instant::now();
         let response = client
-            .get_request(Method::GET, &format!("{}/test", &mock_server.uri()))
+            .get_request(Method::GET, &format!("{}/test", mock_server.uri()))
             .send()
             .await
             .unwrap(); //#[allow_ci]
@@ -957,7 +957,7 @@ mod tests {
 
         let start_time = std::time::Instant::now();
         let response = client
-            .get_request(Method::GET, &format!("{}/test", &mock_server.uri()))
+            .get_request(Method::GET, &format!("{}/test", mock_server.uri()))
             .send()
             .await
             .unwrap(); //#[allow_ci]
@@ -995,7 +995,7 @@ mod tests {
 
         let start_time = std::time::Instant::now();
         let response = client
-            .get_request(Method::GET, &format!("{}/test", &mock_server.uri()))
+            .get_request(Method::GET, &format!("{}/test", mock_server.uri()))
             .send()
             .await
             .unwrap(); //#[allow_ci]
@@ -1087,7 +1087,7 @@ mod tests {
 
         let start_time = std::time::Instant::now();
         let response = client
-            .get_request(Method::GET, &format!("{}/test", &mock_server.uri()))
+            .get_request(Method::GET, &format!("{}/test", mock_server.uri()))
             .send()
             .await
             .unwrap(); //#[allow_ci]

--- a/keylime/src/secure_mount.rs
+++ b/keylime/src/secure_mount.rs
@@ -107,7 +107,7 @@ pub fn mount(work_dir: &Path, secure_size: &str) -> Result<PathBuf> {
 
         info!(
             "Mounting secure storage location {:?} on tmpfs.",
-            &secure_dir_path
+            secure_dir_path
         );
 
         // mount tmpfs with secure directory


### PR DESCRIPTION
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (non-breaking change that improves code quality)
- [ ] Tests (adding or updating tests)
- [ ] CI/CD (changes to build process or tools)
- [ ] Other (please describe):

## Related Issues

N/A

## Change Description

### Concise Summary

Remove redundant `&` references in formatting macro arguments (`info!`, `warn!`, `error!`, `format!`) to fix `clippy::useless_borrows_in_formatting` errors on Rust 1.97+.

### Technical Details

Rust 1.97 introduced the `clippy::useless_borrows_in_formatting` lint, which is implied by `-D clippy::all`. This lint flags unnecessary `&` references passed to formatting macros, since the `fmt::Display`/`fmt::Debug` traits auto-dereference. The redundant borrows cause build failures on newer Rust toolchains.

Affected files:
- `keylime/src/agent_registration.rs` — 2 occurrences in `info!`
- `keylime/src/config/base.rs` — 3 occurrences in `info!`/`warn!`
- `keylime/src/registrar_client.rs` — 4 occurrences in `info!`
- `keylime/src/resilient_client.rs` — 10 occurrences in `format!` (tests)
- `keylime/src/secure_mount.rs` — 1 occurrence in `info!`
- `keylime-agent/src/main.rs` — 3 occurrences in `error!`/`info!`
- `keylime-agent/src/payloads.rs` — 3 occurrences in `format!`/`info!`
- `keylime-agent/src/revocation.rs` — 5 occurrences in `format!`


No behavioral changes — this is a purely cosmetic fix.

## Documentation Updates Required

- [ ] README.md
- [ ] Configuration documentation
- [ ] API documentation
- [ ] Man pages
- [ ] Other:

No documentation updates required.

## Verification Process

1. Run `cargo clippy` — should pass with no warnings
2. Run `cargo test` — should pass with no regressions
3. Run `cargo fmt --check` — should report no formatting issues

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] All CI checks pass

## Additional Context

This fix ensures compatibility with Rust 1.97+ while remaining compatible with older toolchains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal value handling across logging, error reporting, and test code.
  * Removed unnecessary references without changing runtime behavior, APIs, or user-visible functionality.
* **Tests**
  * Updated test inputs to use values directly while preserving existing assertions and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->