### PR TITLE
Fix base64 payload decoding with whitespace

### DIFF
--- a/keylime-agent/src/keys_handler.rs
+++ b/keylime-agent/src/keys_handler.rs
@@ -21,6 +21,17 @@ use log::*;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::convert::TryInto;
+
+fn decode_base64(
+    data: &str,
+) -> std::result::Result<Vec<u8>, base64::DecodeError> {
+    general_purpose::STANDARD.decode(
+        data.bytes()
+            .filter(|byte| !byte.is_ascii_whitespace())
+            .collect::<Vec<_>>(),
+    )
+}
+
 use tokio::sync::{
     mpsc::{Receiver, Sender},
     oneshot,
@@ -142,8 +153,7 @@ async fn u_key(
     debug!("Received ukey");
 
     // get key and decode it from web data
-    let encrypted_key = match general_purpose::STANDARD
-        .decode(&body.encrypted_key)
+    let encrypted_key = match decode_base64(&body.encrypted_key)
         .map_err(Error::from)
     {
         Ok(k) => k,
@@ -213,10 +223,7 @@ async fn u_key(
     };
 
     let payload = match &body.payload {
-        Some(data) => match general_purpose::STANDARD
-            .decode(data)
-            .map_err(Error::from)
-        {
+        Some(data) => match decode_base64(data).map_err(Error::from) {
             Ok(d) => Some(d.into()),
             Err(e) => {
                 warn!("POST u_key returning 400 response. Invalid base64 encoding in payload: {e}");
@@ -256,8 +263,7 @@ async fn v_key(
     debug!("Received vkey");
 
     // get key and decode it from web data
-    let encrypted_key = match general_purpose::STANDARD
-        .decode(&body.encrypted_key)
+    let encrypted_key = match decode_base64(&body.encrypted_key)
         .map_err(Error::from)
     {
         Ok(k) => k,
@@ -972,7 +978,9 @@ mod tests {
         let ukey = KeylimeUKey {
             encrypted_key: general_purpose::STANDARD.encode(&encrypted_key),
             auth_tag: hex::encode(auth_tag),
-            payload: payload.map(|p| general_purpose::STANDARD.encode(p)),
+            payload: payload.map(|p| {
+                format!("{}\n", general_purpose::STANDARD.encode(p))
+            }),
         };
 
         let req = test::TestRequest::post()
@@ -1084,6 +1092,12 @@ mod tests {
     #[actix_rt::test]
     async fn test_u_or_v_key_long() {
         test_u_or_v_key(AES_256_KEY_LEN, None).await;
+    }
+
+    #[cfg(feature = "testing")]
+    #[actix_rt::test]
+    async fn test_u_or_v_key_payload_with_newline() {
+        test_u_or_v_key(AES_128_KEY_LEN, Some(b"test payload")).await;
     }
 
     #[cfg(feature = "testing")]


### PR DESCRIPTION
## Description

Fixes an issue where the Rust Keylime agent fails to process encrypted payloads when Base64-encoded data contains trailing newline or whitespace characters.

### Problem

When a tenant provides payload or key data through the `--payload` and `--key` options, the Base64-encoded content may contain newline characters. The Rust agent previously passed this data directly to the strict Base64 decoder, causing decoding to fail with an error such as:

`Invalid byte 10, offset 64`

### Changes

* Added a shared Base64 decoding helper that ignores ASCII whitespace before decoding.
* Updated encrypted key and payload decoding to use the new helper.
* Added a regression test covering Base64 payloads containing a trailing newline.
* Kept the change limited to the Rust agent implementation.

### Testing

* `cargo fmt`
* `cargo fmt --check`
* `git diff --check`

The full test suite could not be executed in the current Windows environment because the TPM dependency (`tss2-sys`) requires the native TSS2 library, which is not available in the environment.

### Related Issue

Fixes #457


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Base64-encoded U-key, V-key, and payload inputs now support embedded whitespace, including newlines.
  - Improved handling of formatted Base64 payloads during processing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->